### PR TITLE
Alternate Blind Proposal #1

### DIFF
--- a/kod/object/passive/spell/debuff/blind.kod
+++ b/kod/object/passive/spell/debuff/blind.kod
@@ -145,15 +145,23 @@ messages:
 
       iDuration = iDurationSecs;
       
-      oSpell = Send(SYS,@FindSpellByNum,#NUM=SID_EAGLE_EYES);
-      if Send(oTarget,@IsEnchanted,#what=oSpell)
+      if IsClass(oTarget,&Player)
+         AND IsClass(what,&Player)
       {
-         iDuration = Send(oSpell,@DoEagleEyes,#oCaster=what,#oTarget=oTarget,
-                          #iDuration=iDuration);
-         if iDuration = $
+         iDuration = iDuration / 2;
+      }
+      else
+      {
+         oSpell = Send(SYS,@FindSpellByNum,#NUM=SID_EAGLE_EYES);
+         if Send(oTarget,@IsEnchanted,#what=oSpell)
          {
-            % Resisted completely.
-            return;
+            iDuration = Send(oSpell,@DoEagleEyes,#oCaster=what,#oTarget=oTarget,
+                             #iDuration=iDuration);
+            if iDuration = $
+            {
+               % Resisted completely.
+               return;
+            }
          }
       }
 

--- a/kod/object/passive/spell/debuff/dazzle.kod
+++ b/kod/object/passive/spell/debuff/dazzle.kod
@@ -131,16 +131,24 @@ messages:
       local oSpell, iDuration;
 
       iDuration = iDurationSecs;
-
-      oSpell = Send(SYS,@FindSpellByNum,#NUM=SID_EAGLE_EYES);
-      if Send(oTarget,@IsEnchanted,#what=oSpell)
+      
+      if IsClass(oTarget,&Player)
+         AND IsClass(what,&Player)
       {
-         iDuration = Send(oSpell,@DoEagleEyes,#oCaster=what,#oTarget=oTarget,
-                           #iDuration=iDuration,#iFactor=2);
-         if iDuration = $
+         iDuration = iDuration / 2;
+      }
+      else
+      {
+         oSpell = Send(SYS,@FindSpellByNum,#NUM=SID_EAGLE_EYES);
+         if Send(oTarget,@IsEnchanted,#what=oSpell)
          {
-            % Resisted completely.
-            return;
+            iDuration = Send(oSpell,@DoEagleEyes,#oCaster=what,#oTarget=oTarget,
+                             #iDuration=iDuration);
+            if iDuration = $
+            {
+               % Resisted completely.
+               return;
+            }
          }
       }
 


### PR DESCRIPTION
All blinds and dazzles cast between players are always halved,
equivalent to a full-power Eagle Eyes at all times. Eagle Eyes still
resists blinds and dazzles cast by monsters, as well as adding offense
and damage to ranged attacks, but it does not stack with player innate
blind & dazzle resistance.

The purpose of this proposal is to specifically target the extreme
length of blind and dazzle durations against unbuffed targets, as well
as the fact that dazzle is never reduced by Eagle Eyes because a dazzler
can also purge. With this proposal, it's as if all players have Eagle
Eyes all the time. Combat between buffed opponents (Qor, PF, etc)
will be no different at all. Combat between unbuffed opponents and Shals
will have outlier extreme durations of blind and dazzle lowered. Basically,
we remove the 'unbuffed' pain completely. No more 20 seconds Blinds
just because your EE dropped, or extremely long dazzles even under AMA.

This proposal:
- avoids any nerfs to beloved spells
- uses the same durations we've all gotten used to for a decade
- protects builders and unaware players
- relieves some of the excessive power of purge + dazzle