### PR TITLE
Alternate Blind Proposal #4

### DIFF
--- a/kod/object/item/passitem/defmod.kod
+++ b/kod/object/item/passitem/defmod.kod
@@ -43,7 +43,7 @@ messages:
    
    Constructed()
    {
-      if Random(50,100) > 50
+      if Random(1,100) > 50
       {
          Create(&DefModSpellProc,#host_object=self);
       }

--- a/kod/object/item/passitem/defmod.kod
+++ b/kod/object/item/passitem/defmod.kod
@@ -40,6 +40,16 @@ properties:
    piDamage_reduce = 0              %% piDamage_reduce is the maximum amount of damage that will be reduced.
 
 messages:
+   
+   Constructed()
+   {
+      if Random(50,100) > 50
+      {
+         Create(&DefModSpellProc,#host_object=self);
+      }
+
+      propagate;
+   }
 
    ReqUseSomething(what = $)
    {


### PR DESCRIPTION
Enable armor spell procs.

What these do is engrave a random spell on your armor with a random
spellpower and type. Some combinations are useless. Some are awesome.
The design concern is with unbuffed targets being Blinded for so long, and with
Purge; well, these armors will help rebuff you during combat when you
are struck. By making the right choices, you can restore critical buffs during
combat, whether or not you're blind or held. Some even do interesting things
like proc blink or earthquake - it's up to you to make the most of such powerful
and dangerous reactive abilities.

Armor procs appear on half of all bought or dropped armors, helms,
shirts, pants, and shields. This includes herald shields, masks, MSHs...
anything armor except gauntlets, regardless of source.

The random nature creates a natural pursuit of good procs. You won't
find a '99 eagle eyes 15% of the time on yourself' all the time.
Builders will find great armors naturally, but others may have to buy or
farm theirs (NPC-sold armor CAN have procs). It's an entirely
new loot and treasure system with lots of fun and payoff.

-------

Examples:

"When defending against a strike, the runes engraved on this ivy circlet
will cast eagle eyes on you with 73 spellpower 15% of the time."

"When defending against a strike, the runes engraved on this scale armor
will cast resist cold on you with 28 spellpower 6% of the time."

"When defending against a strike, the runes engraved on this magic
spirit helmet will cast dispel illusion with 49 spellpower 1% of the
time."

"When defending against a strike, the runes engraved on this small round
shield will cast blink with 52 spellpower 20% of the time."

"When defending against a strike, the runes engraved on this troll mask
will cast eagle eyes on the enemy with 97 spellpower 7% of the time."
fitting for a troll mask ;)

"When defending against a strike, the runes engraved on this pants will
cast remove curse on you with 66 spellpower 2% of the time."

"When defending against a strike, the runes engraved on this light
jerkin will cast super strength on you with 84 spellpower 4% of the
time."

"When defending against a strike, the runes engraved on this nerudite armor will cast armor of Gort on you with 91 spellpower 2% of the time." VERY RARE! uber builder's tool as well.

"When defending against a strike, the runes engraved on this nerudite armor will cast earthquake with 5 spellpower 8% of the time." <- somebody is going to die. Probably you :)

------

Each armor class has its own set of spells and chances.

Masks can be worn with circlets now, remember, so when we put masks in,
they'll have a use - they'll be an extra sensory spell proc for you :)

This proposal:
- nerfs no spells directly
- creates a new treasure and loot system
- opens up combat to a huge variety of comebacks
- adds lots of utility (remove curse pants, spiritual hammer shirts, and
what not)
- basically it's really cool

Best part is, the vast majority of these do NOTHING if you've already got the buffs. Buffed combat isn't changed at all by these (since they'll just not cast since you already have the buff). But it's the unbuffed situations, purged situations, and building, where these come into serious play. Without being directly changed, Purge becomes more of a temporary situation, as your critical buffs will restore one by one as you're attacked.