### PR TITLE
Deflect Rebalancing

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -167,8 +167,18 @@ messages:
    % They are included here in battler so both user and mobiles can enjoy
    %  the effect.
 
-   TryDeflect()
+   TryDeflect(what = $,caster=$)
    {
+      local oDeflect, lRadiusEnchantment;
+      
+      for lRadiusEnchantment in plRadiusEnchantments
+      {
+         if Send(Nth(lRadiusEnchantment,1),@TryDeflect,#caster=caster,#victim=self,#oSpell=what,#power=Nth(lRadiusEnchantment,2),#source=Nth(lRadiusEnchantment,3))
+         {
+            return TRUE;
+         }
+      }
+      
       return FALSE;
    }
   

--- a/kod/object/passive/spell/persench/makefile
+++ b/kod/object/passive/spell/persench/makefile
@@ -7,7 +7,7 @@
 DEPEND = ..\persench.bof
 BOFS = haste.bof detinvis.bof detgood.bof denial.bof detevil.bof respois.bof cloak.bof freeact.bof\
        eavesdrp.bof eagleyes.bof bless.bof gort.bof mshield.bof nightv.bof shadform.bof\
-       strength.bof resist.bof invis.bof deflect.bof touchatk.bof gaze.bof karahol.bof\
+       strength.bof resist.bof invis.bof touchatk.bof gaze.bof karahol.bof\
        dethlink.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -840,6 +840,11 @@ messages:
    {
       return time;
    }
+   
+   TryDeflect(caster=$,victim=$,oSpell=$,power=0,source=$)
+   {
+      return FALSE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/radiusench/deflect.kod
+++ b/kod/object/passive/spell/radiusench/deflect.kod
@@ -8,7 +8,7 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%S%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Deflect is PersonalEnchantment
+Deflect is RadiusEnchantment
 
 constants:
 
@@ -20,15 +20,9 @@ resources:
    Deflect_icon_rsc = imirror.bgf
    Deflect_desc_rsc = \
       "Calls upon Kraanan's will to form a protective barrier around the "
-      "target which protects them from direct damaging attack magics, but "
+      "caster which protects their allies from direct damaging attack magics - but "
       "not from other magics, such as enchantments.  "
       "Requires a vial of solagh and one kriipa claw to cast."
-
-   Deflect_already_enchanted_rsc = "You are already enchanted by deflect."
-
-   Deflect_on_rsc = "A magical barrier surrounds you."
-   Deflect_success_rsc = "You sense a magical barrier surround %s%s."
-   Deflect_off_rsc = "The magical barrier protecting you seems to be waning."
 
    Deflect_spell_intro = \
       "Kraanan Level 4: Forms a magical barrier around the target, protecting"
@@ -37,34 +31,44 @@ resources:
    Deflect_sound = kdeflect.wav
 
    Deflect_success_to_victim = \
-      "Your deflect enchantment bounces %s's spell back onto its caster!"
+      "The deflection bubble surrounding you bounces %s's spell back onto its caster!"
    Deflect_success_to_caster = \
       "A barrier of mystical energy coalesces in front of %s, bouncing "
       "your spell back at you!"
    Deflect_failure_to_victim = \
-      "Your deflect enchantment attempts to bounce %s's spell back, "
+      "The deflection bubble surrounding you attempts to bounce %s's spell back, "
       "but is not strong enough."
+
+   Deflect_cast = "You extend a silvery dome of light out from your fingertips."
+   Deflect_starts = "A silvery dome of light emerges from %s's fingertips."
+   Deflect_ends = "The dome of silvery energy maintained by %s dissipates."
+   Deflect_caster_ends = "Your dome of silvery energy dissipates."
+   Deflect_caster_enter = "You feel magical deflection energies surround you."
+   Deflect_enter = "You are encompassed by a dome of silvery energy emanating from %s."
+   Deflect_leave = "You have passed outside the dome of silvery energy emanating from %s."
 
 classvars:
 
-   viPersonal_ench = True
+   radius_ench_cast = Deflect_cast
+   radius_ench_starts = Deflect_starts
+   radius_ench_ends = Deflect_ends
+   radius_ench_caster_ends = Deflect_caster_ends
+   radius_ench_caster_enter = Deflect_caster_enter
+   radius_ench_enter = Deflect_enter
+   radius_ench_leave = Deflect_leave
 
    viSpellExertion = 10
    vrName = Deflect_name_rsc
    vrIcon = Deflect_icon_rsc
    vrDesc = Deflect_desc_rsc
 
-   vrAlreadyEnchanted = Deflect_already_enchanted_rsc
-   vrEnchantment_On = Deflect_On_rsc
-   vrEnchantment_Off = Deflect_Off_rsc
-   vrSuccess = Deflect_Success_rsc
-
    viSpell_num = SID_DEFLECT
 
    vrSpell_intro = Deflect_spell_intro
 
    viMana = 20
-   viCast_time = 3000
+   viManaDrain = 5
+   viDrainTime = 5000
    viSpell_level = 4
    viSchool = SS_KRAANAN
 
@@ -74,6 +78,14 @@ classvars:
    viFlash = FLASH_GOOD_SELF
 
    vrSucceed_wav = Deflect_sound
+
+   viIndefinite = ARTICLE_AN
+   viChance_To_Increase = 35
+   viMeditate_ratio = 30
+   viBaseRange = 6
+
+   viAffectsGuildmates = TRUE
+   viAffectsEnemies = TRUE
 
 properties:
 
@@ -88,6 +100,11 @@ messages:
       return;
    }
 
+   CalculateRange(who=$, iSpellPower=25)
+   {
+      return viBaseRange;
+   }
+
    GetStateValue(who=$,iSpellPower=0,Target=$)
    {
       local iReflectOdds;
@@ -96,37 +113,31 @@ messages:
 
       return Bound(iReflectOdds,10,75);
    }
-
-   GetDuration(iSpellPower=0)
-   {
-      local iDuration;
-
-      % 21-119 seconds
-      iDuration = (20 + iSpellPower) * 1000;
-
-      return iDuration;
-   }
-
-   TryDeflect(caster=$,victim=$,oSpell=$)
+   
+   TryDeflect(caster=$,victim=$,oSpell=$,power=0,source=$)
    "Returns TRUE if the spell is deflected."
    {
-      local i, chance;
+      local i, iReflectOdds;
 
-      if Send(oSpell,@IsHarmful)
-         AND Send(oSpell,@GetNumSpellTargets) = 1
-         AND IsClass(oSpell,&AttackSpell)
+      if oSpell = $
+         OR NOT Send(oSpell,@IsHarmful)
+         OR NOT Send(oSpell,@GetNumSpellTargets) = 1
+         OR NOT IsClass(oSpell,&AttackSpell)
+         OR source = $
       {
-         % Give players a decent chance to improve the spell!
-         for i in Send(victim,@GetPassiveImprovementList)
-         {
-            if First(i) = self AND Random(1,3) = 3
-            {
-               Post(First(i),@ImproveAbility,#who=victim);
-            }
-         }
+         return FALSE;
+      }
 
-         chance = Send(victim,@GetEnchantedState,#what=self);
-         if Random(0,100) < chance
+      % Deflect can only protect from outside the radius
+      if Send(caster,@IsAffectedByRadiusEnchantment,#what=self,#caster=source)
+      {
+         return FALSE;
+      }
+      
+      if Send(victim,@IsAffectedByRadiusEnchantment,#what=self,#caster=source)
+      {
+         iReflectOdds = 25 + (power+1) / 4;
+         if iReflectOdds > Random(0,100)
          {
             Send(self,@SendMessageTryDeflectSuccess,#victim=victim,#caster=caster);
             return TRUE;
@@ -159,18 +170,6 @@ messages:
    GetPotionClass()
    {
       return &DeflectPotion;
-   }
-
-   EffectDesc(who=$)
-   {
-      AppendTempString("\n\n");
-      AppendTempString("Your current ");
-      AppendTempString(Send(self,@GetName));
-      AppendTempString(" enchantment will reflect enemy splash and bolt spells ");
-      AppendTempString(Send(who,@GetEnchantedState,#what=self));
-      AppendTempString("\% of the time.");
-      
-      propagate;
    }
 
 end

--- a/kod/object/passive/spell/radiusench/makefile
+++ b/kod/object/passive/spell/radiusench/makefile
@@ -5,6 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\radiusench.bof
-BOFS = umbrella.bof antimag.bof winds.bof sandstor.bof truce.bof jala.bof
+BOFS = umbrella.bof antimag.bof winds.bof sandstor.bof truce.bof jala.bof deflect.bof
 
 !include $(KODDIR)\kod.mak


### PR DESCRIPTION
Deflect is still Kraanan level 4 and still costs 20 mana, but it is no
longer a Personal Enchantment. Instead, it is a Radius Enchantment with
a static range of 6 (splash spells are range 4).

Deflect now creates a bubble that attempts to reflect all single-target
attack spells of any type that are cast from outside that bubble. If you
Lightning Bolt or Blast of Fire or Splash of Acid inside the bubble,
Deflect does nothing. You can't cast splash spells from greater than
range 6, so they are unaffected generally, but Deflect will attempt to
reflect Lightning Bolts and Fireballs that CAN be cast from that far
away.

Your Deflect bubble will protect all of your allies and your enemies.

Casting Deflect and affecting an innocent can cause you to be labeled an
outlaw; this is to prevent muling issues. Keep your safety on.

The general idea behind this new Deflect is that the original PE spell is
simultaneously useless and godly overpowered. It's useless because of
the huge mana cost, focus time, and short duration, but OP because
it reflected up to 75% of all attack spells of any sort.

This new Deflect reflects up to 50% of ranged attack spells cast from
outside the protection radius. It is intended to force mages to close
distance if they want to continue attacking you. For example, if
you AMA, and the mage casts Mana Convergence and Winds, he
can bolt you and you can't really fire arrows back. Now, you cast AMA
and Deflect, and he casts Mana Convergence and Winds, then you're 
both forced to close to melee range. Both of you have one AE and one
RE up of roughly equal mana drains in order to maintain this forced
melee situation.

As Deflect is clearly intended by fighters to be used under AMA, a large
chunk of its effect (25%) is static. The other 25% comes from spellpower,
for a max of 50% reflection.