### PR TITLE
Shatterlock Restructured as Event Spell

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -4734,6 +4734,17 @@ messages:
       pbNoReagents=FALSE;
       return;
    }
-      
+
+   CanShatterlockHere()
+   "Is there a dimensional secret that must be unlocked?"
+   {
+      return FALSE;
+   }
+   
+   Shatterlocked(oPrism=$)
+   {
+      return;
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/monsroom/i9.kod
+++ b/kod/object/active/holder/room/monsroom/i9.kod
@@ -36,6 +36,8 @@ resources:
 
    i9_portal_icon_rsc = teleport.bgf
 
+   shatterlocked_portal = "The mountain winds howl madly as a spacial bridge forms to somewhere cold and dark..."
+
 classvars:
 
    vrName = room_name_i9
@@ -426,6 +428,33 @@ messages:
          }
       }
 
+      return;
+   }
+
+   CanShatterlockHere()
+   {
+      return TRUE;
+   }
+   
+   Shatterlocked(oPrism=$,lCasters=$)
+   {
+      local i, each_obj;
+      
+      if oPrism <> $
+         AND Send(self,@IsInStonehenge,#what=oPrism)
+      {
+         Send(self,@OpenPortalToTemple);
+      }
+      
+      for i in plActive
+      {
+         each_obj = Send(self,@HolderExtractObject,#data=i);
+         if IsClass(each_obj,&User)
+         {
+            Send(each_obj,@MsgSendUser,#message_rsc=shatterlocked_portal);
+         }
+      }
+      
       return;
    }
 

--- a/kod/object/item/passitem/prism.kod
+++ b/kod/object/item/passitem/prism.kod
@@ -515,8 +515,7 @@ messages:
 
    DestroyDisposable()
    {
-      % Don't destroy prisms.
-      return;
+      return FALSE;
    }
 
 end

--- a/kod/object/passive/spell/multicst.kod
+++ b/kod/object/passive/spell/multicst.kod
@@ -104,8 +104,20 @@ messages:
       return 0;
    }
 
-   BreakTrance(who = $, state = $)
+   BreakTrance(who = $, state = $, event = $)
    {
+      % The spell keeps going if you get damaged, move, cast, use an item, or make an attack.
+      % Players must rest or change rooms to end prism spells.
+      if event = EVENT_DAMAGE
+         OR event = EVENT_ATTACK
+         OR event = EVENT_RUN
+         OR event = EVENT_DISRUPT
+         OR event = EVENT_CAST
+         OR event = EVENT_USE
+      {
+         return;
+      }
+
       % If caster runs out of mana or loses trance, spell ends.
       if IsClass(first(state),&prism)
       {
@@ -242,6 +254,11 @@ messages:
    SpellBannedInArena()
    {
       return TRUE;
+   }
+
+   CanBeRemovedByPlayer()
+   {
+      return FALSE;
    }
 
 end

--- a/kod/object/passive/spell/multicst/shttrlck.kod
+++ b/kod/object/passive/spell/multicst/shttrlck.kod
@@ -14,36 +14,20 @@ constants:
 
    include blakston.khd
 
-   % Number of members online greater than this number doesn't apply a penalty.
-   MIN_MEMBERS_ONLINE = 2
-
 resources:
 
    ShatterLock_name_rsc = "shatterlock"
    ShatterLock_icon_rsc = ishatlok.bgf
    ShatterLock_desc_rsc = \
-      "Penetrates the locks of a guild hall (note that it won't open other "
-      "kinds of doors elsewhere).  Requires four Kriipa Claws to cast, and "
-      "the casters' energies must be focused through a prism."
-
-   Shatterlock_safety = \
-      "You must not have a guardian angel and must turn your safety OFF "
-      "before you cast this spell.  Note that you will marked as an outlaw "
-      "as the result of casting this spell."
-
-   Shatterlock_outlaw = \
-      "NOTE: Casting this spell will mark you as an outlaw, even if you are "
-      "not successful in breaking into the hall.  Therefore, you must turn "
-      "your safety OFF before casting the spell."
+      "The concentrated will of several Kraanan masters can be focused to "
+      "force open dimensional barriers.  "
+      "Requires Kriipa Claws to cast, and the casters' "
+      "energies must be focused through a prism."
 
    ShatterLock_cast_complete = \
-      "As you finish your incantation, the door to the guild hall opens!"
+      "As you finish your incantation, the fabric of reality tears open!"
 
-   ShatterLock_guildwarning = \
-      "You have a strange feeling that your guild hall's defenses are "
-      "being tampered with."
-
-   ShatterLock_sound = kraanan.wav
+   ShatterLock_sound = kraanan.wav  
 
 classvars:
 
@@ -66,16 +50,11 @@ classvars:
    viManaDrain = 1       % Drain is amount used every viDrainTime milliseconds
    viDrainTime = 1000    % Drain some mana every viDrainTime milliseconds
 
-   viOutlaw = TRUE
-   vbCastable_in_HappyLand = FALSE
-
 properties:
 
-   viMultiCast_Spellpower = 10800   % 3 hours (in seconds) base casting time
-   piBaseCastTime = 900             % 15 minutes (in seconds) minimum casting time.
-   piGuildWarnTime = 180            % warn once (per caster) every 3 minutes on average
+   viMultiCast_Spellpower = 3600    % 1 hour base casting time
 
-messages:
+messages:      
 
    ResetReagents()
    {
@@ -89,24 +68,9 @@ messages:
    {
       local oPrism;
 
-      if IsClass(who,&Player)
-         AND (Send(who,@CheckPlayerFlag,#flag=PFLAG_SAFETY)
-              OR NOT Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE))
-      {
-         Send(who,@MsgSendUser,#message_rsc=Shatterlock_safety);
-
-         return FALSE;
-      }
-
       oPrism = Send(self,@FindPrism,#who=who);
-      if oPrism = $
-      {
-         Send(who,@MsgSendUser,#message_rsc=multicast_no_prism);
-
-         return;
-      }
-
-      if NOT IsClass(Send(oPrism,@GetOwner),&GuildHall)
+      if NOT IsClass(Send(oPrism,@GetOwner),&Room)
+         OR NOT Send(Send(oPrism,@GetOwner),@CanShatterlockHere)
       {
          return FALSE;
       }
@@ -114,69 +78,15 @@ messages:
       propagate;
    }
 
-   GetTotalSpellPower(oPrism=$)
-   {
-      local lMembers, iMembers, oGuild, oGuildHall, iMembersNotOnline,
-            i, iReqSpellPower;
-
-      oGuildHall = Send(oPrism,@GetOwner);
-
-      % Base time: 3 hours.
-      iReqSpellPower = viMultiCast_Spellpower;
-
-      % Add up to an hour depending on quality of hall
-      iReqSpellPower = iReqSpellPower + (Send(oGuildHall,@GetQuality) * 360);
-
-      oGuild = Send(oGuildHall,@GetGuildOwner);
-      iMembersNotOnline = 0;
-
-      if oGuild <> $
-      {
-         % Reduce casting time with more enemy guildmembers online.
-         lMembers = Send(oGuild,@GetMemberList);
-         for i in lMembers
-         {
-            if NOT Send(First(i),@IsLoggedOn)
-            {
-               iMembersNotOnline = iMembersNotOnline + 1;
-            }
-         }
-
-         iMembers = length(lMembers);
-
-         % If the guild has very few people on, apply a penalty.
-         %  Otherwise, scale the time based on the number of people online.
-         if (iMembers - iMembersNotOnline) <= MIN_MEMBERS_ONLINE
-         {
-            iReqSpellPower = iReqSpellPower * 3;
-         }
-         else
-         {
-            iMembersNotOnline = bound(iMembersNotOnline,1,$);
-            iReqSpellPower = (iReqSpellPower * iMembersNotOnline) / iMembers;
-         }
-
-         % Always takes at least 15 minutes to cast.
-         iReqSpellPower = bound(iReqSpellPower,piBaseCastTime,$);
-
-         % Convert to spellpower: average of 15 points per second added.
-         iReqSpellPower = iReqSpellPower * 15;
-      }
-
-      return iReqSpellPower;
-   }
-
-   PrismCast(spellpower=0,lCasters=$,oPrism=$)
+   PrismCast(spellpower = 0, lCasters=$, oPrism=$)
    {
       local oRoom, i;
 
       oRoom = Send(oPrism,@GetOwner);
-      if IsClass(oRoom,&GuildHall)
+      if IsClass(oRoom,&Room)
+         AND Send(oRoom,@CanShatterlockHere)
       {
-         if Send(oRoom,@InFoyer,#who=oPrism)
-         {
-            Send(oRoom,@OpenEntranceDoor);
-         }
+         Send(oRoom,@Shatterlocked,#oPrism=oPrism,#lCasters=lCasters,#iSpellPower=spellpower);
       }
 
       for i in lCasters
@@ -187,50 +97,6 @@ messages:
       return;
    }
 
-   StartPeriodicEnchantment(who=$,state=$)
-   {
-      local oGuild,lMembers,i;
-
-      % Every 3 minutes on average, tell a guild member that something's up.
-      if Random(1,piGuildWarnTime) > 1
-      {
-         propagate;
-      }
-
-      if NOT IsClass(first(state),&Prism)
-      {
-         Debug("StartPeriodicEnchantment called with bad state (no prism)");
-
-         return;
-      }
-
-      oGuild = Send(Send(first(state),@GetOwner),@GetGuildOwner);
-
-      if oGuild <> $
-      {
-         lMembers = Send(oGuild,@GetMemberList);
-
-         for i in lMembers
-         {
-            if (Random(1,Length(lMembers))=1) AND Send(First(i),@IsLoggedOn)
-            {
-               Send(First(i),@MsgSendUser,#message_rsc=shatterlock_guildwarning);
-            }
-         }
-      }
-
-      propagate;
-   }
-
-   GetExtraDesc()
-   {
-      if Send(SYS,@IsPKAllowed)
-      {
-         return Shatterlock_outlaw;
-      }
-
-      propagate;
-   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Shatterlock opening Guildhalls is a bad idea for many reasons, and
there is no feasible implementation that will preserve its use without it
being an ongoing broken mechanic.

So, instead, Shatterlock can now be used to initiate events in specific
rooms. The first instance of this will be the ability to open the
Martyr's Battleground node by shatterlocking the magic of the stone
henge in Ukgoth.

Prisms also no longer reset on the ground, and the trance for prism
spells has been significantly upgraded - you can now only lose trance by
resting or running out of mana, so combat is still possible while
focusing.

This new Shatterlock can/will be used in several new content implementations
for a player-initiated open-world event.