### PR TITLE
Bond Change Proposal

### DIFF
--- a/kod/object/passive/spell/multicst/bond.kod
+++ b/kod/object/passive/spell/multicst/bond.kod
@@ -20,16 +20,16 @@ resources:
    Bond_name_rsc = "bond"
    Bond_icon_rsc = ibond.bgf
    Bond_desc_rsc = \
-      "Infuses an item with a soft white light.  However, the "
-      "bond requires terrific amounts of energy to form.  A heartstone and "
+      "Repairs an item by creating a multitude of small internal magical bonds.  The "
+      "bonding requires terrific amounts of energy to perform.  A heartstone and "
       "dozens of polished serphym and diamonds must be crushed to amplify "
       "the caster's mystical energy, which must then be focused through a "
       "prism.  The item to be bonded must be targetted.  Once the casting "
-      "is complete the item will follow its owner to hell itself."
+      "is complete, the item will be whole once more, and even slightly stronger than before."
    
    Bond_sound = sbond.wav
 
-   bond_bad_target = "You may only bond items to a player."
+   bond_bad_target = "You may only bond items."
    bond_no_prism = "The magic energies of the prism do not allow it to be bonded."
    bond_failed = \
       "You feel the magical bond begin to reach out in vain for one of its targets, "
@@ -37,7 +37,7 @@ resources:
    bond_already_bonded = "This item is already bonded."
 
    bond_successful_casters = "You feel a magical bond form between %s%s and %s."
-   bond_successful_bondee = "You feel a magical bond form between you and your %s."
+   bond_successful_bondee = "You feel magical bonds strengthen the integrity of your %s."
 
    bond_report_room = "Somehow, you sense that your %s is in %s."
    bond_report_user = "Somehow, you sense that your %s is in %q's possession."
@@ -120,29 +120,15 @@ messages:
          return FALSE;
       }
 
-      if Send(oTarget,@HasAttribute,#ItemAtt=IA_TRANSCENDANT)
-      {
-         Send(who,@MsgSendUser,#message_rsc=bond_already_bonded);
-
-         return FALSE;
-      }
-
       propagate;
    }
 
    PrismCast(spellpower = 0, lCasters=$, lTargets=$) 
    {
-      local oOwner, oCaster;
-      oOwner = Send(First(lTargets),@GetOwner);
+      local oCaster;
 
-      % The Bond infrastructure was left in, in case we want to use it for
-      % something else.  This is the trigger call.
-      %Send(oOwner,@BondItem,#what=First(lTargets));
-
-      % So instead of bonding, we are going to make the item transcendent.
-
-      Send(Send(SYS,@FindItemAttByNum,#Num=IA_TRANSCENDANT),@AddToItem,
-           #oItem=First(lTargets));
+      Send(First(lTargets),@SetMaxHits,#number=Send(First(lTargets),@GetMaxHits)+1);
+      Send(First(lTargets),@SetHits,#number=Send(First(lTargets),@GetMaxHits));
 
       for oCaster in lCasters
       {


### PR DESCRIPTION
People are anxious to have Xeo Attacks going again and have heartstones back in the game. Before we do that, we need to fix Bond (and probably room chests, too). Here, then, is my proposal for new Bond. 

New Bond is a Super Mend that fully repairs an item and even adds 1 permanent max durability. It still costs the same reagents as before.

I know that some will dismiss this as silly or bad or too expensive, but I cannot stress enough how amazingly powerful this ability is for those veterans handling rare and powerful items - interestingly enough, the exact same demographic Soft White Light Bond was useful for.

Currently, 100% mends do not exist. That means that all items eventually break. Uber items will always one day be relegated to the vault when their durability drops low enough. Now, though, with this new Bond, veterans will require a steady stream of Heartstones to keep their gear whole. As a player who has collected and used powerful items in the past, I can tell you, this is a Big Freaking Deal. I would gladly pay 3 heartstones + 150 polished + 150 diamonds and build three shal mules for this ability. So this is anything but weak or useless.

Soft White Light cannot be allowed to be applied to items by veterans because it completely undermines our PvP system, but this does not have that same fault. All this does is encourage the ongoing use of powerful items so they keep being risked in PvP.

http://openmeridian.org/forums/index.php/topic,244.0.html
