### PR TITLE
Elemental Status Effects

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1831,6 +1831,14 @@
    ATCK_SPELL_UNHOLY     = 0x0020
    ATCK_SPELL_ACID       = 0x0040
    ATCK_SPELL_QUAKE      = 0x0080
+   
+   % Elemental status effect types
+   STATUS_SHOCKED        = 1
+   STATUS_CHILLED        = 2
+   STATUS_BURNING        = 3
+   STATUS_CORRODE        = 4
+   STATUS_HUMBLED        = 5
+   STATUS_MANTLED        = 6
 
    % For hunter swords
    ATCK_SPELL_HUNTERSWORD= 0x0100

--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -325,7 +325,7 @@ messages:
       iHumbled = Send(self,@GetStatusEffect,#type=STATUS_HUMBLED);
       if iHumbled > 0
       {
-         iHumbledDivisor = SendSend(SYS,@GetSettings),@GetElementalMultiple,
+         iHumbledDivisor = Send(Send(SYS,@GetSettings),@GetElementalMultiple,
                            #type = STATUS_HUMBLED);
          
          for i in plCurrentResistances
@@ -1753,7 +1753,7 @@ messages:
    
    ClearAllStatusEffects()
    {
-      plStatusEffects = $
+      plStatusEffects = $;
       if ptStatusEffectTimer <> $
       {
          DeleteTimer(ptStatusEffectTimer);

--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -186,6 +186,11 @@ properties:
 
    % Mana regen timer.
    ptMana = $
+   
+   % Elemental status effects. Each element is [value, type]
+   % Timer removes a portion of status effect every period
+   plStatusEffects = $
+   ptStatusEffectTimer = $
 
 messages:
 
@@ -277,20 +282,24 @@ messages:
    }
    
    GetCurrentResistances()
-   "Object attributes, such as spells and items, can change resistances temporarily."
+   "Object attributes, such as spells and items, can change resistances."
    {
-      local oObjectAttribute, plCurrentResistances, oEquipment, oEnchantment;
+      local oObjectAttribute, plCurrentResistances, oEquipment, oEnchantment,
+            iHumbled, iHumbledDivisor, i;
       
-      plCurrentResistances = Send(SYS,@ListCopy,#source=Send(self,@GetBaseResistances));
+      plCurrentResistances = Send(SYS,@ListCopy,
+                               #source=Send(self,@GetBaseResistances));
       
       for oObjectAttribute in plObject_attributes
       {
-         plCurrentResistances = Send(oObjectAttribute,@ModifyResistance,#resistance_list=plCurrentResistances);
+         plCurrentResistances = Send(oObjectAttribute,@ModifyResistance,
+                                #resistance_list=plCurrentResistances);
       }
       
       for oEquipment in Send(self,@GetEquippedItems)
       {
-         plCurrentResistances = Send(oEquipment,@ModifyResistance,#resistance_list=plCurrentResistances);
+         plCurrentResistances = Send(oEquipment,@ModifyResistance,
+                                #resistance_list=plCurrentResistances);
       }
       
       If IsClass(self,&User)
@@ -299,14 +308,34 @@ messages:
          {
             if Length(oEnchantment) > 2
             {
-               plCurrentResistances = Send(Nth(oEnchantment,2),@ModifyResistance,#resistance_list=plCurrentResistances,#iState=Nth(oEnchantment,3));
+               plCurrentResistances = Send(Nth(oEnchantment,2),
+                                      @ModifyResistance,
+                                      #resistance_list=plCurrentResistances,
+                                      #iState=Nth(oEnchantment,3));
             }
             else
             {
-               plCurrentResistances = Send(Nth(oEnchantment,2),@ModifyResistance,#resistance_list=plCurrentResistances);
+               plCurrentResistances = Send(Nth(oEnchantment,2),
+                                      @ModifyResistance,
+                                      #resistance_list=plCurrentResistances);
             }
          }
       }
+      
+      iHumbled = Send(self,@GetStatusEffect,#type=STATUS_HUMBLED);
+      if iHumbled > 0
+      {
+         iHumbledDivisor = SendSend(SYS,@GetSettings),@GetElementalMultiple,
+                           #type = STATUS_HUMBLED);
+         
+         for i in plCurrentResistances
+         {
+            if Nth(i,1) > 0
+            {
+               SetNth(i,1,bound(Nth(i,1) - (iHumbled/iHumbledDivisor),0,$));
+            }
+         }
+      } 
       
       return plCurrentResistances;
    }
@@ -1640,6 +1669,157 @@ messages:
 
       return;
    }
+   
+   AddStatusEffect(value=10,type=STATUS_SHOCKED)
+   {
+      local i;
+      
+      if ptStatusEffectTimer <> $
+      {
+         ptStatusEffectTimer = CreateTimer(self,@StatusEffectTimer,
+                                           Send(Send(SYS,@GetSettings),
+                                           @GetStatusEffectReductionTime));
+      }
+      
+      if type=STATUS_SHOCKED
+         AND IsClass(self,&Player)
+      {
+         Post(self,@DrawDefense);
+      }
+      
+      if type=STATUS_CORRODE
+         AND IsClass(self,&Player)
+      {
+         Post(self,@DrawArmor);
+      }
+      
+      if type=STATUS_HUMBLED
+         AND IsClass(self,&Player)
+      {
+         Post(self,@DrawResistances);
+      }
+      
+      for i in plStatusEffects
+      {
+         if Nth(i,2) = type
+         {
+            SetNth(i,1,Nth(i,1)+value);
+            return;
+         }
+      }
+
+      plStatusEffects = Cons([value,type],plStatusEffects);
+      return;
+   }
+   
+   GetStatusEffect(type=STATUS_SHOCKED)
+   {
+      local i;
+      
+      for i in plStatusEffects
+      {
+         if Nth(i,2) = type
+         {
+            return Nth(i,1);
+         }
+      }
+      return 0;
+   }
+   
+   ClearStatusEffect(type=STATUS_SHOCKED)
+   {
+      local i;
+      
+      for i in plStatusEffects
+      {
+         if Nth(i,2) = type
+         {
+            SetNth(i,1,0);
+            plStatusEffects = DelListElem(plStatusEffects,i);
+         }
+      }
+      
+      if plStatusEffects = $
+      {
+         if ptStatusEffectTimer <> $
+         {
+            DeleteTimer(ptStatusEffectTimer);
+            ptStatusEffectTimer = $;
+         }
+      }
+      
+      return;
+   }
+   
+   ClearAllStatusEffects()
+   {
+      plStatusEffects = $
+      if ptStatusEffectTimer <> $
+      {
+         DeleteTimer(ptStatusEffectTimer);
+         ptStatusEffectTimer = $;
+      }
+      return;
+   }
+   
+   StatusEffectTimer(timer=$)
+   {
+      local i, iBurningDamage;
+      
+      ptStatusEffectTimer = $;
+      
+      for i in plStatusEffects
+      {
+         if Nth(i,2) = STATUS_SHOCKED
+            AND IsClass(self,&Player)
+         {
+            Post(self,@DrawDefense);
+         }
+         if Nth(i,2) = STATUS_CORRODE
+            AND IsClass(self,&Player)
+         {
+            Post(self,@DrawArmor);
+         }
+         if Nth(i,2) = STATUS_HUMBLED
+            AND IsClass(self,&Player)
+         {
+            Post(self,@DrawResistances);
+         }
+
+         if Nth(i,2) = STATUS_BURNING
+         {
+            iBurningDamage = (Nth(i,1) / Send(Send(SYS,@GetSettings),
+                              @GetElementalMultiple,#type=STATUS_BURNING));
+            SetNth(i,1,0);
+            if iBurningDamage >= 1
+            {
+               Send(self,@AssessDamage,#what=self,
+                              #damage=iBurningDamage,
+                              #aspell=-ATCK_SPELL_FIRE);
+            }
+         }
+         else
+         {
+            SetNth(i,1,Nth(i,1) - Send(Send(SYS,@GetSettings),
+                                  @GetStatusEffectReductionAmount));
+         }
+
+         if Nth(i,1) <= 0
+         {
+            plStatusEffects = DelListElem(plStatusEffects,i);
+         }
+      }
+      
+      if plStatusEffects <> $
+      {
+         ptStatusEffectTimer = CreateTimer(self,@StatusEffectTimer,
+                                           Send(Send(SYS,@GetSettings),
+                                           @GetStatusEffectReductionTime));
+      }
+      
+      return;
+   }
+   
 
    GetBoostedLevel()
    {

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4950,7 +4950,7 @@ messages:
    "Ranges from 1 to 2000."
    {
       local i, oWeapon, oShield, iParry, iDodge, iBlock, iAgility,
-            iDefense, iHealth, oMonster;
+            iDefense, iHealth, oMonster, iShocked;
 
       % Morphed?
       oMonster = Send(self,@GetIllusionForm);
@@ -5001,6 +5001,12 @@ messages:
 
       % The universal modifier.
       iDefense = iDefense + ((iDefense * piFlags3) / 100);
+      
+      % Check for Shocked status effect, which lowers defense.
+      iShocked = Send(self,@GetStatusEffect,#type=STATUS_SHOCKED);
+      iDefense = iDefense - (iShocked * Send(Send(SYS,@GetSettings),
+                                             @GetElementalMultiple,
+                                             #type=STATUS_SHOCKED));
 
       return bound(iDefense,1,2000);
    }
@@ -5263,7 +5269,8 @@ messages:
       precision=FALSE)
    {
       local i, j, iResistance, oSoldierShield, gainchance, color_rsc,
-            iDuration, oSpell, oGort,iLimit, origdamage, oWeapon, shrunken;
+            iDuration, oSpell, oGort,iLimit, origdamage, oWeapon, shrunken
+            iCorrode, iCorrodeMultiple, iCorrodeReduction;
 
       if NOT precision
       {
@@ -5302,6 +5309,16 @@ messages:
                            #damage=damage,#atype=atype,#aspell=aspell,
                            #report_resistance=report_resistance);
             Send(i,@DefendingHit,#who=self,#what=what);
+         }
+
+         iCorrode = Send(self,@GetStatusEffect,#type=STATUS_CORRODE);
+         if iCorrode > 0
+         {
+            iCorrodeMultiple = Send(Send(SYS,@GetSettings),
+                               @GetElementalMultiple,#type=STATUS_CORRODE);
+         
+            iCorrodeReduction = (iCorrode/iCorrodeMultiple);
+            damage = bound(damage + iCorrodeReduction,1,origdamage);
          }
       
          iResistance = Send(self,@ResistanceCheck,#atype=atype,#aspell=aspell);
@@ -5474,8 +5491,56 @@ messages:
       {
          Send(shrunken,@DamageTaken,#what=what,#amount=damage/100);
       }
+      
+      % Apply possible elemental status effects
+      if atype = 0
+      {
+         if aspell <> 0
+         {
+            Send(self,@ApplyElementalStatusEffects,#damage=damage,
+                      #aspell=aspell);
+         }
+      }
+      else
+      {
+         % Apply only half the effects from partially magical attacks
+         if aspell <> 0
+         {
+            Send(self,@ApplyElementalStatusEffects,#damage=(damage/2),
+                      #aspell=aspell);
+         }
+      }
 
       return damage;
+   }
+   
+   ApplyElementalStatusEffects(damage=1,aspell=0)
+   {
+      if aspell & -ATCK_SPELL_SHOCK
+      {
+         Send(self,@AddStatusEffect,#value=damage,#type=STATUS_SHOCKED);
+      }
+      if aspell & -ATCK_SPELL_COLD
+      {
+         Send(self,@AddStatusEffect,#value=damage,#type=STATUS_CHILLED);
+      }
+      if aspell & -ATCK_SPELL_FIRE
+      {
+         Send(self,@AddStatusEffect,#value=damage,#type=STATUS_BURNING);
+      }
+      if aspell & -ATCK_SPELL_ACID
+      {
+         Send(self,@AddStatusEffect,#value=damage,#type=STATUS_CORRODE);
+      }
+      if aspell & -ATCK_SPELL_HOLY
+      {
+         Send(self,@AddStatusEffect,#value=damage,#type=STATUS_AVERTED);
+      }
+      if aspell & -ATCK_SPELL_UNHOLY
+      {
+         Send(self,@AddStatusEffect,#value=damage,#type=STATUS_MANTLED);
+      }
+      return;
    }
 
    % This message kicks in when damage is done to the opponent.
@@ -6196,7 +6261,7 @@ messages:
    "Have we waited long enough since the last attack/spell? Sets new "
    "valid attack time (time in msec, default 1 second)."
    {
-      local i;
+      local i, iChilled, iChilledMultiple, iChilledTotal;
 
       if ptAttackTimer <> $
       {
@@ -6214,6 +6279,22 @@ messages:
 
       if i > 0
       {
+         iChilled = Send(self,@GetStatusEffect,#type=STATUS_CHILLED);
+         if iChilled > 0
+         {
+            iChilledMultiple = Send(Send(SYS,@GetSettings),
+                                @GetElementalMultiple,#type=STATUS_CHILLED);
+            iChilledTotal = iChilled * iChilledMultiple;
+            
+            if iChilledTotal > 100
+            {
+               while iChilledTotal > 100
+               {
+                  i = i + 100;
+                  iChilledTotal - 100;
+               }
+            }
+         }
          ptAttackTimer = CreateTimer(self,@AttackTimer,i);
       }
 
@@ -6639,7 +6720,7 @@ messages:
    GainHealthNormal(amount = $, precision = FALSE)
    "Don't add beyond piMax_health"
    {
-      local iOldhealth;
+      local iOldhealth,iMantled, iMantledDivisor;
 
       if NOT precision
       {
@@ -6647,10 +6728,18 @@ messages:
       }
 
       iOldhealth = piHealth;
-
-      if amount < 0
+      
+      iMantled = Send(self,@GetStatusEffect,#type=STATUS_MANTLED);
+      if iMantled > 0
       {
-         return;
+         iMantledDivisor = Send(Send(SYS,@GetSettings),
+                            @GetElementalMultiple,#type=STATUS_MANTLED);
+         amount = amount - (iMantled/iMantledDivisor)*100;
+      }
+
+      if amount < 1
+      {
+         return 0;
       }
 
       if piHealth > piMax_health*100
@@ -14325,7 +14414,7 @@ messages:
 
    SumDamageReduction()
    {
-      local iArmor, d;
+      local iArmor, d, iCorrode, iCorrodeMultiple;
 
       iArmor = 0;
 
@@ -14340,6 +14429,15 @@ messages:
          {
             iArmor = iArmor + (Send(self,@GetEnchantedState,#what=d) / 25);
          }
+      }
+      
+      iCorrode = Send(self,@GetStatusEffect,#type=STATUS_CORRODE);
+      if iCorrode > 0
+      {
+         iCorrodeMultiple = Send(Send(SYS,@GetSettings),
+                            @GetElementalMultiple,#type=STATUS_CORRODE);
+         
+         iArmor = iArmor - (iCorrode/iCorrodeMultiple);
       }
 
       return iArmor;

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5497,7 +5497,7 @@ messages:
       {
          if aspell <> 0
          {
-            Send(self,@ApplyElementalStatusEffects,#damage=damage,
+            Send(self,@ApplyElementalStatusEffects,#damage=damage/100,
                       #aspell=aspell);
          }
       }
@@ -5506,7 +5506,7 @@ messages:
          % Apply only half the effects from partially magical attacks
          if aspell <> 0
          {
-            Send(self,@ApplyElementalStatusEffects,#damage=(damage/2),
+            Send(self,@ApplyElementalStatusEffects,#damage=(damage/100/2),
                       #aspell=aspell);
          }
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -6291,7 +6291,7 @@ messages:
                while iChilledTotal > 100
                {
                   i = i + 100;
-                  iChilledTotal - 100;
+                  iChilledTotal = iChilledTotal - 100;
                }
             }
          }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5269,7 +5269,7 @@ messages:
       precision=FALSE)
    {
       local i, j, iResistance, oSoldierShield, gainchance, color_rsc,
-            iDuration, oSpell, oGort,iLimit, origdamage, oWeapon, shrunken
+            iDuration, oSpell, oGort,iLimit, origdamage, oWeapon, shrunken,
             iCorrode, iCorrodeMultiple, iCorrodeReduction;
 
       if NOT precision

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -216,6 +216,23 @@ properties:
 
    % This amount is added to a battler's offense and defense and serves as a baseline for calculation.
    piBaseRating = 0
+   
+   % Status effect multiples
+   % Shocked temporarily reduces defense by a multiple of damage taken (X*m defense)
+   % Chilled temporarily slows attack and cast timers (X*m ms)
+   % Burning temporarily deals burning damage over time by a divisor (X/m damage)
+   % Corrode temporarily lowers armor (X/m armor)
+   % Humbled temporarily lowers resistances (X/m resit)
+   % Mantled temporarily lowers the effect of healing on the victim (X/m healing)
+   piShockedMultiple = 4
+   piChilledMultiple = 10
+   piBurningDivisor = 5
+   piCorrodeDivisor = 6
+   piHumbledDivisor = 5
+   piMantledDivisor = 6
+   
+   piStatusEffectReductionTime = 3000
+   piStatusEffectReductionAmount = 10
 
    % Percent of mana required/used for broadcasting. Default 0 (no cost).
    piBroadcastManaPercent = 0
@@ -554,6 +571,45 @@ messages:
    GetBaseRating()
    {
       return piBaseRating;
+   }
+   
+   GetElementalMultiple(type=STATUS_SHOCKED)
+   {
+      if type = STATUS_SHOCKED
+      {
+         return piShockedMultiple;
+      }
+      if type = STATUS_CHILLED
+      {
+         return piChilledMultiple;
+      }
+      if type = STATUS_BURNING
+      {
+         return bound(piBurningDivisor,2,100);
+      }
+      if type = STATUS_CORRODE
+      {
+         return bound(piCorrodeDivisor,1,100);
+      }
+      if type = STATUS_HUMBLED
+      {
+         return bound(piHumbledDivisor,1,100);
+      }
+      if type = STATUS_MANTLED
+      {
+         return bound(piMantledDivisor,1,100);
+      }
+      return 0;
+   }
+   
+   GetStatusEffectReductionTime()
+   {
+      return piStatusEffectReductionTime;
+   }
+   
+   GetStatusEffectReductionAmount()
+   {
+      return piStatusEffectReductionAmount;
    }
 
    GetBroadcastManaCost()


### PR DESCRIPTION
This is a framework for the addition of Elemental Status Effects. These
are negative conditions that elemental damage can impose upon players
and monsters. Partially magical attacks, such as touch spells or
dedicated weapons, apply only half as much as fully magical attacks.

These effects wear off very quickly.
Currently, I have the setting defaulted to 3 seconds per reduction cycle.
Each cycle, the elemental status effect will reduce by 10. Ten what?
Damage. If you dealt 30 damage, then the player has '30 damage' worth
of status effect of that type. Three seconds later, it will reduce to 20. Six
seconds after, it will be 10. Nine seconds after, it will be zero. Unless, of
course, you keep using that element, then the effects will be added to
existing totals to strengthen the ailment.

I imagine we could add spells and items to clear, resist, or bolster
these effects, but right now I've tried to balance them for current play.

* Shocked - lightning damage reduces defense by a multiple of damage
dealt. I have this defaulted to 4. A lightning bolt for 20 damage will reduce
your opponent's defense by 80 for three seconds, 40 for three seconds
after that, then zero.

* Chilled - cold damage slows attack and cast timers by a certain number
of ms multiplied by damage dealt (only takes effect in 100 ms steps). That
means a 30 damage explosive frost will make your opponents attacks
take 1.25 seconds or 2.25 seconds for three seconds, etc, etc.

* Burning - fire damage inflicts more fire damage each time status
effects are reduced. The damage is dependent on the initial fire damage.
For example, a 30 damage bof will do 6 damage, then 1, then nothing.

* Corroded - acid damage can reduce armor temporarily by a portion of
damage dealt. This divisor defaults to 6, so a 30 damage splash of acid
will reduce armor by 5 for a few seconds, then 3, then 1... etc.

* Humbled - holy damage can reduce resistances by a portion of damage
dealt (but not less than zero). This one was very tough to design, but I think
this fits holy damage very well in many ways. The complication here is that
holy damage is extremely hard to deliver. There is NO pure holy damage
attack spell that affects players. You will only be able to deliver half-effective
Humble effects through dedicated weapons or Holy Touch, and the divisor
is 5, so 20 damage will reduce enemy resists by 4% for a few seconds, or 2%
if it's a half-effective attack (which it is).
This can add up, certainly, but it can't go below zero, so this is really a tool not for
brainless shal bowers, but for mages who want to cut through opponent
resists. Or, it's a great PvE tool.

* Mantled - unholy damage can reduce the effect of healing by a portion
of damage dealt. This is very significant against low values of healing
(such as heal rods) and less so against spells like Major Heal. THIS is the
crowning jewel of elemental status effects. Hate your enemy heal rodding?
A strike by an unholy dedicated weapon, or by Vampiric Drain, will cut healing
effectiveness by damage/6 for a few seconds. If you think about it, that means
heal rods are almost instantly eliminated. Meanwhile, major heal type
spells will only be marginally nerfed, and normal health regeneration is not
changed. This type of damage is a powerful PvP choice, but has the same
limitations as holy: there aren't many good ways to deliver it.

This is an attempt to give elements their own unique identities and
reasons for use. Monsters can and will inflict these status effects,
and, additionally, because they're based on damage dealt, resistances
help resist these status effects.

I don't think any of these are too insane. Rather, they're all like *tools* that
characters can use to break through an opponent's defenses.