### PR TITLE
Player corpse holds items, summon at shal temple

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/temples/shalprst.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/temples/shalprst.kod
@@ -50,6 +50,9 @@ resources:
       "from the darkness.  I am willing to teach it to those that are "
       "able to learn it."
    shalillepriestess_teach = "The benevolence of Shal'ille offers "
+   
+   shalillepriestess_summon = "I shall aid you in your time of weakness."
+   shalillepriestess_summoned = "A benevolent light gently sets your corpse at your feet!"
 
 classvars:
 
@@ -268,6 +271,30 @@ messages:
       if Send(who,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
       {
          Send(self,@SetMood,#new_mood=piMood-1);
+      }
+
+      propagate;
+   }
+   
+   SomeoneSaid(what=$,type=$,string=$)
+   {
+      local oCorpse;
+
+      if type = SAY_YELL OR NOT IsClass(what,&User)
+      {
+          propagate;
+      }
+
+      if StringContain(string,"summon")
+         AND what <> $
+         AND IsClass(what,&User)
+         AND Send(what,@GetCorpse) <> $
+      {
+         Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_RESOURCE,
+		        #string=shalillepriestess_summon);
+         oCorpse = Send(what,@GetCorpse);
+         Send(poOwner,@NewHold,#what=oCorpse,#new_row=Send(what,@GetRow),#new_col=Send(what,@GetCol));
+         Send(what,@MsgSendUser,#message_rsc=shalillepriestess_summoned);
       }
 
       propagate;

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1086,9 +1086,12 @@ properties:
 
    % Put new reagents in your bag
    pbReagentBagAuto = TRUE
-   
+
    % Spectator mode?
    pbSpectatorMode = FALSE
+
+   % Track your last corpse
+   poCorpse = $
 
 messages:
 
@@ -9103,7 +9106,14 @@ messages:
       }
 
       % Create the corpse.
-      oBody = Send(self,@CreateCorpse);
+      if IsClass(what,&User)
+      {
+         oBody = Send(self,@CreateCorpse,#oPlayerKiller=what);
+      }
+      else
+      {
+         oBody = Send(self,@CreateCorpse);
+      }
       Send(oRoom,@NewHold,#what=oBody,#new_row=iRow,#new_col=iCol,
             #fine_row=16,#fine_col=16,#new_angle=iAngle);
 
@@ -9149,22 +9159,15 @@ messages:
          {
             for i in lItems
             {
-               if Send(oRoom,@ReqNewHold,#what=i,#new_row=iRow,#new_col=iCol)
-                  AND Send(oRoom,@ReqSomethingMoved,#what=i,#new_row=iRow,#new_col=iCol)
-                  AND Send(i,@DropOnDeath)
+               if oItemAtt <> $    
                {
-                  if oItemAtt <> $
-                  {
-                     % We know this was a pk.  Only let PKillables pick up the loot.
-                     % Put the appropriate item attribute on it.
-                     Send(oItemAtt,@AddToItem,#oItem=i,
-                           #timer_duration=PKPOINTER_TIME,
-                           #state1=self);
-                  }
-
-                  Send(oRoom,@NewHold,#what=i,
-                        #new_row=iRow,#new_col=iCol,#merge=FALSE);
+                  % We know this was a pk.  Only let PKillables pick up the loot.
+                  %  Put the appropriate item attribute on it.
+                  Send(oItemAtt,@AddToItem,#oItem=i,#timer_duration=PKPOINTER_TIME,
+                          #state1=self);
                }
+                  
+               Send(oBody,@NewHold,#what=i);
             }
          }
 
@@ -9458,7 +9461,7 @@ messages:
       return piDeathCost;
    }
 
-   CreateCorpse(Assassinated=FALSE)
+   CreateCorpse(Assassinated=FALSE, oPlayerKiller=$)
    {
       local inKocatan;
 
@@ -14620,7 +14623,7 @@ messages:
 
       return;
    }
-   
+
    % Use this for when either phase or spectator do the same thing
    IsInCannotInteractMode()
    {
@@ -14706,6 +14709,17 @@ messages:
       }
 
       propagate;
+   }
+
+   SetCorpse(corpse=$)
+   {
+      poCorpse = corpse;
+      return;
+   }
+   
+   GetCorpse()
+   {
+      return poCorpse;
    }
 
 end

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -4296,6 +4296,7 @@ messages:
 
       if NOT IsClass(what,&Holder)
          AND NOT IsClass(what,&ReagentBag)
+         AND NOT IsClass(what,&DeadBody)
          OR (IsClass(what,&Player)
              AND NOT (what = self OR IsClass(self,&Admin)))
       {
@@ -4326,8 +4327,16 @@ messages:
          }
          else
          {
-            lHolding1 = Send(what,@GetHolderActive);
-            lHolding2 = Send(what,@GetHolderPassive);
+            if IsClass(what,&DeadBody)
+            {
+               lHolding1 = Send(what,@GetCorpseContents);
+               lHolding2 = $;
+            }
+            else
+            {
+               lHolding1 = Send(what,@GetHolderActive);
+               lHolding2 = Send(what,@GetHolderPassive);
+            }
          }
       }
 
@@ -4840,6 +4849,15 @@ messages:
 
          if IsClass(what,&ReagentBag)
             AND Send(what,@GetReagentBagContents) <> $
+         {
+            Send(self,@UserObjectContents,#what=what);
+            return;
+         }
+
+         if IsClass(what,&DeadBody)
+            AND Send(what,@GetCorpseContents) <> $
+            AND Send(self,@SquaredDistanceTo,#what=what) <> $
+            AND Send(self,@SquaredDistanceTo,#what=what) <= 6
          {
             Send(self,@UserObjectContents,#what=what);
             return;

--- a/kod/object/passive/body.kod
+++ b/kod/object/passive/body.kod
@@ -63,10 +63,12 @@ properties:
    piTimeOfDeath = $
 
    pbResurrected = FALSE
+   
+   plCorpseContents = $
+   poPlayerKiller = $
 
 messages:
 
-   % you gotta pass in name, icon, and description to constructor
    Constructor(victim = $,killer = $,inKocatan = FALSE, assassinated = FALSE,
          drawfx = 0, BodyTranslation = 0, LegsTranslation = 0, 
          PlayerBodyOverlay = $, Decomposes = TRUE)
@@ -81,6 +83,12 @@ messages:
       piLegsTrans = LegsTranslation;      
       piTimeOfDeath = GetTime();
       
+      if killer <> $
+         AND IsClass(killer,&Player)
+      {
+         poPlayerKiller = killer;
+      }
+
       if Decomposes
       {
          if pbMob
@@ -104,7 +112,7 @@ messages:
       else
       {
          % Make player corpses hang around longer.
-         ptDelete = CreateTimer(self,@DeleteTimerMessage,600000);	    
+         ptDelete = CreateTimer(self,@DeleteTimerMessage,6000000);	    
          Send(Send(SYS,@Findroombynum,#num=RID_UNDERWORLD),@Newdeath,#what=self,#inKocatan=inKocatan);
       }
 
@@ -142,6 +150,13 @@ messages:
 
    Delete()
    {
+      local i;
+      
+      if poDearlyDeparted <> $
+      {
+         Send(poDearlyDeparted,@SetCorpse);
+      }
+
       if ptDelete <> $
       {
          Send(Send(SYS,@FindRoomByNum,#num=RID_UNDERWORLD),@CorpseDecomposed,#what=self);
@@ -159,6 +174,12 @@ messages:
       {
          send(poOwner,@CorpseFading,#corpse=self);
       }
+      
+      for i in plCorpseContents
+      {
+         Send(i,@Delete);
+      }
+      plCorpseContents = $;
       
       propagate;
    }
@@ -253,6 +274,11 @@ messages:
       
       propagate;
    }
+   
+   GetPlayerKiller()
+   {
+      return poPlayerKiller;
+   }
 
    GetDearlyDeparted()
    {
@@ -276,6 +302,137 @@ messages:
    GetResurrected()
    {
       return pbResurrected;
+   }
+   
+   GetCorpseContents()
+   {
+      return plCorpseContents;
+   }
+
+   HolderExtractObject(data = $)
+   {
+      return data;
+   }
+
+   IsHolding(what = $)
+   {
+      local i,each_obj;
+
+      for i in plCorpseContents
+      {
+         if what = i
+         {
+            return TRUE;
+         }
+      }
+
+      return FALSE;
+   }
+
+   GetBulk()
+   {
+      local i, iSum;
+
+      iSum = 0;
+      
+      for i in plCorpseContents
+      {
+         iSum = iSum + Send(i,@GetBulk);
+      }
+
+      return iSum;
+   }
+
+   GetWeight()
+   {
+      local i, iSum;
+
+      iSum = 0;
+
+      for i in plCorpseContents
+      {
+         iSum = iSum + Send(i,@GetWeight);
+      }
+
+      return iSum;
+   }
+
+   ReqTaker(what=$,taker=$)
+   {
+      if taker = poDearlyDeparted
+      {
+         return TRUE;
+      }
+
+      if poPlayerKiller <> $
+         AND taker <> poPlayerKiller
+      {
+         return FALSE;
+      }
+
+      return TRUE;
+   }
+
+   ReqNewHold(what = $, who = $)
+   {
+      return FALSE;
+   }
+
+   NewHold(what = $)
+   {
+      local i;
+
+      if IsClass(what,&NumberItem)
+      {
+         for i in plCorpseContents
+         {
+            if i <> what
+            {
+               if GetClass(what) = GetClass(i)
+               {
+                  % should only be one of these, so can quit loop if found
+                  Send(i,@AddNumber,#number=Send(what,@GetNumber));
+                  Send(what,@Delete);
+                  return;
+               }
+            }
+         }
+      }
+
+      Send(what,@NewOwner,#what=self);
+      plCorpseContents = Cons(what,plCorpseContents);
+      
+      return;
+   }
+   
+   ReqNewOwner(what=$)
+   {
+      propagate;
+   }
+
+   ReqLeaveHold(what = $)
+   {
+      return TRUE;
+   }
+
+   LeaveHold(what = $)
+   {
+      local i;
+      
+      for i in plCorpseContents
+      {
+         if i = what
+         {
+            plCorpseContents = DelListElem(plCorpseContents,i);
+         }
+      }
+
+      return;
+   }
+   
+   ChangeBulkAndWeight()
+   {
+      return;
    }
 
 


### PR DESCRIPTION
Player corpses now no longer drop their loot on the ground. Instead,
loot is held within the body. Viewing the corpse from beyond range 6
shows you the name of the victim and the corpse description. Viewing the
corpse from within range 6 shows you their loot instead.
* This is a permanent fix to 'loot piles' crashing players and rooms,
most notably from event chars.

The victim and the player killer may full loot any item.
If the death was to a mob, any player may loot.
* This is a permanent fix to loot grabbers during PvP, especially in
towns.

Saying "summon" to the Shal Priestess will summon your corpse to your
feet in cases where corpses cannot be otherwise retrieved.
* This is a permanent fix for loot getting lost in walls.

* Player corpses now last 1 hour rather than 10 minutes for convenience.