### PR TITLE
God Rooms (Survival, PvP)

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -5706,7 +5706,7 @@ messages:
       
       % A survival mob
       if poOwner <> $
-         AND IsClass(poOwner,&SurvivalRoom)
+         AND piBoostedLevel > 0
       {
          return 0;
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -767,6 +767,8 @@ resources:
       "charge from the released energy of your kill."
    rods_fully_recharged_by_safe_place_msg = \
       "This place of safety has recharged your magical rods."
+   rods_fully_recharged_msg = \
+      "Your rods have been recharged."
 
    player_truced = "Shal'ille's magic compels you to respect the truce."
 
@@ -1339,10 +1341,12 @@ messages:
          {
             Send(Nth(i,2),@SetSpellPlayerFlag,#who=self,#state=Nth(i,3));
          }
-      }
-
-      if poOwner <> $
-      {
+         
+         for i in Send(poOwner,@GetObjectAttributes)
+         {
+            Send(i,@SetSpellPlayerFlag,#who=self);
+         }
+         
          Send(poOwner,@SomethingChanged,#what=self);
       }
 
@@ -4019,6 +4023,11 @@ messages:
       {
          return FALSE;
       }
+      
+      if Send(oRoom,@GetChaosZone)
+      {
+         return TRUE;
+      }
 
       % Make sure room allows the attack. Check if room has
       % special combat affects.
@@ -4040,11 +4049,6 @@ messages:
 
       % If we're in an arena and it let us attack, then it's a legal attack.
       if Send(oRoom,@IsArena)
-      {
-         return TRUE;
-      }
-      
-      if Send(oRoom,@GetChaosZone)
       {
          return TRUE;
       }
@@ -14262,7 +14266,7 @@ messages:
       return ptCrystalizeManaSurgeTimer;
    }
 
-   RechargeAllRods()
+   RechargeAllRods(alternate_recharge=FALSE)
    {
       local i, bResult, bGainedCharges;
 
@@ -14283,7 +14287,14 @@ messages:
 
       if bGainedCharges
       {
-         Send(self,@MsgSendUser,#message_rsc=rods_fully_recharged_by_safe_place_msg);
+         if alternate_recharge
+         {
+            Send(self,@MsgSendUser,#message_rsc=rods_fully_recharged_msg);
+         }
+         else
+         {
+            Send(self,@MsgSendUser,#message_rsc=rods_fully_recharged_by_safe_place_msg);
+         }
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -395,6 +395,9 @@ resources:
 
    user_logon_delay = \
       "You take a moment to recollect your senses."
+      
+   real_survival_found = \
+      "Adventurers are undertaking Kraanan's challenge at %q."
 
 classvars:
 
@@ -2599,6 +2602,56 @@ messages:
          }
       }
 
+      if IsClass(what,&Monster)
+         AND NOT (IsClass(what,&Reflection)
+            OR IsClass(what,&EvilTwin))
+      {
+         if Send(what,@GetMaster) <> $
+         {
+            if (Send(what,@GetMaster) = self)
+            {
+               return MM_MINION_SELF;
+            }
+            else
+            {
+               return MM_MINION_OTHER;
+            }
+         }
+         else
+         {
+            % Draw dots for NPCs.
+            if Send(what,@GetBehavior) & AI_NPC
+            {
+               return MM_NPC;
+            }
+            else
+            {
+               if Send(poOwner,@OverridesMonsterDots)
+               {
+                  return Send(poOwner,@OverrideMonsterDots,#what=what,#who=self);
+               }
+
+               % Survival room specific dots.
+               if IsClass(poOwner,&SurvivalRoom)
+               {
+                  if Send(poOwner,@IsMiniBoss,#what=what)
+                  {
+                     return MM_MINIBOSS;
+                  }
+                  else
+                  {
+                     if Send(poOwner,@IsBoss,#what=what)
+                     {
+                        return MM_BOSS;
+                     }
+                  }
+               }
+
+               return MM_MONSTER;
+            }
+         }
+      }
+
       if IsClass(what,&Player)
       {
          if Send(what,@IsInCannotInteractMode)
@@ -2612,6 +2665,11 @@ messages:
             OR oIllusion = $
             OR NOT IsClass(oIllusion,&Monster)
          {
+            if Send(poOwner,@OverridesPlayerDots)
+            {
+               return Send(poOwner,@OverridePlayerDots,#what=what,#who=self);
+            }
+
             if Send(Send(SYS,@GetWarEvent),@IsActive)
             {
                if Send(Send(SYS,@GetWarEvent),@IsSameSide,#player1=self,#player2=what)
@@ -2664,51 +2722,6 @@ messages:
          {
 
             iFlags = (iFlags | MM_MONSTER);
-         }
-      }
-
-      if IsClass(what,&Monster)
-         AND NOT (IsClass(what,&Reflection)
-            OR IsClass(what,&EvilTwin))
-      {
-         if Send(what,@GetMaster) <> $
-         {
-            if (Send(what,@GetMaster) = self)
-            {
-               return MM_MINION_SELF;
-            }
-            else
-            {
-               return MM_MINION_OTHER;
-            }
-         }
-         else
-         {
-            % Draw dots for NPCs.
-            if Send(what,@GetBehavior) & AI_NPC
-            {
-               return MM_NPC;
-            }
-            else
-            {
-               % Survival room specific dots.
-               if IsClass(poOwner,&SurvivalRoom)
-               {
-                  if Send(poOwner,@IsMiniBoss,#what=what)
-                  {
-                     return MM_MINIBOSS;
-                  }
-                  else
-                  {
-                     if Send(poOwner,@IsBoss,#what=what)
-                     {
-                        return MM_BOSS;
-                     }
-                  }
-               }
-
-               return MM_MONSTER;
-            }
          }
       }
 
@@ -4375,7 +4388,7 @@ messages:
    UserSay(type=$,string=$)
    {
       local i, oSpell, lEnchantData, bTranceBlocksSay, lSurvivalOptions,
-            poForceBaseRoom;
+            poForceBaseRoom, bFoundRealSurvival;
 
       % A room can completely block a piece of communication if it chooses.
       % An excellent example is Out Of Grace, which blocks all tells to 
@@ -4546,6 +4559,23 @@ messages:
             
             if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindPublicRoom) = $
             {
+               bFoundRealSurvival = FALSE;
+               for i in Send(SYS,@GetObjectAttributeMasterList)
+               {
+                  if IsClass(i,&SurvivalRoomAttribute)
+                  {
+                     Send(self,@MsgSendUser,#message_rsc=real_survival_found,
+                              #parm1=Send(Send(i,@GetHostObject),@GetName));
+                     
+                     bFoundRealSurvival = TRUE;
+                  }
+               }
+               
+               if bFoundRealSurvival
+               {
+                  return;
+               }
+               
                Send(self,@MsgSendUser,#message_rsc=survival_no_public_rooms);
 
                return;

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1272,7 +1272,7 @@ messages:
 
    ReqSomethingAttack(what = $,victim = $,use_weapon = $,report = TRUE)
    {
-      local oWatcher;
+      local oWatcher, oRoomAttribute;
 
       if what <> $
          AND IsClass(what,&Player)
@@ -1315,6 +1315,18 @@ messages:
 
          % Anything else is legal in the Arena.
          return TRUE;
+      }
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         if NOT Send(oRoomAttribute,@ReqSomethingAttack,
+                                    #what=what,
+                                    #victim=victim,
+                                    #use_weapon=use_weapon,
+                                    #report=report)
+         {
+            return FALSE;
+         }
       }
       
       if (piRoom_flags & ROOM_NO_MOB_COMBAT)

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -4995,19 +4995,19 @@ messages:
    
    GetPlayers()
    {
-      local i, plPlayers;
+      local i, lPlayers;
       
-      plPlayers = $;
+      lPlayers = $;
       
       for i in plActive
       {
          if IsClass(First(i),&Player)
          {
-            plPlayers = Cons(First(i),plPlayers);
+            lPlayers = Cons(First(i),lPlayers);
          }
       }
 
-      return plPlayers;
+      return lPlayers;
    }
    
    GetActivePlayers()

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -729,7 +729,14 @@ messages:
 
    SomethingKilled(what=$,victim=$)
    {
+      local oRoomAttribute;
+      
       Send(self,@SetGroupTime,#victim=victim);
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         Send(oRoomAttribute,@SomethingKilled,#what=what,#victim=victim);
+      }
 
       propagate;
    }
@@ -1436,6 +1443,8 @@ messages:
 
    ReqSpellCast(who = $, oSpell = $, lItems = $)
    {
+      local oRoomAttribute;
+
       if (piRoom_flags & ROOM_NO_MAGIC)
       {
          Send(who,@MsgSendUser,#message_rsc=room_no_magic_allowed);
@@ -1456,6 +1465,17 @@ messages:
          Send(who,@MsgSendUser,#message_rsc=room_no_attack);
 
          return FALSE;
+      }
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         if NOT Send(oRoomAttribute,@ReqSpellCast,
+                                    #who=who,
+                                    #oSpell=oSpell,
+                                    #lItems=lItems)
+         {
+            return FALSE;
+         }
       }
 
       propagate;
@@ -1700,6 +1720,18 @@ messages:
    "Doing this this way allows us to have some zones, such as Ko'catan, have "
    "different skies."
    {
+      local oRoomAttribute;
+
+      for oRoomAttribute in plObject_attributes
+      {
+         if Send(oRoomAttribute,@ModifiesRoomBackground)
+         {
+            prBackground = Send(oRoomAttribute,@ModifyRoomBackground,
+                                     #rBackground=prBackground);
+            return;
+         }
+      }
+
       prBackground = background_night_sky;
       if Send(self,@GetRegion) = RID_KOCATAN
       {
@@ -1894,7 +1926,7 @@ messages:
 
    NewHoldObject(what = $,new_pos = $)
    {
-      local iTimeLeft, i, each_obj;
+      local iTimeLeft, i, each_obj, oRoomAttribute;
 
       % The object still thinks it's with it's old owner.  If it's an item from
       %   a player, then make sure the items don't disappear immediately.
@@ -1945,6 +1977,11 @@ messages:
             Send(each_obj,@StartEnchantmentNewOccupant,#who=what,
                  #state=(Nth(i,3)));
          }
+      }
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         Send(oRoomAttribute,@NewHoldObject,#what=what,#new_pos=new_pos);
       }
 
       return;
@@ -2096,7 +2133,12 @@ messages:
 
    LeaveHold(what = $)
    {
-      local i,each_obj;
+      local i,each_obj, oRoomAttribute;
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         Send(oRoomAttribute,@LeaveHold,#what=what);
+      }
 
       if NOT IsClass(what,&User)
       {
@@ -2718,7 +2760,12 @@ messages:
 
    FirstUserEntered()
    {
-      local iTime;
+      local iTime, oRoomAttribute;
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         Send(oRoomAttribute,@FirstUserEntered);
+      }
 
       pbUser_in_room = TRUE;
 
@@ -2732,8 +2779,15 @@ messages:
       propagate;
    }
 
-   LastUserLeft()
+   LastUserLeft(what=$)
    {
+      local oRoomAttribute;
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         Send(oRoomAttribute,@LastUserLeft,#what=what);
+      }
+
       pbUser_in_room = FALSE;
 
       if (ptPeriodic_sounds <> $)
@@ -4871,22 +4925,174 @@ messages:
    
    OverridesDeathFunction()
    {
+      local oRoomAttribute;
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         if Send(oRoomAttribute,@OverridesDeathFunction)
+         {
+            return TRUE;
+         }
+      }
+      
       return piOverridesDeathFunction;
    }
    
    OverrideDeathFunction(who=$,what=$)
    {
+      local oRoomAttribute, bOverrides;
+
+      % We only reach here by propagation if the room
+      % didn't completely override deaths lower down.
+      
+      % All Room Attributes receive OverrideDeathFunction message.
+      % Make sure different types don't conflict.
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         if Send(oRoomAttribute,@OverridesDeathFunction)
+         {
+            Send(oRoomAttribute,@OverrideDeathFunction,
+                                #who=who,
+                                #what=what);
+         }
+      }
+      
       return;
    }
    
    GetChaosZone()
    {
+      local oRoomAttribute;
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         if Send(oRoomAttribute,@GetChaosZone)
+         {
+            return TRUE;
+         }
+      }
+      
       return piChaosZone;
    }
    
    GetGenerators()
    {
       return $;
+   }
+   
+   GetPlayers()
+   {
+      local i, plPlayers;
+      
+      plPlayers = $;
+      
+      for i in plActive
+      {
+         if IsClass(First(i),&Player)
+         {
+            plPlayers = Cons(First(i),plPlayers);
+         }
+      }
+
+      return plPlayers;
+   }
+   
+   GetActivePlayers()
+   {
+      local i, lPlayers;
+      
+      lPlayers = $;
+      
+      for i in plActive
+      {
+         if IsClass(First(i),&Player)
+            AND NOT Send(First(i),@IsInCannotInteractMode)
+         {
+            lPlayers = Cons(First(i),lPlayers);
+         }
+      }
+
+      return lPlayers;
+   }
+   
+   GetMonsters()
+   {
+      local i, lMonsters;
+      
+      lMonsters = $;
+      
+      for i in plActive
+      {
+         if IsClass(First(i),&Monster)
+         {
+            lMonsters = Cons(First(i),lMonsters);
+         }
+      }
+
+      return lMonsters;
+   }
+   
+   OverridesPlayerDots()
+   {
+      local oRoomAttribute;
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         if Send(oRoomAttribute,@OverridesPlayerDots)
+         {
+            return TRUE;
+         }
+      }
+      
+      return FALSE;
+   }
+   
+   OverridePlayerDots(what=$,who=$)
+   {
+      local oRoomAttribute;
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         if Send(oRoomAttribute,@OverridesPlayerDots)
+         {
+            return Send(oRoomAttribute,@OverridePlayerDots,
+                                       #what=what,#who=who);
+         }
+      }
+      
+      return MM_NONE;
+   }
+   
+   OverridesMonsterDots()
+   {
+      local oRoomAttribute;
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         if Send(oRoomAttribute,@OverridesMonsterDots)
+         {
+            return TRUE;
+         }
+      }
+      
+      return FALSE;
+   }
+   
+   OverrideMonsterDots(what=$,who=$)
+   {
+      local oRoomAttribute;
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         if Send(oRoomAttribute,@OverridesMonsterDots)
+         {
+            return Send(oRoomAttribute,@OverrideMonsterDots,
+                                       #what=what,#who=who);
+         }
+      }
+      
+      return MM_NONE;
    }
       
 end

--- a/kod/object/active/holder/room/monsroom.kod
+++ b/kod/object/active/holder/room/monsroom.kod
@@ -92,7 +92,7 @@ messages:
 
    GetMonsterGenTime()
    {
-      local iWaitTime, iNumberOfPlayers, iMaxPlayers;
+      local iWaitTime, iNumberOfPlayers, iMaxPlayers, oRoomAttribute;
       % GetSpawnRate =  100
       % iWaitTime = (20000 * (100 / 100));
       % iWaitTime = 20000
@@ -120,6 +120,12 @@ messages:
          iNumberOfPlayers = iMaxPlayers;
       }
       iWaitTime = iWaitTime / iNumberOfPlayers;
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         iWaitTime = Send(oRoomAttribute,@ModifyMonsterGenTime,
+                                         #iTime=iWaitTime);
+      }
 
       return iWaitTime;
    }
@@ -146,12 +152,28 @@ messages:
    "Will try to create a monster in the room.  Initroom=TRUE means it's"
    "being called when first player enters."
    {
-      local oMonster,iRoll,iTotal,lMonster_info,iRow,iCol,lPos;
+      local oMonster,iRoll,iTotal,lMonster_info,iRow,iCol,lPos,
+            oRoomAttribute, lMonsterList, iBoostedLevel;
 
       if NOT Send(self,@IsMonsterCountBelowMax)
          OR NOT pbGenerateMonsters
       {
          return;
+      }
+      
+      lMonsterList = plMonsters;
+      
+      for oRoomAttribute in plObject_attributes
+      {
+         if NOT Send(oRoomAttribute,@AllowTryCreateMonster)
+         {
+            return;
+         }
+         
+         if Send(oRoomAttribute,@OverridesMonsterGeneration)
+         {
+            lMonsterList = Send(oRoomAttribute,@GetMonsters);
+         }
       }
 
       iRoll = Random(1,100);
@@ -170,19 +192,27 @@ messages:
       }
 
       iTotal = 0;
-      for lMonster_info in plMonsters
+      for lMonster_info in lMonsterList
       {
          iTotal = iTotal + Nth(lMonster_info,2);
 
          if iRoll <= iTotal
          {
+            iBoostedLevel = 0;
+            for oRoomAttribute in plObject_attributes
+            {
+               iBoostedLevel = Send(oRoomAttribute,@BoostMonster,
+                                                   #boost_val=iBoostedLevel);
+            }
+
             if IsClass(self,&SurvivalRoom)
             {
                oMonster = Create(First(lMonster_info),#piSurvivalLevel=piLevel);
             }
             else
             {
-               oMonster = Create(First(lMonster_info));
+               oMonster = Create(First(lMonster_info),
+                                 #piSurvivalLevel=iBoostedLevel);
             }
 
             if NOT Send(self,@GenerateMonster,#oMonster=oMonster)

--- a/kod/object/passive/objectatt.kod
+++ b/kod/object/passive/objectatt.kod
@@ -102,6 +102,9 @@ messages:
          Send(self,@RemoveFromObject,#host_object=poHostObject);
       }
       Send(SYS,@RemoveObjectAttributeFromMasterList,#attribute=self);
+      
+      poHostObject = $;
+
       propagate;
    }
    

--- a/kod/object/passive/objectatt/makefile
+++ b/kod/object/passive/objectatt/makefile
@@ -5,6 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\objectatt.bof
-BOFS = weaponobjectatt.bof defmodobjectatt.bof
+BOFS = weaponobjectatt.bof defmodobjectatt.bof roomatt.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/objectatt/roomatt.kod
+++ b/kod/object/passive/objectatt/roomatt.kod
@@ -1,0 +1,175 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+RoomAttribute is ObjectAttribute
+
+constants:
+
+   include blakston.khd   
+
+resources:
+      
+classvars:
+
+
+properties:
+   
+   % How long do we last? If piDuration is 0, no natural expiration.
+   ptDurationTimer = $
+   piDuration = 0
+
+messages:
+
+   Constructor(oRoom = $, iDuration = 0)
+   {
+      piDuration = iDuration;
+
+      propagate;
+   }
+   
+   Constructed()
+   {
+      if piDuration > 0
+      {
+         ptDurationTimer = CreateTimer(self,@Expire,piDuration);
+      }
+
+      propagate;
+   }
+   
+   Expire()
+   {
+      ptDurationTimer = $;
+      Post(self,@Delete);
+      return;
+   }
+   
+   Delete()
+   {
+      if ptDurationTimer <> $
+      {
+         DeleteTimer(ptDurationTimer);
+         ptDurationTimer = $;
+      }
+
+      if Send(self,@ModifiesRoomBackground)
+      {
+         Post(poHostObject,@RecalcLightAndWeather);
+      }
+
+      propagate;
+   }
+     
+   ReqAddToObject(host_object=$)
+   {
+      if NOT IsClass(host_object,&Room)
+      {
+         return 0;
+      }
+      return 1;
+   }
+   
+   GetChaosZone()
+   {
+      return FALSE;
+   }
+   
+   OverridesDeathFunction()
+   {
+      return FALSE;
+   }
+   
+   OverrideDeathFunction(who=$,what=$)
+   {
+      return;
+   }
+
+   LeaveHold(what=$)
+   {
+      return;
+   }
+   
+   AllowTryCreateMonster()
+   {
+      return TRUE;
+   }
+   
+   OverridesMonsterGeneration()
+   {
+      return TRUE;
+   }
+
+   GetMonsters()
+   {
+      return $;
+   }
+
+   BoostMonster(boost_val=0)
+   {
+      return boost_val;
+   }
+
+   FirstUserEntered()
+   {
+      return;
+   }
+   
+   LastUserLeft(what=$)
+   {
+      return;
+   }
+   
+   ModifiesRoomBackground()
+   {
+      return FALSE;
+   }
+   
+   ModifyRoomBackground(rBackground=$)
+   {
+      return rBackground;
+   }
+   
+   SomethingKilled(what=$,victim=$)
+   {
+      return;
+   }
+   
+   OverridesPlayerDots()
+   {
+      return FALSE;
+   }
+   
+   OverridePlayerDots(what=$,who=$)
+   {
+      return MM_NONE;
+   }
+   
+   SetSpellPlayerFlag(who=$)
+   {
+      return;
+   }
+   
+   OverridesMonsterDots()
+   {
+      return FALSE;
+   }
+   
+   OverrideMonsterDots(what=$,who=$)
+   {
+      return MM_NONE;
+   }
+   
+   ModifyMonsterGenTime(iTime=0)
+   {
+      return iTime;
+   }
+   
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/objectatt/roomatt.kod
+++ b/kod/object/passive/objectatt/roomatt.kod
@@ -171,5 +171,10 @@ messages:
       return iTime;
    }
    
+   ReqSomethingAttack(what = $,victim = $,use_weapon = $,report = TRUE)
+   {
+      return TRUE;
+   }
+   
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/objectatt/roomatt/anonroomatt.kod
+++ b/kod/object/passive/objectatt/roomatt/anonroomatt.kod
@@ -43,8 +43,8 @@ resources:
       "unobfuscate yourself?"
 
    anonatt_killed_by_player = \
-      "~B~U~k[###]~n ~B~v%q was just slain in the confusion at "
-      "%q by %q."
+      "~B~U~k[###]~n ~B~v%s was just slain in the confusion at "
+      "%s by %s."
 
    background_anonatt = 1skyd.bgf
       

--- a/kod/object/passive/objectatt/roomatt/anonroomatt.kod
+++ b/kod/object/passive/objectatt/roomatt/anonroomatt.kod
@@ -1,0 +1,221 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+AnonymousRoomAttribute is RoomAttribute
+
+% This renders everyone in the room anonymous.
+% All player dots are red halo (attackable).
+% Descriptions can't be clicked.
+% This allows anyone to fight anyone, assuming you can figure out who they are.
+% No change to penalties.
+
+constants:
+
+   include blakston.khd
+   
+   DEFLT_START_TIME = 60000
+
+resources:
+
+   anonatt_welcome_message = \
+      "~IAs you enter this place, you feel Riija's mocking smile upon you. "
+      "The trickster god's prank has made things... complicated."
+      
+   anonatt_beginning_in_sixty = \
+      "~IYou're starting to feel a little weird."
+   
+   anonatt_has_begun = \
+      "~IThe mocking smile of Riija falls upon you. You blink, yawn once, "
+      "and then... wait, that can't be right..."
+   
+   anonatt_ended = \
+      "Bored of mortal affairs, Riija moves on."
+      
+   anonatt_no_cast_rsc = \
+      "If you obscure your obfuscation, how will you ever "
+      "unobfuscate yourself?"
+
+   anonatt_killed_by_player = \
+      "~B~U~k[###]~n ~B~v%q was just slain in the confusion at "
+      "%q by %q."
+
+   background_anonatt = 1skyd.bgf
+      
+classvars:
+
+properties:
+
+   ptInitiateTimer = $
+   piHasBegun = FALSE
+
+messages:
+
+   Constructed()
+   {
+      local i;
+
+      ptInitiateTimer = CreateTimer(self,@InitiateAnonAtt,DEFLT_START_TIME);
+      
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Send(i,@MsgSendUser,#message_rsc=anonatt_beginning_in_sixty);
+      }
+
+      propagate;
+   }
+   
+   InitiateAnonAtt()
+   {
+      local i;
+
+      ptInitiateTimer = $;
+      piHasBegun = TRUE;
+      
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Post(i,@MsgSendUser,#message_rsc=anonatt_has_begun);
+         Post(i,@RemoveEnchantment,
+                  #what=Send(SYS,@FindSpellByNum,#num=SID_ANONYMITY));
+         Post(i,@SetPlayerFlag,#flag=PFLAG_ANONYMOUS,#value=TRUE);
+         Post(i,@SetPlayerDrawFX,#drawfx=DRAWFX_BLACK,
+                                   #SendSomethingChanged=TRUE);
+      }
+      
+      Post(poHostObject,@RecalcLightAndWeather);
+
+      return;
+   }
+   
+   ModifiesRoomBackground()
+   {
+      return piHasBegun;
+   }
+   
+   ModifyRoomBackground(rBackground=$)
+   {
+      if piHasBegun
+      {
+         return background_anonatt;
+      }
+
+      return rBackground;
+   }
+
+   NewHoldObject(what=$)
+   {
+      if IsClass(what,&User)
+         AND piHasBegun
+      {
+         Post(what,@MsgSendUser,#message_rsc=anonatt_welcome_message);
+         Post(what,@RemoveEnchantment,
+                  #what=Send(SYS,@FindSpellByNum,#num=SID_ANONYMITY));
+         Post(what,@RemoveEnchantment,
+                  #what=Send(SYS,@FindSpellByNum,#num=SID_SHADOW_FORM));
+         Post(what,@SetPlayerFlag,#flag=PFLAG_ANONYMOUS,#value=TRUE);
+         Post(what,@SetPlayerDrawFX,#drawfx=DRAWFX_BLACK,
+                                   #SendSomethingChanged=TRUE);
+      }
+
+      return;
+   }
+   
+   SetSpellPlayerFlag(who=$)
+   {
+      if piHasBegun
+      {
+         Send(who,@SetPlayerFlag,#flag=PFLAG_ANONYMOUS,#value=TRUE);
+         Send(who,@SetPlayerDrawFX,#drawfx=DRAWFX_BLACK,
+                                   #SendSomethingChanged=TRUE);
+      }
+
+      return;
+   }
+
+   LeaveHold(what=$)
+   {
+      if IsClass(what,&User)
+         AND piHasBegun
+      {
+         Post(what,@SetPlayerFlag,#flag=PFLAG_ANONYMOUS,#value=FALSE);
+         Post(what,@ResetPlayerDrawfx);
+      }
+
+      return;
+   }
+
+   ReqSpellCast(who = $, oSpell = $, lItems = $)
+   {
+      if (IsClass(oSpell,&Anonymity)
+         OR IsClass(oSpell,&ShadowForm))
+         AND piHasBegun
+      {
+         % We have to provide the fail message here.
+         Send(who,@MsgSendUser,#message_rsc=anonatt_no_cast_rsc,
+               #parm1=Send(oSpell,@GetName));
+
+         return FALSE;
+      }
+
+      return TRUE;
+   }
+   
+   SomethingKilled(what=$,victim=$)
+   {
+      local i;
+      
+      if IsClass(what,&Player)
+         AND IsClass(victim,&Player)
+         AND piHasBegun
+      {
+         for i in Send(SYS,@GetUsersLoggedOn)
+         {
+            Post(i,@MsgSendUser,#message_rsc=anonatt_killed_by_player,
+                                   #parm1=Send(victim,@GetTrueName),
+                                   #parm2=Send(poHostObject,@GetName),
+                                   #parm3=Send(what,@GetTrueName));
+         }
+      }
+
+      return;
+   }
+
+   Delete()
+   {
+      local i;
+
+      if ptInitiateTimer <> $
+      {
+         DeleteTimer(ptInitiateTimer);
+         ptInitiateTimer = $;
+         propagate;
+      }
+
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Send(i,@MsgSendUser,#message_rsc=anonatt_ended);
+         Post(i,@SetPlayerFlag,#flag=PFLAG_ANONYMOUS,#value=FALSE);
+         Post(i,@ResetPlayerDrawfx);
+      }
+
+      propagate;
+   }
+   
+   OverridesPlayerDots()
+   {
+      return piHasBegun;
+   }
+   
+   OverridePlayerDots(what=$,who=$)
+   {
+      return (MM_PLAYER | MM_PLAYER_IS_ENEMY);
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/objectatt/roomatt/chaosroomatt.kod
+++ b/kod/object/passive/objectatt/roomatt/chaosroomatt.kod
@@ -37,8 +37,8 @@ resources:
       "Civilized behavior returns as Faren's surging ferocity fades."
 
    chaosatt_killed_by_player = \
-      "~B~U~k[###]~n ~B~v%q was just slain in the furious wilds at "
-      "%q by %q."
+      "~B~U~k[###]~n ~B~v%s was just slain in the furious wilds at "
+      "%s by %s."
 
    chaos_room_begin_wav = chaosup.wav
    background_chaosatt = 1skyc.bgf

--- a/kod/object/passive/objectatt/roomatt/chaosroomatt.kod
+++ b/kod/object/passive/objectatt/roomatt/chaosroomatt.kod
@@ -1,0 +1,158 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+ChaosRoomAttribute is RoomAttribute
+
+% This allows anyone to fight anyone.
+% No change to penalties.
+
+constants:
+
+   include blakston.khd
+   
+   DEFLT_START_TIME = 60000
+
+resources:
+
+   chaosatt_welcome_message = \
+      "~BAs you enter this place, you feel the gaze of Faren upon you. "
+      "The natural order reigns supreme. It is kill or be killed."
+      
+   chaosatt_beginning_in_sixty = \
+      "~BYou feel the order of law fading away."
+   
+   chaosatt_has_begun = \
+      "~BThe gaze of Faren falls upon you. Suddenly, civilization falls "
+      "away, and you know that no artificial law can trump that of nature. "
+      "Life and death are intertwined - it is kill or be killed."
+   
+   chaosatt_ended = \
+      "Civilized behavior returns as Faren's surging ferocity fades."
+
+   chaosatt_killed_by_player = \
+      "~B~U~k[###]~n ~B~v%q was just slain in the furious wilds at "
+      "%q by %q."
+
+   chaos_room_begin_wav = chaosup.wav
+   background_chaosatt = 1skyc.bgf
+      
+classvars:
+
+properties:
+
+   ptInitiateTimer = $
+   piHasBegun = FALSE
+
+messages:
+
+   Constructed()
+   {
+      local i;
+
+      ptInitiateTimer = CreateTimer(self,@InitiateChaosAtt,DEFLT_START_TIME);
+      
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Send(i,@MsgSendUser,#message_rsc=chaosatt_beginning_in_sixty);
+      }
+
+      propagate;
+   }
+   
+   InitiateChaosAtt()
+   {
+      local i;
+
+      ptInitiateTimer = $;
+      piHasBegun = TRUE;
+      
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Post(i,@MsgSendUser,#message_rsc=chaosatt_has_begun);
+         Post(i,@WaveSendUser,#what=i,#wave_rsc=chaos_room_begin_wav);
+      }
+      
+      Post(poHostObject,@RecalcLightAndWeather);
+
+      return;
+   }
+   
+   ModifiesRoomBackground()
+   {
+      return piHasBegun;
+   }
+   
+   ModifyRoomBackground(rBackground=$)
+   {
+      if piHasBegun
+      {
+         return background_chaosatt;
+      }
+
+      return rBackground;
+   }
+
+   NewHoldObject(what=$)
+   {
+      if IsClass(what,&User)
+         AND piHasBegun
+      {
+         Post(what,@MsgSendUser,#message_rsc=chaosatt_welcome_message);
+      }
+
+      return;
+   }
+   
+   SomethingKilled(what=$,victim=$)
+   {
+      local i;
+      
+      if IsClass(what,&Player)
+         AND IsClass(victim,&Player)
+         AND piHasBegun
+      {
+         for i in Send(SYS,@GetUsersLoggedOn)
+         {
+            Post(i,@MsgSendUser,#message_rsc=chaosatt_killed_by_player,
+                                   #parm1=Send(victim,@GetTrueName),
+                                   #parm2=Send(poHostObject,@GetName),
+                                   #parm3=Send(what,@GetTrueName));
+         }
+      }
+
+      return;
+   }
+
+   Delete()
+   {
+      local i;
+
+      if ptInitiateTimer <> $
+      {
+         DeleteTimer(ptInitiateTimer);
+         ptInitiateTimer = $;
+         propagate;
+      }
+
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Send(i,@MsgSendUser,#message_rsc=chaosatt_ended);
+      }
+
+      propagate;
+   }
+   
+   GetChaosZone()
+   {
+      return piHasBegun;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/objectatt/roomatt/frenzyroomatt.kod
+++ b/kod/object/passive/objectatt/roomatt/frenzyroomatt.kod
@@ -1,0 +1,191 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+FrenzyRoomAttribute is RoomAttribute
+
+% This turns a pre-existing room into a mini-frenzy.
+
+constants:
+
+   include blakston.khd
+   
+   DEFLT_START_TIME = 60000
+
+resources:
+
+   frenzyatt_welcome_message = \
+      "~BAs you enter this place, you feel the eyes of Qor upon you. "
+      "Death has no meaning here, good has become pain, and bloodshed "
+      "has become the natural order."
+      
+   frenzyatt_beginning_in_sixty = \
+      "~BYou feel something ominous approaching."
+   
+   frenzyatt_has_begun = \
+      "~BThe eyes of Qor fall upon you. All the world's virtues burn "
+      "away, and evil surges through this place. Qor's ally, Death, "
+      "turns a blind eye to you who have been forsaken."
+   
+   frenzyatt_ended = \
+      "The skies return to normal as the natural order shrugs off "
+      "Qor's bloodlust."
+      
+   frenzyatt_qor_reward_kill = \
+      "Qor gleefully rewards you with energy for your brutal slaying of %s!"
+
+   frenzyatt_killed_by_player = \
+      "~B~U~k[###]~n ~B~v%q was just slain under the blood skies at "
+      "%q by %q."
+
+   frenzy_room_begin_wav = chaosup.wav
+   background_frenzyatt = redsky.bgf
+      
+classvars:
+
+properties:
+
+   ptInitiateTimer = $
+   piHasBegun = FALSE
+
+messages:
+
+   Constructed()
+   {
+      local i;
+
+      ptInitiateTimer = CreateTimer(self,@InitiateFrenzyAtt,DEFLT_START_TIME);
+      
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Send(i,@MsgSendUser,#message_rsc=frenzyatt_beginning_in_sixty);
+      }
+
+      propagate;
+   }
+   
+   InitiateFrenzyAtt()
+   {
+      local i;
+
+      ptInitiateTimer = $;
+      piHasBegun = TRUE;
+      
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Post(i,@MsgSendUser,#message_rsc=frenzyatt_has_begun);
+         Post(i,@WaveSendUser,#what=i,#wave_rsc=frenzy_room_begin_wav);
+      }
+      
+      Post(poHostObject,@RecalcLightAndWeather);
+
+      return;
+   }
+   
+   ModifiesRoomBackground()
+   {
+      return piHasBegun;
+   }
+   
+   ModifyRoomBackground(rBackground=$)
+   {
+      if piHasBegun
+      {
+         return background_frenzyatt;
+      }
+
+      return rBackground;
+   }
+   
+   SomethingKilled(what=$,victim=$)
+   {
+      % Give successful killers a boost.
+
+      if IsClass(victim,&Player)
+         AND IsClass(what,&Player)
+         AND piHasBegun
+      {
+         Send(what,@SetHealth,#amount=Send(what,@GetMaxHealth));
+         Send(what,@EatSomething,#nutrition=20);
+         if NOT Send(what,@IsCrystalizeManaSurging)
+         {
+            Send(what,@GainMana,#amount=Send(what,@GetMaxMana),
+               #bCapped=TRUE);
+         }
+         Send(what,@RechargeAllRods,#alternate_recharge=TRUE);
+         Post(what,@MsgSendUser,#message_rsc=frenzyatt_qor_reward_kill,
+                                #parm1=Send(victim,@GetTrueName));
+      }
+
+      return;
+   }
+
+   NewHoldObject(what=$)
+   {
+      if IsClass(what,&User)
+         AND piHasBegun
+      {
+         Post(what,@MsgSendUser,#message_rsc=frenzyatt_welcome_message);
+      }
+
+      return;
+   }
+
+   Delete()
+   {
+      local i;
+
+      if ptInitiateTimer <> $
+      {
+         DeleteTimer(ptInitiateTimer);
+         ptInitiateTimer = $;
+         propagate;
+      }
+
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Send(i,@MsgSendUser,#message_rsc=frenzyatt_ended);
+         if NOT Send(i,@IsInCannotInteractMode)
+         {
+            Send(i,@SetHealth,#amount=Send(i,@GetMaxHealth));
+         }
+      }
+
+      propagate;
+   }
+   
+   GetChaosZone()
+   {
+      return piHasBegun;
+   }
+   
+   OverridesDeathFunction()
+   {
+      return piHasBegun;
+   }
+   
+   OverrideDeathFunction(who=$,what=$)
+   {
+      local i;
+
+      for i in Send(SYS,@GetUsersLoggedOn)
+      {
+         Post(i,@MsgSendUser,#message_rsc=frenzyatt_killed_by_player,
+                                #parm1=Send(who,@GetTrueName),
+                                #parm2=Send(poHostObject,@GetName),
+                                #parm3=Send(what,@GetTrueName));
+      }
+
+      Post(who,@AdminGoToLastSafeRoom);
+      
+      return;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/objectatt/roomatt/frenzyroomatt.kod
+++ b/kod/object/passive/objectatt/roomatt/frenzyroomatt.kod
@@ -41,8 +41,8 @@ resources:
       "Qor gleefully rewards you with energy for your brutal slaying of %s!"
 
    frenzyatt_killed_by_player = \
-      "~B~U~k[###]~n ~B~v%q was just slain under the blood skies at "
-      "%q by %q."
+      "~B~U~k[###]~n ~B~v%s was just slain under the blood skies at "
+      "%s by %s."
 
    frenzy_room_begin_wav = chaosup.wav
    background_frenzyatt = redsky.bgf

--- a/kod/object/passive/objectatt/roomatt/invasionroomatt.kod
+++ b/kod/object/passive/objectatt/roomatt/invasionroomatt.kod
@@ -42,6 +42,9 @@ resources:
    definvasionatt_beginning_in_location = \
       "~BThe forces of evil are preparing to attack at %s. Shal'ille calls "
       "for the aid of all adventurers!"
+   
+   definvasionatt_happening_in_location = \
+      "Shal'ille calls for the aid of all adventurers at %s!"
       
    invasionatt_beginning_in_sixty = \
       "You sense approaching doom."
@@ -111,6 +114,7 @@ resources:
 classvars:
 
    invasionatt_beginning_in_location = definvasionatt_beginning_in_location
+   invasionatt_happening_in_location = definvasionatt_happening_in_location
    invasionatt_ended = definvasionatt_ended
    invasionatt_boss_goal_msg = definvasionatt_boss_goal_msg
    invasionatt_minibosses_goal_msg = definvasionatt_minibosses_goal_msg
@@ -150,6 +154,13 @@ properties:
    
    % This keeps track of [player, kills, rounds participated]
    plRewardPoints = $
+   
+   % Enemies rise by this many levels per wave
+   % Boss is finallevel * boost
+   % Miniboss is finallevel-1 * boost
+   piBoostMultiplier = 5
+   piBossBoostMultiplier = 10
+   piMiniBossBoostMultiplier = 10
 
 messages:
 
@@ -204,6 +215,11 @@ messages:
       
       ptReportGoalsTimer = CreateTimer(self,@ReportGoalsTrigger,REPORT_TIME);
       
+      for i in Send(SYS,@GetUsersLoggedOn)
+      {
+         Send(i,@MsgSendUser,#message_rsc=invasionatt_happening_in_location,
+                             #parm1=Send(poHostObject,@GetName));
+      }
       for i in Send(poHostObject,@GetPlayers)
       {
          Send(i,@MsgSendUser,#message_rsc=invasionatt_begin_level);
@@ -410,7 +426,7 @@ messages:
 
       cBoss = Nth(plBosses,Random(1,Length(plBosses)));
       Send(poHostObject,@GenerateMonster,#oMonster=Create(cBoss),#bStack=TRUE,
-                                    #piSurvivalLevel=piLevel*10);
+                                    #piSurvivalLevel=piLevel*piBossBoostMultiplier);
       piSpawnedBossThisRound = TRUE;
 
       return;
@@ -430,7 +446,7 @@ messages:
 
       cMiniboss = Nth(plMinibosses,Random(1,Length(plMinibosses)));
       Send(poHostObject,@GenerateMonster,#oMonster=Create(cMiniboss),#bStack=TRUE,
-                                 #piSurvivalLevel=piLevel*10);
+                                 #piSurvivalLevel=piLevel*piMiniBossBoostMultiplier);
       return;
    }
    
@@ -988,7 +1004,7 @@ messages:
    
    BoostMonster(boost_val=0)
    {
-      return boost_val + (piLevel*5);
+      return boost_val + (piLevel*piBoostMultiplier);
    }
    
    Victory()
@@ -1045,7 +1061,7 @@ messages:
             }
             if Nth(i,2) = REWARD_TOUGHER
             {
-               Send(oHighestPlayer,@GainBaseMaxHealth,#amount = 1);
+               Send(oHighestPlayer,@GainBaseMaxHealth,#amount = Nth(i,1));
 
                Send(oHighestPlayer,@evaluatepkstatus);
 
@@ -1065,6 +1081,7 @@ messages:
                   lRanking = DelListElem(lRanking,n);
                }
             }
+            oHighestPlayer = $;
          }
       }
       

--- a/kod/object/passive/objectatt/roomatt/invasionroomatt.kod
+++ b/kod/object/passive/objectatt/roomatt/invasionroomatt.kod
@@ -8,24 +8,17 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-SurvivalRoomAttribute is RoomAttribute
+InvasionRoomAttribute is RoomAttribute
 
-% This turns any pre-existing room into a survival room with a specific list
-% of participants.
-% Players may join these from any safe location, but, if they do, they
-% return to that location upon leaving, penning, or dying.
-
-% Survival begins after 60 seconds of waiting for participants.
-% The Survival begins at Level 1.
-% When players complete certain objectives, the level increases.
-% Monsters are more difficult at each level, and loot drops and XP increase.
-
-% If players aren't attacked for a long period of time, they're clearly
-% abusing something. Enemies will begin spawning with MOVES_THROUGH_WALLS.
+% This is a standard event invasion by mobs.
 
 constants:
 
    include blakston.khd
+   
+   REWARD_MONEY = 1
+   REWARD_ITEM = 2
+   REWARD_TOUGHER = 3
    
    GOAL_KILLS = 1
    GOAL_BOSS = 2
@@ -45,62 +38,84 @@ constants:
 
 resources:
 
-   survatt_welcome_message = \
-      "You can feel Kraanan's eyes upon you as you undertake his greatest "
-      "challenge. This place will grow progressively more "
-      "dangerous as time goes on. Death seems inevitable, and dying will be "
-      "as lethal as ever."
+   invasionatt_welcome_message = \
+      "As you enter this place, you feel Shal'ille's holy support fill you. "
+      "You will need it to defeat the forces of evil that have gathered here."
       
-   survatt_beginning_in_sixty = \
-      "~BCombat will begin in sixty seconds."
+   invasionatt_beginning_in_location = \
+      "~BThe forces of evil are preparing to attack at %s. Shal'ille calls "
+      "for the aid of all adventurers!"
       
-   survatt_beginning_in_location = \
-      "~BKraanan grins. Sounds of combat echo from %s. "
-      "Survive, conquer, and be rewarded."
+   invasionatt_beginning_in_sixty = \
+      "You sense approaching doom."
    
-   survatt_ended_at_level = \
-      "~BKraanan's challenge at %s has ended, and the warrior god is "
-      "satisfied. "
-      "His valorous combatants reached level %i. "
-      "%s was the last survivor."
+   invasionatt_has_begun = \
+      "Shal'ille bolsters you with her holy support even as the forces of "
+      "evil flood the area!"
    
-   survatt_next_level_in_seconds = \
-      "~BYou have defeated wave number %i. The next arrives in %i seconds."
-      
-   survatt_begin_level = \
-      "~BWave %i of the enemy force has arrived."
+   invasionatt_ended = \
+      "The forces of evil have been defeated!"
+   
+   invasionatt_cant_pvp = \
+      "Shal'ille refuses to allow you to attack another player. The forces of "
+      "evil must be defeated at all costs!"
+   
+   invasionatt_begin_level = \
+      "The forces of evil rally and surge!"
+   
+   invasionatt_survival_no_cast_rsc = \
+      "The forces of evil prevent your %s spell!"
 
-   survatt_survival_no_cast_rsc = "You cannot cast %s here."
-
-   survatt_goals_header = \
-      "To defeat this wave of enemies, you must:"
-   survatt_kill_goal_msg = \
-      "Kill %i enemy creatures."
-   survatt_boss_goal_msg = \
-      "Kill a boss."
-   survatt_minibosses_goal_msg = \
-      "Kill %i minibosses."
+   invasionatt_goals_header = \
+      "To defeat the forces of evil and save the land, you must:"
+   invasionatt_kill_goal_msg = \
+      "Defeat %i of the attacking monsters."
+   invasionatt_boss_goal_msg = \
+      "Slay the evil orc pit boss himself!"
+   invasionatt_minibosses_goal_msg = \
+      "Slay the wizard servants of the evil orc pit boss."
       
-   survatt_boss_slain_goal_msg = \
-      "~BA boss has been slain!"
-   survatt_minibosses_slain_goal_msg = \
-      "~BTwo minibosses have been slain!"
+   invasionatt_boss_slain_goal_msg = \
+      "~BThe orc pit boss has been slain!"
+   
+   invasionatt_minibosses_slain_goal_msg = \
+      "The lieutenants of the orc pit boss have fallen!"
       
-   survatt_kills_remaining = \
-      "There are %i kills remaining until the next wave."
+   invasionatt_kills_remaining = \
+      "There are %i monsters remaining in this offensive."
       
-   survatt_wall_blitz_activated = \
-      "~BA surge of ethereal fury overcomes the horde!"
+   invasionatt_fixed_reward_msg = \
+      "You see the glimmer of a %s somewhere on the battlefield."
+      
+   invasionatt_next_level_in_seconds = \
+      "The enemy will rally in %i seconds."
+      
+   victory_message = \
+      "The battle was hard-fought, but the thrill of victory brings "
+      "its own rewards."
+      
+   reward_money_msg = \
+      "You find and loot %i shillings."
+   reward_item_msg = \
+      "You find and loot one %s."
+   reward_improve_maxhealth = \
+      "You know you'll feel stronger once you heal from today's battle."
+      
+   invasionatt_broadcast_victory = \
+      "With Shal'ille's aid, the brave adventurers of the land have staved off "
+      "evil at %s."
+      
+   reward_tougher_wav_rsc = tougher.wav
 
-   survatt_fixed_reward_msg = \
-      "It seems one of the fallen enemies has dropped one %s on the battlefield!"
+   invasion_room_begin_wav = gong.wav
 
-   survatt_round_begin_wav = gong.wav
-   background_survival_sky = 3sky.bgf
+   background_invasion_sky = 3sky.bgf
       
 classvars:
 
 properties:
+
+   plVictoryRewards = $
 
    plGenerators = $
    
@@ -113,11 +128,8 @@ properties:
    
    piRegroupTime = 15000
    ptNextLevelTimer = $
-   piWallBlitzTime = 300000
    
    pbSpawnWaves = FALSE
-
-   ptWallBlitzTimer = $
    
    plFixedRewards = $
    
@@ -128,44 +140,45 @@ properties:
    
    % Boolean for resource restoration on level completion.
    pbRestoreResources = TRUE
+   
+   % This keeps track of [player, kills, rounds participated]
+   plRewardPoints = $
 
 messages:
 
    Constructed()
    {
       local i;
+      
+      plVictoryRewards = [[1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [&Rose,REWARD_ITEM],
+                          [5000,REWARD_MONEY],
+                          [4000,REWARD_MONEY],
+                          [3000,REWARD_MONEY],
+                          [2000,REWARD_MONEY]];
 
       plGenerators = Send(poHostObject,@GetGenerators);
-
-      % Set the regroup time from the SurvivalRoomMaintenance default
-      piRegroupTime = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                           @GetRegroupTime);
-      % Set wall blitz time.
-      piWallBlitzTime = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                              @GetWallBlitzTime);
-      pbRestoreResources = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                              @GetRestoreResources);
-      plBosses = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                              @GetBosses);
-      plMinibosses = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                              @GetMiniBosses);
-      plFixedRewards = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                              @GetFixedRewards);
+      plBosses = [&OrcPitBoss];
+      plMinibosses = [&OrcWizard];
+      plFixedRewards = [[&RingInvisibility,3]];
       
-      plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                              @GetRoundOneMonsters);
+      plMonsters = [[&CaveOrc,20],[&Orc,80]];
 
       ptNextLevelTimer = CreateTimer(self,@InitiateNextLevel,DEFLT_START_TIME);
 
       for i in Send(SYS,@GetUsersLoggedOn)
       {
-         Send(i,@MsgSendUser,#message_rsc=survatt_beginning_in_location,
+         Send(i,@MsgSendUser,#message_rsc=invasionatt_beginning_in_location,
                              #parm1=Send(poHostObject,@GetName));
       }
       
       for i in Send(poHostObject,@GetPlayers)
       {
-         Send(i,@MsgSendUser,#message_rsc=survatt_beginning_in_sixty);
+         Send(i,@MsgSendUser,#message_rsc=invasionatt_beginning_in_sixty);
       }
       
       for i in Send(poHostObject,@GetMonsters)
@@ -190,55 +203,36 @@ messages:
 
       if piLevel = 2
       {
-         plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                              @GetRoundTwoMonsters);
+         plMonsters = [[&CaveOrc,40],[&Orc,60]];
       }
-      
+
       if piLevel = 3
       {
-         plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                              @GetRoundThreeMonsters);
+         plMonsters = [[&CaveOrc,60],[&Orc,40]];
       }
-      
+
       if piLevel = 4
       {
-         plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                              @GetRoundFourMonsters);
+         plMonsters = [[&CaveOrc,80],[&Orc,20]];
       }
+
+      if piLevel = 5
+      {
+         plMonsters = [[&CaveOrc,90],[&Shadowbeast,10]];
+      }
+      
+      ptReportGoalsTimer = CreateTimer(self,@ReportGoalsTrigger,REPORT_TIME);
       
       if piLevel = 5
       {
-         plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                              @GetRoundFiveMonsters);
-      }
-      
-      if piLevel = 6
-      {
-         plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                              @GetRoundSixMonsters);
-      }
-      
-      if piLevel = 7
-      {
-         plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                              @GetAllMonsters);
-      }
-      
-      ptWallBlitzTimer = CreateTimer(self,@ActivateWallBlitz,piWallBlitzTime);
-      ptReportGoalsTimer = CreateTimer(self,@ReportGoalsTrigger,REPORT_TIME);
-      
-      if Random(1,20) < piLevel
-      {
          Send(self,@SpawnBoss);
+         Send(self,@SpawnMiniboss);
+         Send(self,@SpawnMiniboss);
       }
-      
-      Send(self,@SpawnMiniboss);
-      Send(self,@SpawnMiniboss);
       
       for i in Send(poHostObject,@GetPlayers)
       {
-         Send(i,@MsgSendUser,#message_rsc=survatt_begin_level,
-                             #parm1=piLevel);
+         Send(i,@MsgSendUser,#message_rsc=invasionatt_begin_level);
       }
 
       plLevelGoals = $;
@@ -246,7 +240,7 @@ messages:
       
       Send(self,@ReportGoals);
       
-      Send(poHostObject,@SomethingWaveRoom,#wave_rsc=survatt_round_begin_wav);
+      Send(poHostObject,@SomethingWaveRoom,#wave_rsc=invasion_room_begin_wav);
 
       return;
    }
@@ -267,51 +261,32 @@ messages:
    
       for i in Send(poHostObject,@GetPlayers)
       {
-         Send(i,@MsgSendUser,#message_rsc=survatt_goals_header);
+         Send(i,@MsgSendUser,#message_rsc=invasionatt_goals_header);
          for n in plLevelGoals
          {
             if Nth(n,1) = GOAL_KILLS
             {
-               Send(i,@MsgSendUser,#message_rsc=survatt_kill_goal_msg,
+               Send(i,@MsgSendUser,#message_rsc=invasionatt_kill_goal_msg,
+                                   #parm1=Nth(n,2));
+            }
+            if Nth(n,1) = GOAL_MINIBOSSES
+            {
+               Send(i,@MsgSendUser,#message_rsc=invasionatt_minibosses_goal_msg,
                                    #parm1=Nth(n,2));
             }
             if Nth(n,1) = GOAL_BOSS
             {
-               Send(i,@MsgSendUser,#message_rsc=survatt_boss_goal_msg);
-            }
-            if Nth(n,1) = GOAL_MINIBOSSES
-            {
-               Send(i,@MsgSendUser,#message_rsc=survatt_minibosses_goal_msg,
-                                   #parm1=Nth(n,2));
+               Send(i,@MsgSendUser,#message_rsc=invasionatt_boss_goal_msg);
             }
          }
       }
       return;
    }
-   
-   ActivateWallBlitz()
-   {
-      local i, each_obj;
-      
-      ptWallBlitzTimer = $;
-      
-      for i in Send(poHostObject,@GetMonsters)
-      {
-         Send(i,@SetBehaviorFlag,#flag=AI_MOVE_WALKTHROUGH_WALLS);
 
-      }
-      
-      for i in Send(poHostObject,@GetPlayers)
-      {
-         Send(i,@MsgSendUser,#message_rsc=survatt_wall_blitz_activated);
-      }
-      
-      return;
-   }
-   
    LevelComplete()
    {
-      local i, lFixedReward, oReward, iRewardTime, lRandomSpawnPoint;
+      local i, n, lFixedReward, oReward, iRewardTime, lRandomSpawnPoint,
+            bFoundPlayerInRewards;
 
       iRewardTime = 0;
 
@@ -333,11 +308,6 @@ messages:
          }
       }
       
-      if ptWallBlitzTimer <> $
-      {
-         DeleteTimer(ptWallBlitzTimer);
-         ptWallBlitzTimer = $;
-      }
       if ptReportGoalsTimer <> $
       {
          DeleteTimer(ptReportGoalsTimer);
@@ -356,7 +326,7 @@ messages:
             oReward = Create(Nth(lFixedReward,1));
             for i in Send(poHostObject,@GetPlayers)
             {
-               Send(i,@MsgSendUser,#message_rsc=survatt_fixed_reward_msg,
+               Send(i,@MsgSendUser,#message_rsc=invasionatt_fixed_reward_msg,
                                    #parm1=Send(oReward,@GetName));
             }
             
@@ -377,9 +347,6 @@ messages:
             iRewardTime = iRewardTime + 45000;
          }
       }
-
-      ptNextLevelTimer = CreateTimer(self,@InitiateNextLevel,
-                              piRegroupTime + iRewardTime);
       
       for i in Send(poHostObject,@GetPlayers)
       {
@@ -395,12 +362,35 @@ messages:
             }
             Send(i,@RechargeAllRods,#alternate_recharge=TRUE);
          }
-         Send(i,@MsgSendUser,#message_rsc=survatt_next_level_in_seconds,
-                             #parm1 = piLevel,
-                             #parm2 = (piRegroupTime + iRewardTime)/1000);
+         Send(i,@MsgSendUser,#message_rsc=invasionatt_next_level_in_seconds,
+                             #parm1 = (piRegroupTime + iRewardTime)/1000);
+
+         bFoundPlayerInRewards = FALSE;
+         for n in plRewardPoints
+         {
+            if Nth(n,1) = i
+            {
+               SetNth(n,3,Nth(n,3)+1);
+               bFoundPlayerInRewards = TRUE;
+            }
+         }
+         
+         if NOT bFoundPlayerInRewards
+         {
+            plRewardPoints = Cons([i,0,1],plRewardPoints);
+         }
       }
 
       piLevel = piLevel + 1;
+      
+      if piLevel > 5
+      {
+         Send(self,@Victory);
+         return;
+      }
+
+      ptNextLevelTimer = CreateTimer(self,@InitiateNextLevel,
+                              piRegroupTime + iRewardTime);
       
       return;
    }
@@ -423,19 +413,13 @@ messages:
       iRand = Random((iTotalParticipants)*5,
                      (iTotalParticipants)*15);
                      
-      iRand = Bound(iRand,1,75);
+      iRand = Bound(iRand,15,150);
 
       plLevelGoals = Cons([GOAL_KILLS,iRand],plLevelGoals);
 
-      iRand = Random(1,3);
-      if iRand = 1
-         AND piSpawnedBossThisRound
+      if piSpawnedBossThisRound
       {
          plLevelGoals = Cons([GOAL_BOSS,1],plLevelGoals);
-      }
-
-      if iRand = 2
-      {
          plLevelGoals = Cons([GOAL_MINIBOSSES,2],plLevelGoals);
       }
       
@@ -448,7 +432,7 @@ messages:
 
       cBoss = Nth(plBosses,Random(1,Length(plBosses)));
       Send(poHostObject,@GenerateMonster,#oMonster=Create(cBoss),#bStack=TRUE,
-                                    #piSurvivalLevel=piLevel);
+                                    #piSurvivalLevel=piLevel*10);
       piSpawnedBossThisRound = TRUE;
 
       return;
@@ -468,13 +452,14 @@ messages:
 
       cMiniboss = Nth(plMinibosses,Random(1,Length(plMinibosses)));
       Send(poHostObject,@GenerateMonster,#oMonster=Create(cMiniboss),#bStack=TRUE,
-                                 #piSurvivalLevel=piLevel);
+                                 #piSurvivalLevel=piLevel*10);
       return;
    }
    
    SomethingKilled(what=$,victim=$)
    {
-      local i, n, p, cDeadClass, respawnCheck, oTarget, mob, oMonster, plParticipants;
+      local i, n, p, cDeadClass, respawnCheck, oTarget, mob, oMonster, plParticipants,
+            bPlayerFoundInRewardPoints, iPointsMultiplier;
       
       if IsClass(victim,&User)
       {
@@ -491,6 +476,45 @@ messages:
          }
 
          cDeadClass = GetClass(victim);
+         
+         % Measure players' contributions
+         if IsClass(what,&Player)
+         {
+            if plRewardPoints = $
+            {
+               plRewardPoints = Cons([what,0,0],plRewardPoints);
+            }
+            
+            iPointsMultiplier = 1;
+            if Send(what,@GetBaseMaxHealth) < 100
+            {
+               iPointsMultiplier = 2;
+            }
+            if Send(what,@GetBaseMaxHealth) < 50
+            {
+               iPointsMultiplier = 3;
+            }
+
+            bPlayerFoundInRewardPoints = FALSE;
+            for i in plRewardPoints
+            {
+               if Nth(i,1) = what
+               {
+                  SetNth(i,2,Nth(i,2)+
+                             (Send(self,@GetWorth,#mob=victim)*
+                              iPointsMultiplier));
+                  bPlayerFoundInRewardPoints = TRUE;
+               }
+            }
+            
+            if NOT bPlayerFoundInRewardPoints
+            {
+               plRewardPoints = Cons([what,
+                                      (Send(self,@GetWorth,#mob=victim)*
+                                      iPointsMultiplier),0],
+                                      plRewardPoints);
+            }
+         }
          
          for respawnCheck in plMinibosses
          {
@@ -510,7 +534,7 @@ messages:
                
                for p in Send(poHostObject,@GetPlayers)
                {
-                  Send(p,@MsgSendUser,#message_rsc=survatt_kills_remaining,
+                  Send(p,@MsgSendUser,#message_rsc=invasionatt_kills_remaining,
                                       #parm1=Nth(i,2));
                }
             }
@@ -554,7 +578,7 @@ messages:
                for n in plParticipants
                {
                   Send(n,@MsgSendUser,
-                         #message_rsc=survatt_boss_slain_goal_msg);
+                         #message_rsc=invasionatt_boss_slain_goal_msg);
                }
             }
             if Nth(i,1) = GOAL_MINIBOSSES
@@ -562,7 +586,7 @@ messages:
                for n in plParticipants
                {
                   Send(n,@MsgSendUser,
-                       #message_rsc=survatt_minibosses_slain_goal_msg);
+                       #message_rsc=invasionatt_minibosses_slain_goal_msg);
                }
             }
 
@@ -596,6 +620,39 @@ messages:
       }
 
       return;
+   }
+   
+   GetWorth(mob=$)
+   {
+      local i;
+      
+      for i in plMiniBosses
+      {
+         if i = GetClass(mob)
+         {
+            return 50;
+         }
+      }
+      
+      for i in plBosses
+      {
+         if i = GetClass(mob)
+         {
+            return 100;
+         }
+      }
+      
+      if Send(mob,@GetLevel) >= 100
+      {
+         return 3;
+      }
+      
+      if Send(mob,@GetLevel) >= 50
+      {
+         return 2;
+      }
+      
+      return 1;
    }
 
    AggroBosses(victim = $)
@@ -664,7 +721,7 @@ messages:
       if IsClass(what,&User)
       {
          Post(self,@AggroSome,#who=what);
-         Post(what,@MsgSendUser,#message_rsc=survatt_welcome_message);
+         Post(what,@MsgSendUser,#message_rsc=invasionatt_welcome_message);
          return;
       }
 
@@ -723,11 +780,6 @@ messages:
             % run after mob is set up in room.
             Post(what,@TargetSwitch,#what=oTarget,#iHatred=100);
             Post(what,@EnterStateChase,#target=oTarget,#actnow=True);
-         }
-
-         if ptWallBlitzTimer = $
-         {
-            Send(what,@SetBehaviorFlag,#flag=AI_MOVE_WALKTHROUGH_WALLS);
          }
       }
 
@@ -817,15 +869,12 @@ messages:
          }
       }
       
+      plRewardPoints = $;
+      
       if ptNextLevelTimer <> $
       {
          DeleteTimer(ptNextLevelTimer);
          ptNextLevelTimer = $;
-      }
-      if ptWallBlitzTimer <> $
-      {
-         DeleteTimer(ptWallBlitzTimer);
-         ptWallBlitzTimer = $;
       }
       if ptReportGoalsTimer <> $
       {
@@ -840,22 +889,6 @@ messages:
 
       propagate;
    }
-   
-   LastUserLeft(what=$)
-   {
-      local i;
-
-      for i in Send(SYS,@GetUsersLoggedOn)
-      {
-         Send(i,@MsgSendUser,#message_rsc=survatt_ended_at_level,
-                             #parm1=Send(poHostObject,@GetName),
-                             #parm2=piLevel,
-                             #parm3=Send(what,@GetTrueName));
-      }
-
-      Post(self,@Delete);
-      propagate;
-   }
 
    GetLevel()
    {
@@ -868,7 +901,7 @@ messages:
          OR IsClass(oSpell,&Jig)
       {
          % We have to provide the fail message here.
-         Send(who,@MsgSendUser,#message_rsc=survatt_survival_no_cast_rsc,
+         Send(who,@MsgSendUser,#message_rsc=invasionatt_survival_no_cast_rsc,
                #parm1=Send(oSpell,@GetName));
 
          return FALSE;
@@ -934,17 +967,7 @@ messages:
    {
       return plMonsters;
    }
-   
-   BoostsMonsters()
-   {
-      return TRUE;
-   }
-   
-   BoostMonster(boost_val=0)
-   {
-      return boost_val + piLevel;
-   }
-   
+
    ModifiesRoomBackground()
    {
       return TRUE;
@@ -952,7 +975,7 @@ messages:
    
    ModifyRoomBackground(rBackground=$)
    {
-      return background_survival_sky;
+      return background_invasion_sky;
    }
    
    OverridesMonsterDots()
@@ -978,6 +1001,96 @@ messages:
    ModifyMonsterGenTime(iTime=0)
    {
       return 1000;
+   }
+   
+   BoostsMonsters()
+   {
+      return TRUE;
+   }
+   
+   BoostMonster(boost_val=0)
+   {
+      return boost_val + (piLevel*5);
+   }
+   
+   Victory()
+   {
+      local i, n, z, lRanking, iHighestPoints, oHighestPlayer, oTreasure;
+
+      for i in Send(SYS,@GetUsersLoggedOn)
+      {
+         Send(i,@MsgSendUser,#message_rsc=invasionatt_broadcast_victory,
+                             #parm1=Send(poHostObject,@GetName));
+      }
+      
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Send(i,@MsgSendUser,#message_rsc=victory_message);
+         
+         for n in plRewardPoints
+         {
+            if Nth(n,1) = i
+            {
+               lRanking = Cons([i,Nth(n,2)*Nth(n,3)],lRanking);
+            }
+         }
+      }
+      
+      for i in plVictoryRewards
+      {
+         for n in lRanking
+         {
+            iHighestPoints = 0;
+            oHighestPlayer = $;
+            if Nth(n,2) > iHighestPoints
+            {
+               oHighestPlayer = Nth(n,1);
+               iHighestPoints = Nth(n,2);
+            }
+         }
+         
+         if oHighestPlayer <> $
+         {
+            if Nth(i,2) = REWARD_MONEY
+            {
+               oTreasure = Create(&Money,#amount=Nth(i,1));
+               Send(oHighestPlayer,@MsgSendUser,#message_rsc=reward_money_msg,
+                                   #parm1=Nth(i,1));
+               Send(oHighestPlayer,@NewHold,#what=oTreasure);
+            }
+            if Nth(i,2) = REWARD_ITEM
+            {
+               oTreasure = Create(Nth(i,1));
+               Send(oHighestPlayer,@MsgSendUser,#message_rsc=reward_item_msg,
+                                   #parm1=Send(oTreasure,@GetName));
+               Send(oHighestPlayer,@NewHold,#what=oTreasure);
+            }
+            if Nth(i,2) = REWARD_TOUGHER
+            {
+               Send(oHighestPlayer,@GainBaseMaxHealth,#amount = 1);
+
+               Send(oHighestPlayer,@evaluatepkstatus);
+
+               Send(oHighestPlayer,@MsgSendUser,#message_rsc=reward_improve_maxhealth);
+               Send(oHighestPlayer,@WaveSendUser,#what=oHighestPlayer,
+                     #wave_rsc=reward_tougher_wav_rsc);
+               Send(oHighestPlayer,@DrawHealth);
+               Post(oHighestPlayer,@DrawOffense);
+               Post(oHighestPlayer,@DrawDefense);
+            }
+            
+            % Been rewarded, remove from rankings
+            for n in lRanking
+            {
+               if Nth(n,1) = oHighestPlayer
+               {
+                  lRanking = DelListElem(lRanking,n);
+               }
+            }
+         }
+      }
+      
+      return;
    }
 
 end

--- a/kod/object/passive/objectatt/roomatt/invasionroomatt.kod
+++ b/kod/object/passive/objectatt/roomatt/invasionroomatt.kod
@@ -23,9 +23,6 @@ constants:
    GOAL_KILLS = 1
    GOAL_BOSS = 2
    GOAL_MINIBOSSES = 3
-
-   % 3 minutes to begin public survivals
-   PB_START_TIME = 180000
    
    % 1 minute to begin other survivals
    DEFLT_START_TIME = 60000
@@ -42,7 +39,7 @@ resources:
       "As you enter this place, you feel Shal'ille's holy support fill you. "
       "You will need it to defeat the forces of evil that have gathered here."
       
-   invasionatt_beginning_in_location = \
+   definvasionatt_beginning_in_location = \
       "~BThe forces of evil are preparing to attack at %s. Shal'ille calls "
       "for the aid of all adventurers!"
       
@@ -53,7 +50,7 @@ resources:
       "Shal'ille bolsters you with her holy support even as the forces of "
       "evil flood the area!"
    
-   invasionatt_ended = \
+   definvasionatt_ended = \
       "The forces of evil have been defeated!"
    
    invasionatt_cant_pvp = \
@@ -70,16 +67,16 @@ resources:
       "To defeat the forces of evil and save the land, you must:"
    invasionatt_kill_goal_msg = \
       "Defeat %i of the attacking monsters."
-   invasionatt_boss_goal_msg = \
-      "Slay the evil orc pit boss himself!"
-   invasionatt_minibosses_goal_msg = \
-      "Slay the wizard servants of the evil orc pit boss."
+   definvasionatt_boss_goal_msg = \
+      "Slay the boss himself!"
+   definvasionatt_minibosses_goal_msg = \
+      "Slay the lieutenants of the boss."
       
-   invasionatt_boss_slain_goal_msg = \
-      "~BThe orc pit boss has been slain!"
+   definvasionatt_boss_slain_goal_msg = \
+      "~BThe boss has been slain!"
    
-   invasionatt_minibosses_slain_goal_msg = \
-      "The lieutenants of the orc pit boss have fallen!"
+   definvasionatt_minibosses_slain_goal_msg = \
+      "The lieutenants of the boss have fallen!"
       
    invasionatt_kills_remaining = \
       "There are %i monsters remaining in this offensive."
@@ -101,7 +98,7 @@ resources:
    reward_improve_maxhealth = \
       "You know you'll feel stronger once you heal from today's battle."
       
-   invasionatt_broadcast_victory = \
+   definvasionatt_broadcast_victory = \
       "With Shal'ille's aid, the brave adventurers of the land have staved off "
       "evil at %s."
       
@@ -112,6 +109,15 @@ resources:
    background_invasion_sky = 3sky.bgf
       
 classvars:
+
+   invasionatt_beginning_in_location = definvasionatt_beginning_in_location
+   invasionatt_ended = definvasionatt_ended
+   invasionatt_boss_goal_msg = definvasionatt_boss_goal_msg
+   invasionatt_minibosses_goal_msg = definvasionatt_minibosses_goal_msg
+
+   invasionatt_boss_slain_goal_msg = definvasionatt_boss_slain_goal_msg
+   invasionatt_minibosses_slain_goal_msg = definvasionatt_minibosses_slain_goal_msg
+   invasionatt_broadcast_victory = definvasionatt_broadcast_victory
 
 properties:
 
@@ -125,6 +131,7 @@ properties:
    plMonsters = $
    
    piLevel = 1
+   piFinalLevel = 5
    
    piRegroupTime = 15000
    ptNextLevelTimer = $
@@ -149,25 +156,8 @@ messages:
    Constructed()
    {
       local i;
-      
-      plVictoryRewards = [[1,REWARD_TOUGHER],
-                          [1,REWARD_TOUGHER],
-                          [1,REWARD_TOUGHER],
-                          [1,REWARD_TOUGHER],
-                          [1,REWARD_TOUGHER],
-                          [&Rose,REWARD_ITEM],
-                          [5000,REWARD_MONEY],
-                          [4000,REWARD_MONEY],
-                          [3000,REWARD_MONEY],
-                          [2000,REWARD_MONEY]];
 
       plGenerators = Send(poHostObject,@GetGenerators);
-      plBosses = [&OrcPitBoss];
-      plMinibosses = [&OrcWizard];
-      plFixedRewards = [[&RingInvisibility,3]];
-      
-      plMonsters = [[&CaveOrc,20],[&Orc,80]];
-
       ptNextLevelTimer = CreateTimer(self,@InitiateNextLevel,DEFLT_START_TIME);
 
       for i in Send(SYS,@GetUsersLoggedOn)
@@ -198,37 +188,21 @@ messages:
    {
       local i, n, p;
 
-      ptNextLevelTimer = $;
-      pbSpawnWaves = TRUE;
-
-      if piLevel = 2
+      if piLevel = piFinalLevel - 1
       {
-         plMonsters = [[&CaveOrc,40],[&Orc,60]];
+         Send(self,@SpawnMiniboss);
+         Send(self,@SpawnMiniboss);
       }
 
-      if piLevel = 3
-      {
-         plMonsters = [[&CaveOrc,60],[&Orc,40]];
-      }
-
-      if piLevel = 4
-      {
-         plMonsters = [[&CaveOrc,80],[&Orc,20]];
-      }
-
-      if piLevel = 5
-      {
-         plMonsters = [[&CaveOrc,90],[&Shadowbeast,10]];
-      }
-      
-      ptReportGoalsTimer = CreateTimer(self,@ReportGoalsTrigger,REPORT_TIME);
-      
-      if piLevel = 5
+      if piLevel = piFinalLevel
       {
          Send(self,@SpawnBoss);
-         Send(self,@SpawnMiniboss);
-         Send(self,@SpawnMiniboss);
       }
+
+      ptNextLevelTimer = $;
+      pbSpawnWaves = TRUE;
+      
+      ptReportGoalsTimer = CreateTimer(self,@ReportGoalsTrigger,REPORT_TIME);
       
       for i in Send(poHostObject,@GetPlayers)
       {
@@ -383,7 +357,7 @@ messages:
 
       piLevel = piLevel + 1;
       
-      if piLevel > 5
+      if piLevel > piFinalLevel
       {
          Send(self,@Victory);
          return;
@@ -417,10 +391,14 @@ messages:
 
       plLevelGoals = Cons([GOAL_KILLS,iRand],plLevelGoals);
 
-      if piSpawnedBossThisRound
+      if piLevel = piFinalLevel - 1
+      {
+         plLevelGoals = Cons([GOAL_MINIBOSSES,2],plLevelGoals);
+      }
+
+      if piLevel = piFinalLevel
       {
          plLevelGoals = Cons([GOAL_BOSS,1],plLevelGoals);
-         plLevelGoals = Cons([GOAL_MINIBOSSES,2],plLevelGoals);
       }
       
       return;

--- a/kod/object/passive/objectatt/roomatt/invasionroomatt/avarinvasion.kod
+++ b/kod/object/passive/objectatt/roomatt/invasionroomatt/avarinvasion.kod
@@ -1,0 +1,148 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+AvarInvasion is InvasionRoomAttribute
+
+% This is a standard event invasion by avars.
+
+constants:
+
+   include blakston.khd
+   
+   REWARD_MONEY = 1
+   REWARD_ITEM = 2
+   REWARD_TOUGHER = 3
+
+resources:
+      
+   avarinvasionatt_beginning_in_location = \
+      "~BAn avar chieftain and other denizens of the jungle are preparing "
+      "to attack at %s. Shal'ille calls for the aid of all adventurers!"
+   
+   avarinvasionatt_happening_in_location = \
+      "The avar chieftain and his wild allies rally and attack %s once more!"
+
+   avarinvasionatt_ended = \
+      "The forces of the avar chieftain have been defeated!"
+
+   avarinvasionatt_boss_goal_msg = \
+      "Slay the avar chieftain himself!"
+   avarinvasionatt_minibosses_goal_msg = \
+      "Slay the shaman servants of the avar chieftain."
+      
+   avarinvasionatt_boss_slain_goal_msg = \
+      "~BThe avar chieftain has been slain!"
+   
+   avarinvasionatt_minibosses_slain_goal_msg = \
+      "The lieutenants of the avar chieftain have fallen!"
+
+   avarinvasionatt_broadcast_victory = \
+      "With Shal'ille's aid, the brave adventurers of the land have staved off "
+      "the avar invasion at %s."
+      
+classvars:
+
+   invasionatt_beginning_in_location = avarinvasionatt_beginning_in_location
+   invasionatt_happening_in_location = avarinvasionatt_happening_in_location
+   invasionatt_ended = avarinvasionatt_ended
+   invasionatt_boss_goal_msg = avarinvasionatt_boss_goal_msg
+   invasionatt_minibosses_goal_msg = avarinvasionatt_minibosses_goal_msg
+
+   invasionatt_boss_slain_goal_msg = avarinvasionatt_boss_slain_goal_msg
+   invasionatt_minibosses_slain_goal_msg = avarinvasionatt_minibosses_slain_goal_msg
+   invasionatt_broadcast_victory = avarinvasionatt_broadcast_victory
+
+properties:
+
+   piFinalLevel = 8
+   
+   % Enemies rise by this many levels per wave
+   % Boss is finallevel * boost
+   % Miniboss is finallevel-1 * boost
+   piBoostMultiplier = 2
+   piBossBoostMultiplier = 8
+   piMiniBossBoostMultiplier = 5
+
+messages:
+
+   Constructed()
+   {
+      local i;
+      
+      plVictoryRewards = [[5,REWARD_TOUGHER],
+                          [4,REWARD_TOUGHER],
+                          [3,REWARD_TOUGHER],
+                          [2,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [100000,REWARD_MONEY],
+                          [90000,REWARD_MONEY],
+                          [80000,REWARD_MONEY],
+                          [70000,REWARD_MONEY],
+                          [60000,REWARD_MONEY],
+                          [50000,REWARD_MONEY]];
+
+      plBosses = [&AvarChieftain];
+      plMinibosses = [&AvarShaman];
+      plFixedRewards = [[&Rose,5],
+                        [&Prism,7]];
+
+      propagate;
+   }
+
+   InitiateNextLevel(timer=$)
+   {
+      if piLevel = 1
+      {
+         plMonsters = [[&Dragonfly,20],[&Avar,80]];
+      }
+
+      if piLevel = 2
+      {
+         plMonsters = [[&Kriipa,5],[&Dragonfly,40],[&Avar,60]];
+      }
+
+      if piLevel = 3
+      {
+         plMonsters = [[&Kriipa,15],[&Dragonfly,30],[&Avar,60]];
+      }
+
+      if piLevel = 4
+      {
+         plMonsters = [[&Kriipa,15],[&Dragonfly,30],[&Avar,60]];
+      }
+
+      if piLevel = 5
+      {
+         plMonsters = [[&Avar,100]];
+      }
+
+      if piLevel = 6
+      {
+         plMonsters = [[&Dragonfly,100]];
+      }
+
+      if piLevel = 7
+      {
+         plMonsters = [[&Kriipa,100]];
+      }
+
+      if piLevel = piFinalLevel
+      {
+         plMonsters = [[&Shadowbeast,20],
+                       [&Kriipa,25],
+                       [&Dragonfly,30],
+                       [&Avar,30]];
+      }
+      
+      propagate;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/objectatt/roomatt/invasionroomatt/makefile
+++ b/kod/object/passive/objectatt/roomatt/invasionroomatt/makefile
@@ -5,6 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\invasionroomatt.bof
-BOFS = orcinvasion.bof avarinvasion.bof
+BOFS = orcinvasion.bof avarinvasion.bof ratinvasion.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/objectatt/roomatt/invasionroomatt/makefile
+++ b/kod/object/passive/objectatt/roomatt/invasionroomatt/makefile
@@ -5,6 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\invasionroomatt.bof
-BOFS = orcinvasion.bof
+BOFS = orcinvasion.bof avarinvasion.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/objectatt/roomatt/invasionroomatt/makefile
+++ b/kod/object/passive/objectatt/roomatt/invasionroomatt/makefile
@@ -1,0 +1,10 @@
+#
+# Makefile for compiling the Blakod
+#
+
+!include $(TOPDIR)\common.mak
+
+DEPEND = ..\invasionroomatt.bof
+BOFS = orcinvasion.bof
+
+!include $(KODDIR)\kod.mak

--- a/kod/object/passive/objectatt/roomatt/invasionroomatt/orcinvasion.kod
+++ b/kod/object/passive/objectatt/roomatt/invasionroomatt/orcinvasion.kod
@@ -1,0 +1,129 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+OrcInvasion is InvasionRoomAttribute
+
+% This is a standard event invasion by orcs.
+
+constants:
+
+   include blakston.khd
+   
+   REWARD_MONEY = 1
+   REWARD_ITEM = 2
+   REWARD_TOUGHER = 3
+   
+   GOAL_KILLS = 1
+   GOAL_BOSS = 2
+   GOAL_MINIBOSSES = 3
+   
+   % 1 minute to begin other survivals
+   DEFLT_START_TIME = 60000
+   
+   % Report goals every 1 minute
+   REPORT_TIME = 60000
+
+   % Starts when Miniboss is killed
+   RESPAWN_MINIBOSS_TIME = 60000
+
+resources:
+      
+   orcinvasionatt_beginning_in_location = \
+      "~BThe orc pit boss and other denizens of the caves are preparing "
+      "to attack at %s. Shal'ille calls for the aid of all adventurers!"
+   orcinvasionatt_ended = \
+      "The forces of the orc pit boss have been defeated!"
+
+   orcinvasionatt_boss_goal_msg = \
+      "Slay the evil orc pit boss himself!"
+   orcinvasionatt_minibosses_goal_msg = \
+      "Slay the wizard servants of the evil orc pit boss."
+      
+   orcinvasionatt_boss_slain_goal_msg = \
+      "~BThe orc pit boss has been slain!"
+   
+   orcinvasionatt_minibosses_slain_goal_msg = \
+      "The lieutenants of the orc pit boss have fallen!"
+
+   orcinvasionatt_broadcast_victory = \
+      "With Shal'ille's aid, the brave adventurers of the land have staved off "
+      "the orc invasion at %s."
+      
+classvars:
+
+   invasionatt_beginning_in_location = orcinvasionatt_beginning_in_location
+   invasionatt_ended = orcinvasionatt_ended
+   invasionatt_boss_goal_msg = orcinvasionatt_boss_goal_msg
+   invasionatt_minibosses_goal_msg = orcinvasionatt_minibosses_goal_msg
+
+   invasionatt_boss_slain_goal_msg = orcinvasionatt_boss_slain_goal_msg
+   invasionatt_minibosses_slain_goal_msg = orcinvasionatt_minibosses_slain_goal_msg
+   invasionatt_broadcast_victory = orcinvasionatt_broadcast_victory
+
+properties:
+
+   piFinalLevel = 5
+
+messages:
+
+   Constructed()
+   {
+      local i;
+      
+      plVictoryRewards = [[1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [&Rose,REWARD_ITEM],
+                          [5000,REWARD_MONEY],
+                          [4000,REWARD_MONEY],
+                          [3000,REWARD_MONEY],
+                          [2000,REWARD_MONEY]];
+
+      plBosses = [&OrcPitBoss];
+      plMinibosses = [&OrcWizard];
+      plFixedRewards = [[&RingInvisibility,3]];
+
+      propagate;
+   }
+
+   InitiateNextLevel(timer=$)
+   {
+      if piLevel = 1
+      {
+         plMonsters = [[&CaveOrc,20],[&Orc,80]];
+      }
+
+      if piLevel = 2
+      {
+         plMonsters = [[&CaveOrc,40],[&Orc,60]];
+      }
+
+      if piLevel = 3
+      {
+         plMonsters = [[&CaveOrc,60],[&Orc,40]];
+      }
+
+      if piLevel = 4
+      {
+         plMonsters = [[&CaveOrc,80],[&Orc,20]];
+      }
+
+      if piLevel = piFinalLevel
+      {
+         plMonsters = [[&CaveOrc,90],[&Shadowbeast,10]];
+      }
+      
+      propagate;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/objectatt/roomatt/invasionroomatt/orcinvasion.kod
+++ b/kod/object/passive/objectatt/roomatt/invasionroomatt/orcinvasion.kod
@@ -67,7 +67,7 @@ messages:
    {
       local i;
       
-      plVictoryRewards = [[1,REWARD_TOUGHER],
+      plVictoryRewards = [[2,REWARD_TOUGHER],
                           [1,REWARD_TOUGHER],
                           [1,REWARD_TOUGHER],
                           [1,REWARD_TOUGHER],

--- a/kod/object/passive/objectatt/roomatt/invasionroomatt/orcinvasion.kod
+++ b/kod/object/passive/objectatt/roomatt/invasionroomatt/orcinvasion.kod
@@ -19,25 +19,16 @@ constants:
    REWARD_MONEY = 1
    REWARD_ITEM = 2
    REWARD_TOUGHER = 3
-   
-   GOAL_KILLS = 1
-   GOAL_BOSS = 2
-   GOAL_MINIBOSSES = 3
-   
-   % 1 minute to begin other survivals
-   DEFLT_START_TIME = 60000
-   
-   % Report goals every 1 minute
-   REPORT_TIME = 60000
-
-   % Starts when Miniboss is killed
-   RESPAWN_MINIBOSS_TIME = 60000
 
 resources:
       
    orcinvasionatt_beginning_in_location = \
       "~BThe orc pit boss and other denizens of the caves are preparing "
       "to attack at %s. Shal'ille calls for the aid of all adventurers!"
+   
+   orcinvasionatt_happening_in_location = \
+      "The forces of the orc pit boss rally and attack %s once more!"
+   
    orcinvasionatt_ended = \
       "The forces of the orc pit boss have been defeated!"
 
@@ -59,6 +50,7 @@ resources:
 classvars:
 
    invasionatt_beginning_in_location = orcinvasionatt_beginning_in_location
+   invasionatt_happening_in_location = orcinvasionatt_happening_in_location
    invasionatt_ended = orcinvasionatt_ended
    invasionatt_boss_goal_msg = orcinvasionatt_boss_goal_msg
    invasionatt_minibosses_goal_msg = orcinvasionatt_minibosses_goal_msg
@@ -68,8 +60,6 @@ classvars:
    invasionatt_broadcast_victory = orcinvasionatt_broadcast_victory
 
 properties:
-
-   piFinalLevel = 5
 
 messages:
 

--- a/kod/object/passive/objectatt/roomatt/invasionroomatt/ratinvasion.kod
+++ b/kod/object/passive/objectatt/roomatt/invasionroomatt/ratinvasion.kod
@@ -1,0 +1,126 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+RatInvasion is InvasionRoomAttribute
+
+% This is a standard event invasion by rats.
+
+constants:
+
+   include blakston.khd
+   
+   REWARD_MONEY = 1
+   REWARD_ITEM = 2
+   REWARD_TOUGHER = 3
+
+resources:
+      
+   ratinvasionatt_beginning_in_location = \
+      "~BA rat king and other denizens of the forests are preparing "
+      "to attack at %s. Shal'ille calls for the aid of all adventurers!"
+   
+   ratinvasionatt_happening_in_location = \
+      "The rat king and his vermin rally and attack %s once more!"
+
+   ratinvasionatt_ended = \
+      "The forces of the rat king have been defeated!"
+
+   ratinvasionatt_boss_goal_msg = \
+      "Slay the rat king himself!"
+   ratinvasionatt_minibosses_goal_msg = \
+      "Slay the lieutenants of the rat king."
+      
+   ratinvasionatt_boss_slain_goal_msg = \
+      "~BThe rat king has been slain!"
+   
+   ratinvasionatt_minibosses_slain_goal_msg = \
+      "The lieutenants of the rat king have fallen!"
+
+   ratinvasionatt_broadcast_victory = \
+      "With Shal'ille's aid, the brave adventurers of the land have staved off "
+      "the rat king invasion at %s."
+      
+classvars:
+
+   invasionatt_beginning_in_location = ratinvasionatt_beginning_in_location
+   invasionatt_happening_in_location = ratinvasionatt_happening_in_location
+   invasionatt_ended = ratinvasionatt_ended
+   invasionatt_boss_goal_msg = ratinvasionatt_boss_goal_msg
+   invasionatt_minibosses_goal_msg = ratinvasionatt_minibosses_goal_msg
+
+   invasionatt_boss_slain_goal_msg = ratinvasionatt_boss_slain_goal_msg
+   invasionatt_minibosses_slain_goal_msg = ratinvasionatt_minibosses_slain_goal_msg
+   invasionatt_broadcast_victory = ratinvasionatt_broadcast_victory
+
+properties:
+
+   piFinalLevel = 4
+   
+   % Enemies rise by this many levels per wave
+   % Boss is finallevel * boost
+   % Miniboss is finallevel-1 * boost
+   piBoostMultiplier = 2
+   piBossBoostMultiplier = 4
+   piMiniBossBoostMultiplier = 3
+
+messages:
+
+   Constructed()
+   {
+      local i;
+      
+      plVictoryRewards = [[1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER],
+                          [1,REWARD_TOUGHER]];
+
+      plBosses = [&RatKing];
+      plMinibosses = [&Spider];
+      plFixedRewards = [[&MysticSword,3]];
+
+      propagate;
+   }
+
+   InitiateNextLevel(timer=$)
+   {
+      if piLevel = 1
+      {
+         plMonsters = [[&Centipede,20],[&GiantRat,80]];
+      }
+
+      if piLevel = 2
+      {
+         plMonsters = [[&Ant,5],[&Centipede,40],[&GiantRat,60]];
+      }
+
+      if piLevel = 3
+      {
+         plMonsters = [[&Ant,15],[&GiantRat,30],[&Centipede,60]];
+      }
+
+      if piLevel = piFinalLevel
+      {
+         plMonsters = [[&Ant,40],
+                       [&GiantRat,30],
+                       [&Centipede,30]];
+      }
+      
+      propagate;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/objectatt/roomatt/makefile
+++ b/kod/object/passive/objectatt/roomatt/makefile
@@ -6,6 +6,6 @@
 
 DEPEND = ..\roomatt.bof
 BOFS = survivalroomatt.bof chaosroomatt.bof frenzyroomatt.bof \
-       anonroomatt.bof
+       anonroomatt.bof invasionroomatt.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/objectatt/roomatt/makefile
+++ b/kod/object/passive/objectatt/roomatt/makefile
@@ -1,0 +1,11 @@
+#
+# Makefile for compiling the Blakod
+#
+
+!include $(TOPDIR)\common.mak
+
+DEPEND = ..\roomatt.bof
+BOFS = survivalroomatt.bof chaosroomatt.bof frenzyroomatt.bof \
+       anonroomatt.bof
+
+!include $(KODDIR)\kod.mak

--- a/kod/object/passive/objectatt/roomatt/survivalroomatt.kod
+++ b/kod/object/passive/objectatt/roomatt/survivalroomatt.kod
@@ -1,0 +1,984 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+SurvivalRoomAttribute is RoomAttribute
+
+% This turns any pre-existing room into a survival room with a specific list
+% of participants.
+% Players may join these from any safe location, but, if they do, they
+% return to that location upon leaving, penning, or dying.
+
+% Survival begins after 60 seconds of waiting for participants.
+% The Survival begins at Level 1.
+% When players complete certain objectives, the level increases.
+% Monsters are more difficult at each level, and loot drops and XP increase.
+
+% If players aren't attacked for a long period of time, they're clearly
+% abusing something. Enemies will begin spawning with MOVES_THROUGH_WALLS.
+
+constants:
+
+   include blakston.khd
+   
+   GOAL_KILLS = 1
+   GOAL_BOSS = 2
+   GOAL_MINIBOSSES = 3
+
+   % 3 minutes to begin public survivals
+   PB_START_TIME = 180000
+   
+   % 1 minute to begin other survivals
+   DEFLT_START_TIME = 60000
+   
+   % Report goals every 1 minute
+   REPORT_TIME = 60000
+
+   % Starts when Miniboss is killed
+   RESPAWN_MINIBOSS_TIME = 60000
+
+resources:
+
+   survatt_welcome_message = \
+      "You can feel Kraanan's eyes upon you as you undertake his greatest "
+      "challenge. This place will grow progressively more "
+      "dangerous as time goes on. Death seems inevitable, and dying will be "
+      "as lethal as ever."
+      
+   survatt_beginning_in_sixty = \
+      "~BCombat will begin in sixty seconds."
+      
+   survatt_beginning_in_location = \
+      "~BKraanan grins. Sounds of combat echo from %q. "
+      "Survive, conquer, and be rewarded."
+   
+   survatt_ended_at_level = \
+      "~BKraanan's challenge at %q has ended, and the warrior god is "
+      "satisfied. "
+      "His valorous combatants reached level %i. "
+      "%q was the last survivor."
+   
+   survatt_next_level_in_seconds = \
+      "~BYou have defeated wave number %i. The next arrives in %i seconds."
+      
+   survatt_begin_level = \
+      "~BWave %i of the enemy force has arrived."
+
+   survatt_survival_no_cast_rsc = "You cannot cast %s here."
+
+   survatt_goals_header = \
+      "To defeat this wave of enemies, you must:"
+   survatt_kill_goal_msg = \
+      "Kill %i enemy creatures."
+   survatt_boss_goal_msg = \
+      "Kill a boss."
+   survatt_minibosses_goal_msg = \
+      "Kill %i minibosses."
+      
+   survatt_boss_slain_goal_msg = \
+      "~BA boss has been slain!"
+   survatt_minibosses_slain_goal_msg = \
+      "~BTwo minibosses have been slain!"
+      
+   survatt_kills_remaining = \
+      "There are %i kills remaining until the next wave."
+      
+   survatt_wall_blitz_activated = \
+      "~BA surge of ethereal fury overcomes the horde!"
+
+   survatt_fixed_reward_msg = \
+      "It seems one of the fallen enemies has dropped one %s on the battlefield!"
+
+   survatt_round_begin_wav = gong.wav
+   background_survival_sky = 3sky.bgf
+      
+classvars:
+
+properties:
+
+   plGenerators = $
+   
+   plLevelGoals = $
+   plBosses = $
+   plMinibosses = $
+   plMonsters = $
+   
+   piLevel = 1
+   
+   piRegroupTime = 15000
+   ptNextLevelTimer = $
+   piWallBlitzTime = 300000
+   
+   pbSpawnWaves = FALSE
+
+   ptWallBlitzTimer = $
+   
+   plFixedRewards = $
+   
+   piSpawnedBossThisRound = FALSE
+   
+   ptReportGoalsTimer = $
+   ptRespawnMiniBossTimer = $
+   
+   % Boolean for resource restoration on level completion.
+   pbRestoreResources = TRUE
+
+messages:
+
+   Constructed()
+   {
+      local i;
+
+      plGenerators = Send(poHostObject,@GetGenerators);
+
+      % Set the regroup time from the SurvivalRoomMaintenance default
+      piRegroupTime = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                           @GetRegroupTime);
+      % Set wall blitz time.
+      piWallBlitzTime = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetWallBlitzTime);
+      pbRestoreResources = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetRestoreResources);
+      plBosses = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetBosses);
+      plMinibosses = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetMiniBosses);
+      plFixedRewards = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetFixedRewards);
+      
+      plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetRoundOneMonsters);
+
+      ptNextLevelTimer = CreateTimer(self,@InitiateNextLevel,DEFLT_START_TIME);
+
+      for i in Send(SYS,@GetUsersLoggedOn)
+      {
+         Send(i,@MsgSendUser,#message_rsc=survatt_beginning_in_location,
+                             #parm1=Send(poHostObject,@GetName));
+      }
+      
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Send(i,@MsgSendUser,#message_rsc=survatt_beginning_in_sixty);
+      }
+      
+      for i in Send(poHostObject,@GetMonsters)
+      {
+         if IsClass(i,&Monster)
+         {
+            Send(i,@Delete);
+         }
+      }
+      
+      Post(poHostObject,@RecalcLightAndWeather);
+
+      propagate;
+   }
+
+   InitiateNextLevel(timer=$)
+   {
+      local i, n, p;
+
+      ptNextLevelTimer = $;
+      pbSpawnWaves = TRUE;
+
+      if piLevel = 2
+      {
+         plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetRoundTwoMonsters);
+      }
+      
+      if piLevel = 3
+      {
+         plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetRoundThreeMonsters);
+      }
+      
+      if piLevel = 4
+      {
+         plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetRoundFourMonsters);
+      }
+      
+      if piLevel = 5
+      {
+         plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetRoundFiveMonsters);
+      }
+      
+      if piLevel = 6
+      {
+         plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetRoundSixMonsters);
+      }
+      
+      if piLevel = 7
+      {
+         plMonsters = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetAllMonsters);
+      }
+      
+      ptWallBlitzTimer = CreateTimer(self,@ActivateWallBlitz,piWallBlitzTime);
+      ptReportGoalsTimer = CreateTimer(self,@ReportGoalsTrigger,REPORT_TIME);
+      
+      if Random(1,20) < piLevel
+      {
+         Send(self,@SpawnBoss);
+      }
+      
+      Send(self,@SpawnMiniboss);
+      Send(self,@SpawnMiniboss);
+      
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Send(i,@MsgSendUser,#message_rsc=survatt_begin_level,
+                             #parm1=piLevel);
+      }
+
+      plLevelGoals = $;
+      Send(self,@ChooseGoals);
+      
+      Send(self,@ReportGoals);
+      
+      Send(poHostObject,@SomethingWaveRoom,#wave_rsc=survatt_round_begin_wav);
+
+      return;
+   }
+   
+   ReportGoalsTrigger(timer=$)
+   {
+      ptReportGoalsTimer = $;
+      
+      Send(self,@ReportGoals);
+      ptReportGoalsTimer = CreateTimer(self,@ReportGoalsTrigger,REPORT_TIME);
+      
+      return;
+   }
+   
+   ReportGoals()
+   {
+      local i, n;
+   
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Send(i,@MsgSendUser,#message_rsc=survatt_goals_header);
+         for n in plLevelGoals
+         {
+            if Nth(n,1) = GOAL_KILLS
+            {
+               Send(i,@MsgSendUser,#message_rsc=survatt_kill_goal_msg,
+                                   #parm1=Nth(n,2));
+            }
+            if Nth(n,1) = GOAL_BOSS
+            {
+               Send(i,@MsgSendUser,#message_rsc=survatt_boss_goal_msg);
+            }
+            if Nth(n,1) = GOAL_MINIBOSSES
+            {
+               Send(i,@MsgSendUser,#message_rsc=survatt_minibosses_goal_msg,
+                                   #parm1=Nth(n,2));
+            }
+         }
+      }
+      return;
+   }
+   
+   ActivateWallBlitz()
+   {
+      local i, each_obj;
+      
+      ptWallBlitzTimer = $;
+      
+      for i in Send(poHostObject,@GetMonsters)
+      {
+         Send(i,@SetBehaviorFlag,#flag=AI_MOVE_WALKTHROUGH_WALLS);
+
+      }
+      
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         Send(i,@MsgSendUser,#message_rsc=survatt_wall_blitz_activated);
+      }
+      
+      return;
+   }
+   
+   LevelComplete()
+   {
+      local i, lFixedReward, oReward, iRewardTime, lRandomSpawnPoint;
+
+      iRewardTime = 0;
+
+      % Prevent multi-level completion
+      if NOT pbSpawnWaves
+         OR ptNextLevelTimer <> $
+      {
+         return;
+      }
+
+      pbSpawnWaves = FALSE;
+      piSpawnedBossThisRound = FALSE;
+      
+      for i in Send(poHostObject,@GetMonsters)
+      {
+         if Send(i,@GetMaster) = $
+         {
+            Send(i,@Delete);
+         }
+      }
+      
+      if ptWallBlitzTimer <> $
+      {
+         DeleteTimer(ptWallBlitzTimer);
+         ptWallBlitzTimer = $;
+      }
+      if ptReportGoalsTimer <> $
+      {
+         DeleteTimer(ptReportGoalsTimer);
+         ptReportGoalsTimer = $;
+      }
+      if ptRespawnMiniBossTimer <> $
+      {
+         DeleteTimer(ptRespawnMiniBossTimer);
+         ptRespawnMiniBossTimer = $;
+      }
+
+      for lFixedReward in plFixedRewards
+      {
+         if Nth(lFixedReward,2) = piLevel
+         {
+            oReward = Create(Nth(lFixedReward,1));
+            for i in Send(poHostObject,@GetPlayers)
+            {
+               Send(i,@MsgSendUser,#message_rsc=survatt_fixed_reward_msg,
+                                   #parm1=Send(oReward,@GetName));
+            }
+            
+            if plGenerators <> $
+            {
+               lRandomSpawnPoint = Nth(plGenerators,
+                                       Random(1,Length(plGenerators)));
+            }
+            else
+            {
+               lRandomSpawnPoint = [Send(poHostObject,@GetTeleportRow),
+                                    Send(poHostObject,@GetTeleportCol)];
+            }
+            
+            Send(poHostObject,@NewHold,#what=oReward,
+                               #new_row=Nth(lRandomSpawnPoint,1),
+                               #new_col=Nth(lRandomSpawnPoint,2));
+            iRewardTime = iRewardTime + 45000;
+         }
+      }
+
+      ptNextLevelTimer = CreateTimer(self,@InitiateNextLevel,
+                              piRegroupTime + iRewardTime);
+      
+      for i in Send(poHostObject,@GetPlayers)
+      {
+         if pbRestoreResources
+            AND NOT Send(i,@IsInCannotInteractMode)
+         {
+            Send(i,@SetHealth,#amount=Send(i,@GetMaxHealth));
+            Send(i,@EatSomething,#nutrition=200);
+            if NOT Send(i,@IsCrystalizeManaSurging)
+            {
+               Send(i,@GainMana,#amount=Send(i,@GetMaxMana),
+                  #bCapped=TRUE);
+            }
+            Send(i,@RechargeAllRods,#alternate_recharge=TRUE);
+         }
+         Send(i,@MsgSendUser,#message_rsc=survatt_next_level_in_seconds,
+                             #parm1 = piLevel,
+                             #parm2 = (piRegroupTime + iRewardTime)/1000);
+      }
+
+      piLevel = piLevel + 1;
+      
+      return;
+   }
+   
+   ChooseGoals()
+   {
+      local iRand,plBosses,iTotalParticipants,plParticipants;
+      
+      plParticipants = Send(poHostObject,@GetActivePlayers);
+      
+      if plParticipants <> $
+      {
+        iTotalParticipants = Length(plParticipants);
+      }
+      else
+      {
+         iTotalParticipants = 0;
+      }
+
+      iRand = Random((iTotalParticipants)*5,
+                     (iTotalParticipants)*15);
+                     
+      iRand = Bound(iRand,1,75);
+
+      plLevelGoals = Cons([GOAL_KILLS,iRand],plLevelGoals);
+
+      iRand = Random(1,3);
+      if iRand = 1
+         AND piSpawnedBossThisRound
+      {
+         plLevelGoals = Cons([GOAL_BOSS,1],plLevelGoals);
+      }
+
+      if iRand = 2
+      {
+         plLevelGoals = Cons([GOAL_MINIBOSSES,2],plLevelGoals);
+      }
+      
+      return;
+   }
+   
+   SpawnBoss()
+   {
+      local cBoss;
+
+      cBoss = Nth(plBosses,Random(1,Length(plBosses)));
+      Send(poHostObject,@GenerateMonster,#oMonster=Create(cBoss),#bStack=TRUE,
+                                    #piSurvivalLevel=piLevel);
+      piSpawnedBossThisRound = TRUE;
+
+      return;
+   }
+   
+   RespawnMiniboss(timer=$)
+   {
+      ptRespawnMiniBossTimer = $;
+      Send(self,@SpawnMiniboss);
+
+      return;
+   }
+   
+   SpawnMiniboss()
+   {
+      local cMiniboss;
+
+      cMiniboss = Nth(plMinibosses,Random(1,Length(plMinibosses)));
+      Send(poHostObject,@GenerateMonster,#oMonster=Create(cMiniboss),#bStack=TRUE,
+                                 #piSurvivalLevel=piLevel);
+      return;
+   }
+   
+   SomethingKilled(what=$,victim=$)
+   {
+      local i, n, p, cDeadClass, respawnCheck, oTarget, mob, oMonster, plParticipants;
+      
+      if IsClass(victim,&User)
+      {
+         return;
+      }
+
+      if IsClass(victim,&Monster)
+      {
+         % These kills don't count towards the room goals.
+         if Send(victim,@IsMinion)
+            OR IsClass(victim,&Brambles)
+         {
+            return;
+         }
+
+         cDeadClass = GetClass(victim);
+         
+         for respawnCheck in plMinibosses
+         {
+            if respawnCheck = cDeadClass
+               AND ptRespawnMiniBossTimer = $
+            {
+               ptRespawnMiniBossTimer = 
+                    CreateTimer(self,@RespawnMiniboss,RESPAWN_MINIBOSS_TIME);
+            }
+         }
+         
+         for i in plLevelGoals
+         {
+            if Nth(i,1) = GOAL_KILLS
+            {
+               SetNth(i,2,Nth(i,2)-1);
+               
+               for p in Send(poHostObject,@GetPlayers)
+               {
+                  Send(p,@MsgSendUser,#message_rsc=survatt_kills_remaining,
+                                      #parm1=Nth(i,2));
+               }
+            }
+            
+            if Nth(i,1) = GOAL_BOSS
+            {
+               for n in plBosses
+               {
+                  if n = cDeadClass
+                  {
+                     SetNth(i,2,Nth(i,2)-1);
+                  }
+               }
+            }
+            
+            if Nth(i,1) = GOAL_MINIBOSSES
+            {
+               for n in plMinibosses
+               {
+                  if n = cDeadClass
+                  {
+                     SetNth(i,2,Nth(i,2)-1);
+                  }
+               }
+            }
+         }
+      }
+      
+      for i in plLevelGoals
+      {
+         plParticipants = Send(poHostObject,@GetActivePlayers);
+         
+         if Nth(i,2) <= 0
+         {
+            if Nth(i,1) = GOAL_KILLS
+            {
+               Post(self,@AggroBosses,#victim=victim);
+            }
+            if Nth(i,1) = GOAL_BOSS
+            {
+               for n in plParticipants
+               {
+                  Send(n,@MsgSendUser,
+                         #message_rsc=survatt_boss_slain_goal_msg);
+               }
+            }
+            if Nth(i,1) = GOAL_MINIBOSSES
+            {
+               for n in plParticipants
+               {
+                  Send(n,@MsgSendUser,
+                       #message_rsc=survatt_minibosses_slain_goal_msg);
+               }
+            }
+
+            plLevelGoals = DelListElem(plLevelGoals,i);
+         }
+
+         if plParticipants <> $
+            AND Length(plParticipants) = 1
+            AND plLevelGoals <> $
+         {
+            for mob in Send(poHostObject,@GetMonsters)
+            {
+               if NOT Send(mob,@IsOwnedByPlayer)
+                  AND mob <> victim
+                  AND Random(1,2) = 1
+               {
+                  oTarget = First(plParticipants);
+                  if oTarget <> $
+                  {
+                     Send(mob,@TargetSwitch,#what=oTarget,#iHatred=100);
+                     Send(mob,@EnterStateChase,#target=oTarget,#actnow=True);
+                  }
+               }
+            }
+         }
+      }
+
+      if plLevelGoals = $
+      {
+         Send(self,@LevelComplete);
+      }
+
+      return;
+   }
+
+   AggroBosses(victim = $)
+   {
+      local oTarget, i, n, z, each_obj, count, plParticipants;
+      
+      plParticipants = Send(poHostObject,@GetActivePlayers);
+
+      if plParticipants = $
+         OR plLevelGoals = $
+      {
+         return;
+      }
+
+      for i in Send(poHostObject,@GetMonsters)
+      {
+         if victim <> $
+            AND victim = i
+         {
+            continue;
+         }
+
+         for z in [plBosses,plMiniBosses]
+         {
+            for n in z
+            {
+               if GetClass(i) = n
+               {
+                  if Length(plParticipants) = 1
+                  {
+                     oTarget = First(plParticipants);
+                  }
+                  else
+                  {
+                     oTarget = Nth(plParticipants,
+                                   Random(1,Length(plParticipants)));
+                     count = 0;
+                     while (oTarget = $
+                        OR ((IsClass(oTarget,&DM)
+                           AND Send(oTarget,@PlayerIsImmortal))
+                        OR Send(oTarget,@IsInCannotInteractMode)))
+                     {
+                        oTarget = Nth(plParticipants,Random(1,
+                                      Length(plParticipants)));
+                        count = count + 1;
+                        if count > 10
+                        {
+                           break;
+                        }
+                     }
+                  }
+                  Send(i,@TargetSwitch,#what=oTarget,#iHatred=100);
+                  Send(i,@EnterStateChase,#target=oTarget,#actnow=True);
+               }
+            }
+         }
+      }
+
+      return;
+   }
+
+   NewHoldObject(what=$)
+   {
+      local oTarget, i, count, plParticipants;
+      
+      if IsClass(what,&User)
+      {
+         Post(self,@AggroSome,#who=what);
+         Post(what,@MsgSendUser,#message_rsc=survatt_welcome_message);
+         return;
+      }
+
+      if IsClass(what,&Monster)
+         AND (plBosses = $
+            OR (plBosses <> $
+               AND FindListElem(plBosses,GetClass(what)) = 0))
+         AND (plMiniBosses = $
+            OR (plMinibosses <> $
+               AND FindListElem(plMinibosses,GetClass(what)) = 0))
+      {
+         plParticipants = Send(poHostObject,@GetActivePlayers);
+         
+         if plParticipants = $
+            OR Send(what,@IsMinion)
+         {
+            return;
+         }
+
+         if Length(plParticipants) = 1
+         {
+            oTarget = First(plParticipants);
+         }
+         else
+         {
+            oTarget = Nth(plParticipants,Random(1,Length(plParticipants)));
+            count = 0;
+            while (oTarget = $
+               OR ((IsClass(oTarget,&DM)
+                     AND Send(oTarget,@PlayerIsImmortal))
+                  OR Send(oTarget,@IsInCannotInteractMode)))
+            {
+               oTarget = Nth(plParticipants,Random(1,Length(plParticipants)));
+               count = count + 1;
+               if count > 10
+               {
+                  break;
+               }
+            }
+         }
+
+         if Length(plParticipants) = 1
+         {
+            % Cut aggro to 1/5th in solo. Post these so they
+            % run after mob is set up in room.
+            if Random(1,5) = 1
+            {
+               Post(what,@TargetSwitch,#what=oTarget,#iHatred=100);
+               Post(what,@EnterStateChase,#target=oTarget,
+                     #actnow=True);
+            }
+         }
+         else
+         {
+            % Public arenas get full aggro. Post these so they
+            % run after mob is set up in room.
+            Post(what,@TargetSwitch,#what=oTarget,#iHatred=100);
+            Post(what,@EnterStateChase,#target=oTarget,#actnow=True);
+         }
+
+         if ptWallBlitzTimer = $
+         {
+            Send(what,@SetBehaviorFlag,#flag=AI_MOVE_WALKTHROUGH_WALLS);
+         }
+      }
+
+      return;
+   }
+
+   AggroOne(who = $,victim = $)
+   {
+      local i, iCount, oMonster;
+
+      if (IsClass(who,&DM)
+            AND Send(who,@PlayerIsImmortal))
+         OR Send(who,@IsInCannotInteractMode)
+      {
+         return;
+      }
+
+      iCount = 0;
+
+      for oMonster in Send(poHostObject,@GetMonsters)
+      {
+         if NOT Send(oMonster,@IsOwnedByPlayer)
+            AND Random(1,5) = 1
+         {
+            % If this is called from SomethingKilled, don't aggro
+            % the mob that was just killed.
+            if victim <> $
+               AND oMonster = victim
+            {
+               continue;
+            }
+            Send(oMonster,@TargetSwitch,#what=who,#iHatred=100);
+            Send(oMonster,@EnterStateChase,#target=who,#actnow=True);
+            iCount = iCount + 1;
+            
+            if iCount >= 1
+            {
+               return;
+            }
+         }
+      }
+
+      return;
+   }
+
+   AggroSome(who=$)
+   {
+      local i, iCount;
+
+      if (IsClass(who,&DM)
+            AND Send(who,@PlayerIsImmortal))
+         OR Send(who,@IsInCannotInteractMode)
+      {
+         return;
+      }
+
+      iCount = 0;
+
+      for i in Send(poHostObject,@GetMonsters)
+      {
+         if NOT Send(i,@IsOwnedByPlayer)
+            AND Random(1,5) = 1
+         {
+            Send(i,@TargetSwitch,#what=who,#iHatred=100);
+            Send(i,@EnterStateChase,#target=who,#actnow=True);
+            iCount = iCount + 1;
+            
+            if iCount >= 5
+            {
+               return;
+            }
+         }
+      }
+
+      return;
+   }
+
+   Delete()
+   {
+      local i;
+      
+      for i in Send(poHostObject,@GetMonsters)
+      {
+         if IsClass(i,&Monster)
+         {
+            Send(i,@Delete);
+         }
+      }
+      
+      if ptNextLevelTimer <> $
+      {
+         DeleteTimer(ptNextLevelTimer);
+         ptNextLevelTimer = $;
+      }
+      if ptWallBlitzTimer <> $
+      {
+         DeleteTimer(ptWallBlitzTimer);
+         ptWallBlitzTimer = $;
+      }
+      if ptReportGoalsTimer <> $
+      {
+         DeleteTimer(ptReportGoalsTimer);
+         ptReportGoalsTimer = $;
+      }
+      if ptRespawnMiniBossTimer <> $
+      {
+         DeleteTimer(ptRespawnMiniBossTimer);
+         ptRespawnMiniBossTimer = $;
+      }
+
+      propagate;
+   }
+   
+   LastUserLeft(what=$)
+   {
+      local i;
+
+      for i in Send(SYS,@GetUsersLoggedOn)
+      {
+         Send(i,@MsgSendUser,#message_rsc=survatt_ended_at_level,
+                             #parm1=Send(poHostObject,@GetName),
+                             #parm2=piLevel,
+                             #parm3=Send(what,@GetTrueName));
+      }
+
+      Post(self,@Delete);
+      propagate;
+   }
+
+   GetLevel()
+   {
+      return piLevel;
+   }
+
+   ReqSpellCast(who = $, oSpell = $, lItems = $)
+   {
+      if IsClass(oSpell,&Truce)
+         OR IsClass(oSpell,&Jig)
+      {
+         % We have to provide the fail message here.
+         Send(who,@MsgSendUser,#message_rsc=survatt_survival_no_cast_rsc,
+               #parm1=Send(oSpell,@GetName));
+
+         return FALSE;
+      }
+
+      return TRUE;
+   }
+
+   IsBoss(what=$)
+   {
+      local i, cMob;
+
+      if what <> $
+      {
+         cMob = GetClass(what);
+         for i in plBosses
+         {
+            if cMob = i
+            {
+               return TRUE;
+            }
+         }
+      }
+
+      return FALSE;
+   }
+
+   IsMiniBoss(what=$)
+   {
+      local i, cMob;
+
+      if what <> $
+      {
+         cMob = GetClass(what);
+         for i in plMiniBosses
+         {
+            if cMob = i
+            {
+               return TRUE;
+            }
+         }
+      }
+
+      return FALSE;
+   }
+   
+   OverridesMonsterGeneration()
+   {
+      return TRUE;
+   }
+   
+   AllowTryCreateMonster()
+   {
+      if NOT pbSpawnWaves
+      {
+         return FALSE;
+      }
+
+      return TRUE;
+   }
+
+   GetMonsters()
+   {
+      return plMonsters;
+   }
+   
+   BoostsMonsters()
+   {
+      return TRUE;
+   }
+   
+   BoostMonster(boost_val=0)
+   {
+      return boost_val + piLevel;
+   }
+   
+   ModifiesRoomBackground()
+   {
+      return TRUE;
+   }
+   
+   ModifyRoomBackground(rBackground=$)
+   {
+      return background_survival_sky;
+   }
+   
+   OverridesMonsterDots()
+   {
+      return TRUE;
+   }
+   
+   OverrideMonsterDots(what=$,who=$)
+   {
+      if Send(self,@IsMiniBoss,#what=what)
+      {
+         return MM_MINIBOSS;
+      }
+      
+      if Send(self,@IsBoss,#what=what)
+      {
+         return MM_BOSS;
+      }
+
+      return MM_MONSTER;
+   }
+   
+   ModifyMonsterGenTime(iTime=0)
+   {
+      return 1000;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/survivalmaint.kod
+++ b/kod/util/survivalmaint.kod
@@ -466,6 +466,235 @@ messages:
 
       return plSurvivalRooms;
    }
+   
+   GetRoundOneMonsters()
+   {
+      return [[&GiantRat, 14],
+              [&SpiderBaby, 14],
+              [&Centipede, 21],
+              [&EvilFairy, 7],
+              [&FungusBeast, 16],
+              [&SpectralMummy, 14],
+              [&Slime, 14]];
+   }
+   
+   GetRoundTwoMonsters()
+   {
+      return [[&GiantRat, 6],
+              [&SpiderBaby, 6],
+              [&Centipede, 6],
+              [&EvilFairy, 3],
+              [&FungusBeast, 9],
+              [&SpectralMummy, 6],
+              [&Slime, 9],
+              [&Zombie, 11],
+              [&Spider, 6],
+              [&Scorpion, 9],
+              [&BatteredSkeleton, 11],
+              [&Skeleton, 3],
+              [&RedAnt, 6],
+              [&Frogman, 6],
+              [&Troll, 3]];
+   }
+   
+   GetRoundThreeMonsters()
+   {
+      return [[&GiantRat, 3],
+              [&SpiderBaby, 3],
+              [&Centipede, 3],
+              [&EvilFairy, 3],
+              [&FungusBeast, 6],
+                            [&SpectralMummy, 6],
+                            [&Slime, 9],
+                            [&Zombie, 11],
+                            [&Spider, 6],
+                            [&Scorpion, 6],
+                            [&BatteredSkeleton, 11],
+                            [&Skeleton, 3],
+                            [&RedAnt, 3],
+                            [&Frogman, 6],
+                            [&Troll, 3],
+                            [&GroundWorm, 3],
+                            [&CaveOrc, 6],
+                            [&OrcWizard, 6],
+                            [&SnowRat, 3]];
+   }
+   
+   GetRoundFourMonsters()
+   {
+      return [[&GiantRat, 3],
+              [&SpiderBaby, 3],
+              [&Centipede, 3],
+              [&EvilFairy, 3],
+              [&FungusBeast, 3],
+              [&SpectralMummy, 3],
+              [&Slime, 6],
+              [&Zombie, 3],
+              [&Spider, 3],
+              [&Scorpion, 6],
+              [&BatteredSkeleton, 11],
+              [&Skeleton, 3],
+              [&RedAnt, 3],
+              [&Frogman, 6],
+              [&Troll, 3],
+              [&GroundWorm, 3],
+              [&CaveOrc, 6],
+              [&OrcWizard, 6],
+              [&SnowRat, 3],
+              [&TuskedSkeleton, 11],
+              [&Lupogg, 3],
+              [&DeathSpider, 3],
+              [&DragonFly, 3],
+              [&Avar, 3]];
+   }
+   
+   GetRoundFiveMonsters()
+   {
+      return [[&GiantRat, 3],
+              [&SpiderBaby, 3],
+              [&Centipede, 3],
+              [&EvilFairy, 3],
+              [&FungusBeast, 3],
+              [&SpectralMummy, 3],
+              [&Slime, 6],
+              [&Zombie, 3],
+              [&Spider, 3],
+              [&Scorpion, 6],
+              [&BatteredSkeleton, 5],
+              [&Skeleton, 3],
+              [&RedAnt, 3],
+              [&Frogman, 6],
+              [&Troll, 3],
+              [&GroundWorm, 3],
+              [&CaveOrc, 6],
+              [&OrcWizard, 6],
+              [&SnowRat, 3],
+              [&TuskedSkeleton, 5],
+              [&Lupogg, 3],
+              [&DeathSpider, 3],
+              [&DragonFly, 3],
+              [&Avar, 3],
+              [&AvarShaman, 3],
+              [&DuskRat, 3],
+              [&EvilEnt, 3],
+              [&Iceperson, 3]];
+   }
+   
+   GetRoundSixMonsters()
+   {
+      return [[&GiantRat, 3],
+              [&SpiderBaby, 3],
+              [&Centipede, 3],
+              [&EvilFairy, 3],
+              [&FungusBeast, 3],
+              [&SpectralMummy, 3],
+              [&Slime, 3],
+              [&Zombie, 3],
+              [&Spider, 3],
+              [&Scorpion, 6],
+              [&BatteredSkeleton, 5],
+              [&Skeleton, 3],
+              [&RedAnt, 3],
+              [&Frogman, 6],
+              [&Troll, 3],
+              [&GroundWorm, 3],
+              [&CaveOrc, 3],
+              [&OrcWizard, 3],
+              [&SnowRat, 3],
+              [&TuskedSkeleton, 5],
+              [&Lupogg, 3],
+              [&DeathSpider, 3],
+              [&DragonFly, 3],
+              [&Avar, 3],
+              [&AvarShaman, 3],
+              [&DuskRat, 3],
+              [&EvilEnt, 3],
+              [&Iceperson, 3],
+              [&MolluskMonster, 3],
+              [&NarthylWorm, 3],
+              [&DaemonSkeleton, 3]];
+   }
+   
+   GetAllMonsters()
+   {
+      return [[&GiantRat, 3],
+              [&SpiderBaby, 2],
+              [&Centipede, 3],
+              [&EvilFairy, 2],
+              [&FungusBeast, 3],
+              [&SpectralMummy, 3],
+              [&Slime, 3],
+              [&Zombie, 3],
+              [&Spider, 3],
+              [&Scorpion, 3],
+              [&BatteredSkeleton, 3],
+              [&Skeleton, 3],
+              [&RedAnt, 3],
+              [&Frogman, 3],
+              [&Troll, 3],
+              [&GroundWorm, 3],
+              [&CaveOrc, 3],
+              [&OrcWizard, 3],
+              [&SnowRat, 3],
+              [&TuskedSkeleton, 3],
+              [&Lupogg, 3],
+              [&DeathSpider, 3],
+              [&DragonFly, 3],
+              [&Avar, 3],
+              [&AvarShaman, 3],
+              [&DuskRat, 3],
+              [&EvilEnt, 3],
+              [&Iceperson, 3],
+              [&MolluskMonster, 3],
+              [&NarthylWorm, 3],
+              [&DaemonSkeleton, 3],
+              [&AvarChieftain, 3],
+              [&Kriipa, 3],
+              [&StoneTroll, 3]];
+   }
+   
+   GetBosses()
+   {
+      return [&LupoggKing,
+              &EarthElementalChampion,
+              &FireElementalChampion,
+              &IceElementalChampion,
+              &NeruElementalChampion,
+              &GiantRatKing,
+              &DarkAngel,
+              &Thrasher,
+              &Ghost];
+   }
+   
+   GetMiniBosses()
+   {
+      return [&GroundWormQueen,
+              &OrcPitBoss,
+              &DragonFlyQueen,
+              &Shadowbeast,
+              &SpiderQueen,
+              &Yeti,
+              &EarthElemental,
+              &FireElemental,
+              &IceElemental,
+              &NeruElemental];
+   }
+   
+   GetFixedRewards()
+   {
+      return [[&AntMask,10],
+              [&RatMask,15],
+              [&MummyMask,20],
+              [&SkullMask,25],
+              [&TrollMask,30],
+              [&ShrunkenHeadMask,35],
+              [&DaemonMask,40],
+              [&FeyMask,45],
+              [&XeoMask,50],
+              [&KriipaMask,55],
+              [&CowMask,75],
+              [&KraananCharm,100]];
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -7303,6 +7303,11 @@ messages:
        
        return lDamageTypes;
     }
+    
+   GetObjectAttributeMasterList()
+   {
+      return plObject_attributes_master;
+   }
 
    AddObjectAttributeToMasterList(attribute=$)
    {


### PR DESCRIPTION
Included in this pull a series of RoomAttributes (a subset of Object Attributes)
that can be applied to rooms. These ones are God-themed, and text and 
effects are slated to match. These God rooms have a heavy emphasis on
being an 'event'. The Kraanan challenge is Survival as we know it, just
applied to real existing rooms that players can walk in and out of and PvP in
with normal rules. The other God events are a mini-frenzy, a lawless bloodbath,
and an anonymous+shadowformed mess of confusion.

Kraanan:
Rooms can have the SurvivalRoomAttribute added to them to turn them into
a functioning survival arena. Players may come and go at will, but the
Survival lasts only as long as at least one person is on screen - and if
only one person is left on screen, the situation gets deadlier. Unlike
Survival instances, this is the real world. Deaths and pens are REAL.*

Qor:
Rooms can have the FrenzyRoomAttribute added to them to turn them into a
functioning mini-frenzy. Anyone can attack anyone without consequence;
deaths send players to their last safe room; kills recharge health,
mana, vigor, and charges. Deaths have no penalty, but there is no change
for log pens. Why are you logging in a frenzy, coward?

Faren:
The room is overcome by the natural order of the wild. ChaosRoomAttributes
allow anyone to attack anyone regardless of the useless trappings of
civilization, like guild affiliations or town areas - deaths and combat
are REAL, but nobody will go orange or red, because outlaw and 
murderer statuses are a foolish conceit of the civilized.
This is nature - it is kill or be killed!

Riija:
Everybody's anonymous, shadow formed, and red haloed thanks to Riija's
ill-intentioned trickery, so anyone can attack anyone - but good luck
figuring out who the enemy is! Deaths and pens are REAL. Guild affiliations,
angels, and the usual restrictions to anonymity still apply, however.

Shal:
Shal'ille calls for the aid of all adventurers to defeat an invasion of monsters.
This is a standard 'invasion' event as players have seen in the past,
with coded support. Waves of monsters attack, and the players who 
participate the most (both in kills and in time) get directly rewarded at 
the end. There are often bosses and minibosses who are worth more points
in this regard. The monsters do grow in strength each wave like survival.
Invasion types:
OrcInvasion, top 5 get a tougher, 6-10 get money
AvarInvasion, top 5 get 1-5 toughers each, 6-11 get money VERY HARD

* I intend the Kraanan God Room / real survival to replace survival instances
on a general basis. The existing &SurvivalRoom mechanics still exist,
but I propose they be shut off except for scheduled or surprise events. For
example, we could have one major public survival instance each week
on Fridays. Otherwise, survival challenges need to be set in real places
so that PK / hunter / PvP / soldier shielding etc can begin functioning again.

* Pull also includes new Room functions GetPlayers and GetMonsters. I'm
just tired of all the hoops to jump through for getting a list of a room's players
or a room's monsters - this returns a direct list with one call.