### PR TITLE
Standardize Weapon Offense Loss

### DIFF
--- a/kod/object/item/passitem/weapon.kod
+++ b/kod/object/item/passitem/weapon.kod
@@ -256,33 +256,81 @@ messages:
       % Weapon type
       if viWeaponType = WEAPON_TYPE_BLUDGEON
       {
-         iBaseHit = iBaseHit + WEAPON_HITMOD_MID;
+         if piHits >= (piHits_Init/2)
+         {
+            iBaseHit = iBaseHit + WEAPON_HITMOD_MID;
+         }
+         else
+         {
+            iBaseHit = iBaseHit + 
+                       ((WEAPON_HITMOD_MID*piHits*2)/piHits_Init);
+         }
       }
 
       if viWeaponType = WEAPON_TYPE_THRUST
       {
-         iBaseHit = iBaseHit + WEAPON_HITMOD_HIGH;
+         if piHits >= (piHits_Init/2)
+         {
+            iBaseHit = iBaseHit + WEAPON_HITMOD_HIGH;
+         }
+         else
+         {
+            iBaseHit = iBaseHit + 
+                       ((WEAPON_HITMOD_HIGH*piHits*2)/piHits_Init);
+         }
       }
 
       if viWeaponType = WEAPON_TYPE_SLASH
       {
-         iBaseHit = iBaseHit + WEAPON_HITMOD_LOW;
+         if piHits >= (piHits_Init/2)
+         {
+            iBaseHit = iBaseHit + WEAPON_HITMOD_LOW;
+         }
+         else
+         {
+            iBaseHit = iBaseHit + 
+                       ((WEAPON_HITMOD_LOW*piHits*2)/piHits_Init);
+         }
       }
 
       % Weapon quality modifiers
       if viWeaponQuality = WEAPON_QUALITY_LOW
       {
-         iBaseHit = iBaseHit + WEAPON_LOW_QUALITY_HITMOD;
+         if piHits >= (piHits_Init/2)
+         {
+            iBaseHit = iBaseHit + WEAPON_LOW_QUALITY_HITMOD;
+         }
+         else
+         {
+            iBaseHit = iBaseHit + 
+                       ((WEAPON_LOW_QUALITY_HITMOD*piHits*2)/piHits_Init);
+         }
       }
 
       if viWeaponQuality = WEAPON_QUALITY_HIGH
       {
-         iBaseHit = iBaseHit + WEAPON_HIGH_QUALITY_HITMOD;
+         if piHits >= (piHits_Init/2)
+         {
+            iBaseHit = iBaseHit + WEAPON_HIGH_QUALITY_HITMOD;
+         }
+         else
+         {
+            iBaseHit = iBaseHit + 
+                       ((WEAPON_HIGH_QUALITY_HITMOD*piHits*2)/piHits_Init);
+         }
       }
 
       if viWeaponQuality = WEAPON_NERUDITE
       {
-         iBaseHit = iBaseHit + WEAPON_NERUDITE_HITMOD;
+         if piHits >= (piHits_Init/2)
+         {
+            iBaseHit = iBaseHit + WEAPON_NERUDITE_HITMOD;
+         }
+         else
+         {
+            iBaseHit = iBaseHit + 
+                       ((WEAPON_NERUDITE_HITMOD*piHits*2)/piHits_Init);
+         }
       }
 
       for i in plItem_Attributes
@@ -305,45 +353,7 @@ messages:
 
    GetHitBonus()
    {
-      local iBaseHit, oWeapAtt, i, iWeapHit;
-
-      iBaseHit = 0;
-
-      % Weapon type
-      if viWeaponType = WEAPON_TYPE_BLUDGEON
-      {
-         iBaseHit = iBaseHit + WEAPON_HITMOD_MID;
-      }
-
-      if viWeaponType = WEAPON_TYPE_THRUST
-      {
-         iBaseHit = iBaseHit + WEAPON_HITMOD_HIGH;
-      }
-
-      if viWeaponType = WEAPON_TYPE_SLASH
-      {
-         iBaseHit = iBaseHit + WEAPON_HITMOD_LOW;
-      }
-
-      % Weapon quality modifiers
-      if viWeaponQuality = WEAPON_QUALITY_LOW
-      {
-         iBaseHit = iBaseHit + WEAPON_LOW_QUALITY_HITMOD;
-      }
-
-      if viWeaponQuality = WEAPON_QUALITY_HIGH
-      {
-         iBaseHit = iBaseHit + WEAPON_HIGH_QUALITY_HITMOD;
-      }
-
-      if viWeaponQuality = WEAPON_NERUDITE
-      {
-         iBaseHit = iBaseHit + WEAPON_NERUDITE_HITMOD;
-      }
-
-      iBaseHit = iBaseHit + piHitBonus;
-
-      return iBaseHit;
+      return Send(self,@ModifyHitRoll);
    }
 
    GetBaseDamage(who=$,target=$)
@@ -722,6 +732,12 @@ messages:
       if random(1,100) < WEAPON_TAKE_DAMAGE_PCT
       {
          piHits = piHits - 1;
+         if poOwner <> $
+            AND IsClass(poOwner,&User)
+            AND piHits < (piHits_Init/2)
+         {
+            Post(poOwner,@DrawOffense);
+         }
       }
 
       if piHits <= 0

--- a/kod/object/item/passitem/weapon/ranged.kod
+++ b/kod/object/item/passitem/weapon/ranged.kod
@@ -149,9 +149,7 @@ messages:
    "When someone attacks with this weapon, they send us their attack value "
    "and we change it based on quality of weapon"
    {
-      local iBaseHit, oWeapAtt, i, iWeapHit;
-
-      iBaseHit = hit_roll;
+      local oWeapAtt, i;
 
       if viHit_roll_modifier < 0
       {
@@ -159,10 +157,15 @@ messages:
       }
       else
       {
-         hit_roll = hit_roll + ((viHit_roll_modifier*piHits)/piHits_Init);
+         if piHits >= (piHits_Init/2)
+         {
+            hit_roll = hit_roll + viHit_roll_modifier;
+         }
+         else
+         {
+            hit_roll = hit_roll + ((viHit_roll_modifier*piHits*2)/piHits_Init);
+         }
       }
-      
-      iWeapHit = hit_roll;
 
       for i in plItem_Attributes
       {


### PR DESCRIPTION
Ranged weapons used to lose offense from their bonus every time they lost
a point of durability. Melee weapons never lost offense from their bonus.

Now, all weapons of any type will progressively lose their offense bonus
as they lose durability, beginning at 50% durability and below. All
weapons with half durability or greater will operate at full efficiency;
it's only below half that they start losing their offense bonus, down to
zero at broken.

Weapons that have no offense bonus, or negative offense bonus,
are not affected.

All weapons will also draw this offense loss in your stat bar (they
previously did not, leading to much confusion).