### PR TITLE
Flame Dash, Lightning Strike, Ice Guard movement spells

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2085,6 +2085,8 @@
    SID_MEDITATE = 187
    SID_FLAME_DASH = 188
    SID_LIGHTNING_STRIKE = 189
+   
+   SID_ICE_GUARD = 199
 
    % Depreciated spell IDs
    SID_LIGHTNING = 1                   % use SID_LIGHTNING_BOLT

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2084,6 +2084,7 @@
    SID_PHASE = 186
    SID_MEDITATE = 187
    SID_FLAME_DASH = 188
+   SID_LIGHTNING_STRIKE = 189
 
    % Depreciated spell IDs
    SID_LIGHTNING = 1                   % use SID_LIGHTNING_BOLT

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2083,6 +2083,7 @@
    SID_DEATH_RIFT = 185
    SID_PHASE = 186
    SID_MEDITATE = 187
+   SID_FLAME_DASH = 188
 
    % Depreciated spell IDs
    SID_LIGHTNING = 1                   % use SID_LIGHTNING_BOLT

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -14057,6 +14057,16 @@ messages:
 
       return;
    }
+   
+   ClearAttackTimer()
+   {
+      if ptAttackTimer <> $
+      {
+         DeleteTimer(ptAttackTimer);
+         ptAttackTimer = $;
+      }
+      return;
+   }
 
    SendLightingInformation()
    {

--- a/kod/object/active/wallelem.kod
+++ b/kod/object/active/wallelem.kod
@@ -71,12 +71,12 @@ properties:
 
 messages:
 
-   Constructor(caster=$,duration=$)
+   Constructor(caster=$,duration=$,bMS=FALSE)
    {
       poCaster = caster;
 
       ptExpire = CreateTimer(self,@Expire,
-                        Send(self,@GetDuration,#duration=duration));
+                        Send(self,@GetDuration,#duration=duration,#bMS=bMS));
       ptPeriodic = CreateTimer(self,@PeriodicEffect,
                         Send(self,@GetPeriodicDuration));
 

--- a/kod/object/active/wallelem/fogice.kod
+++ b/kod/object/active/wallelem/fogice.kod
@@ -52,11 +52,7 @@ messages:
 
    Constructor(caster=$,duration=$,range=$)
    {
-      if range <> $
-      {
-         piRange = range;
-         piBonus = range;
-      }
+      range = 1;
 
       propagate;
    }

--- a/kod/object/active/wallelem/fogice.kod
+++ b/kod/object/active/wallelem/fogice.kod
@@ -15,7 +15,7 @@ constants:
    include blakston.khd
 
    % What's the base duration for the hold effect?
-   BASE_HOLD_DURATION = 1
+   BASE_HOLD_DURATION = 3
 
 resources:
 

--- a/kod/object/active/wallelem/fogice.kod
+++ b/kod/object/active/wallelem/fogice.kod
@@ -1,0 +1,86 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+FogIce is ActiveWallElement
+
+constants:
+
+   include blakston.khd
+
+   % What's the base duration for the hold effect?
+   BASE_HOLD_DURATION = 1
+
+resources:
+
+   FogIce_name_rsc = "frozen fog"
+   FogIce_icon_rsc = poisoncl.bgf
+   FogIce_desc_rsc = \
+      "This fog looks bitterly cold."
+
+   FogIce_dissipates = "The ice clouds drift away on the wind."
+   FogIce_unaffected = \
+      "Strangely, the freezing cloud does not affect you."
+
+classvars:
+
+   vrName = FogIce_name_rsc
+   vrIcon = FogIce_icon_rsc
+   vrDesc = FogIce_desc_rsc
+
+   viObject_flags = OF_NOEXAMINE
+
+   vrDissipateMessage = FogIce_dissipates
+   vrUnaffectedMessage = FogIce_unaffected
+
+   vbPeriodic = FALSE
+
+properties:
+
+   piDrawFx = DRAWFX_TRANSLUCENT_50
+
+   piRangeSquared = 1
+   piBonus = 1
+
+messages:
+
+   Constructor(caster=$,duration=$,range=$)
+   {
+      if range <> $
+      {
+         piRange = range;
+         piBonus = range;
+      }
+
+      propagate;
+   }
+
+   DoEffect(what=$)
+   {
+      local oSpell;
+
+      oSpell = Send(SYS,@FindSpellByNum,#num=SID_HOLD);
+
+      Send(oSpell,@DoHold,#what=self,#otarget=what,
+            #iDurationSecs=BASE_HOLD_DURATION+piBonus);
+      Send(poOwner,@SomethingAttacked,#what=poCaster,#victim=what,
+            #use_weapon=self,#stroke_obj=self);
+
+      propagate;
+   }
+
+   SendAnimation()
+   {
+      AddPacket(1,ANIMATE_CYCLE, 4,random(240,280), 2,1, 2,5);
+
+      return;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/wallelem/makefile
+++ b/kod/object/active/wallelem/makefile
@@ -5,7 +5,8 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\wallelem.bof
-BOFS =  wallfire.bof wallltng.bof poisfogc.bof web.bof asburstc.bof
+BOFS =  wallfire.bof wallltng.bof poisfogc.bof web.bof asburstc.bof \
+        fogice.bof
 
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/active/wallelem/wallfire.kod
+++ b/kod/object/active/wallelem/wallfire.kod
@@ -65,11 +65,19 @@ messages:
       propagate;
    }
 
-   GetDuration(duration = 0)
+   GetDuration(duration = 0,bMS=FALSE)
    {
       local iDuration;
 
-      iDuration = iDuration * 1000;
+      
+      if bMS
+      {
+         iDuration = duration;
+      }
+      else
+      {
+         iDuration = duration * 1000;
+      }
 
       return iDuration;
    }

--- a/kod/object/active/wallelem/wallfire.kod
+++ b/kod/object/active/wallelem/wallfire.kod
@@ -69,9 +69,7 @@ messages:
    {
       local iDuration;
 
-      iDuration = Random(duration-20,duration+20);
       iDuration = iDuration * 1000;
-      iDuration = bound(iDuration,30000,200000);
 
       return iDuration;
    }

--- a/kod/object/active/wallelem/wallltng.kod
+++ b/kod/object/active/wallelem/wallltng.kod
@@ -64,13 +64,19 @@ messages:
       propagate;
    }
 
-   GetDuration(duration = 0)
+   GetDuration(duration = 0,bMS=FALSE)
    {
       local iDuration;
 
-      iDuration = Random(duration-20,duration+20);
-      iDuration = iDuration * 1000;
-      iDuration = bound(iDuration,30000,200000);
+      
+      if bMS
+      {
+         iDuration = duration;
+      }
+      else
+      {
+         iDuration = duration * 1000;
+      }
 
       return iDuration;
    }

--- a/kod/object/passive/spell/flamedash.kod
+++ b/kod/object/passive/spell/flamedash.kod
@@ -13,6 +13,9 @@ FlameDash is Spell
 constants:
    include blakston.khd
 
+   % What change in elevation will stop flame dash?
+   ELEVATION_RISE_MAX = 30
+
 resources:
 
    flame_dash_name_rsc = "flame dash"
@@ -108,7 +111,7 @@ messages:
                    iRowPercentage, iColPercentage, iRowSign, iColSign,
                    iRowDist, iColDist, oRoomData, iSteps,
                    iRowSuccess, iColSuccess, iFineRowSuccess, iFineColSuccess,
-                   oElement, iRot, iCurDist;
+                   oElement, iRot, iCurDist, iStartHeight, iNextHeight;
 
       oRoom = Send(who,@GetOwner);
       if oRoom = $
@@ -140,6 +143,8 @@ messages:
       iRowPercentage = 0;
       iColSign = 1;
       iRowSign = 1;
+      
+      iStartHeight = GetHeight(oRoomData,iRow,iCol,iFineRow,iFineCol);
       
       % iRot 0 - 4100
       
@@ -217,6 +222,8 @@ messages:
                                 #col_end=iNewCol,
                                 #fine_row_end=iNewFineRow,
                                 #fine_col_end=iNewFineCol)
+            AND GetHeight(oRoomData,iNewRow,iNewCol,iNewFineRow,iNewFineCol) <=
+                   iStartHeight + ELEVATION_RISE_MAX
          {
             oElement = Create(&WallOfFire,#MaxDamage=iSpellPower/6,#Caster=who,
                         #duration=iSteps*200,#bMS=TRUE);

--- a/kod/object/passive/spell/flamedash.kod
+++ b/kod/object/passive/spell/flamedash.kod
@@ -29,10 +29,12 @@ resources:
       "You don't have enough power to dash even a step!"
    flame_dash_dashed = \
       "You dash %i steps!"
-   flame_dash_failed = \
-      "Tried to dash %i. %i XPerc, %i YPerc, %i XSign, %i YSign."
    flame_dash_no_space = \
       "You don't have enough space to dash!"
+   flame_dash_no_longer = \
+      "You are exhausted, and cannot dash again for %i seconds."
+   flame_dash_can_do_now = \
+      "You feel that you can dash again."
 
 classvars:
 
@@ -100,13 +102,13 @@ messages:
    }
 
    CastSpell(who = $, iSpellPower=0)
-   {
-      local oRoom, iX, iY, iRot, iFineX, iFineY, iDist,
-                   iNewX, iNewY, iNewFineX, iNewFineY,
-                   iXPercentage, iYPercentage, iXSign, iYSign,
-                   iXDist, iYDist, oRoomData, iSteps,
-                   iXSuccess,iYSuccess,iFineXSuccess,iFineYSuccess,
-                   oElement;
+   {                   
+      local oRoom, iRow, iCol, iFineRow, iFineCol, iDist,
+                   iNewRow, iNewCol, iNewFineRow, iNewFineCol,
+                   iRowPercentage, iColPercentage, iRowSign, iColSign,
+                   iRowDist, iColDist, oRoomData, iSteps,
+                   iRowSuccess, iColSuccess, iFineRowSuccess, iFineColSuccess,
+                   oElement, iRot, iCurDist;
 
       oRoom = Send(who,@GetOwner);
       if oRoom = $
@@ -115,8 +117,8 @@ messages:
       }
       oRoomData = Send(oRoom,@GetRoomData);
 
-      % Can go up to 5 rows/cols (expressed in *64 fine)
-      iDist = ((iSpellPower+1)*64)/20;
+      % Can go up to 10 rows/cols (expressed in *64 fine)
+      iDist = ((iSpellPower+1)*64)/10;
       
       if iDist < 64
       {
@@ -127,102 +129,128 @@ messages:
       % This spell calculates your intended destination without trigonometry.
       % The diff you travel is split into percentages of X and Y distance.
       % The spell then attempts to teleport you by checking with
-      % CanMoveInRoomHighRes().
+      % Line of Sight.
       
-      iX = Send(who,@GetCol);
-      iY = Send(who,@GetRow);
-      iFineX = Send(who,@GetFineCol);
-      iFineY = Send(who,@GetFineRow);
+      iCol = Send(who,@GetCol);
+      iRow = Send(who,@GetRow);
+      iFineCol = Send(who,@GetFineCol);
+      iFineRow = Send(who,@GetFineRow);
       iRot = Send(who,@GetAngle);
-      iXPercentage = 100;
-      iYPercentage = 0;
-      iXSign = 1;
-      iYSign = 1;
+      iColPercentage = 100;
+      iRowPercentage = 0;
+      iColSign = 1;
+      iRowSign = 1;
       
       % iRot 0 - 4100
       
       if iRot >= 0
          AND iRot <= 1025
       {
-         iXPercentage = 100 - (100*iRot)/1025;
-         iYPercentage = (100*iRot)/1025;
-         iXSign = 1;
-         iYSign = 1;
+         iColPercentage = 100 - (100*iRot)/1025;
+         iRowPercentage = (100*iRot)/1025;
+         iColSign = 1;
+         iRowSign = 1;
       }
       
       if iRot > 1025
          AND iRot <= 2050
       {
-         iXPercentage = (100*(iRot-1025))/1025;
-         iYPercentage = 100 - (100*(iRot-1025))/1025;
-         iXSign = -1;
-         iYSign = 1;
+         iColPercentage = (100*(iRot-1025))/1025;
+         iRowPercentage = 100 - (100*(iRot-1025))/1025;
+         iColSign = -1;
+         iRowSign = 1;
       }
       
       if iRot > 2050
          AND iRot <= 3175
       {
-         iXPercentage = 100 - (100*(iRot-2050))/1025;
-         iYPercentage = (100*(iRot-2050))/1025;
-         iXSign = -1;
-         iYSign = -1;
+         iColPercentage = 100 - (100*(iRot-2050))/1025;
+         iRowPercentage = (100*(iRot-2050))/1025;
+         iColSign = -1;
+         iRowSign = -1;
       }
       
       if iRot > 3175
          AND iRot < 4100
       {
-         iXPercentage = (100*(iRot-3175))/1025;
-         iYPercentage = 100 - (100*(iRot-3175))/1025;
-         iXSign = 1;
-         iYSign = -1;
+         iColPercentage = (100*(iRot-3175))/1025;
+         iRowPercentage = 100 - (100*(iRot-3175))/1025;
+         iColSign = 1;
+         iRowSign = -1;
       }
 
-      iSteps = 0;  
-      iXDist = ((iDist*iXPercentage)/100)*iXSign;
-      iYDist = ((iDist*iYPercentage)/100)*iYSign;
-         
-      iNewX = Send(who,@GetCol) + (iXDist/FINENESS);
-      iNewY = Send(who,@GetRow) + (iYDist/FINENESS);
-      iNewFineX = iXDist - (iXDist/FINENESS);
-      iNewFineY = iYDist - (iYDist/FINENESS);
-         
-      if CanMoveInRoomHighRes(oRoomData,iX,iY,
-                              iFineX,iFineY,
-                              iNewX,iNewY,iNewFineX,iNewFineY)
+      iSteps = 0;
+      iCurDist = 0;
+      iColSuccess = iCol;
+      iRowSuccess = iRow;
+      iFineColSuccess = iFineCol;
+      iFineRowSuccess = iFineRow;
+      
+      while iCurDist <= iDist
       {
-         iXSuccess = iNewX;
-         iYSuccess = iNewY;
-         iFineXSuccess = iNewFineX;
-         iFineYSuccess = iNewFineY;
-         iSteps = iSteps + 1;
+         iColDist = ((FINENESS*iColPercentage)/100)*iColSign;
+         iRowDist = ((FINENESS*iRowPercentage)/100)*iRowSign;
+
+         iNewFineCol = iFineColSuccess + iColDist;
+         iNewFineRow = iFineRowSuccess + iRowDist;
+         
+         iNewCol = iColSuccess;
+         if iNewFineCol > 63
+         {
+            iNewCol = iNewCol + 1;
+            iNewFineCol = iNewFineCol - FINENESS;
+         }
+         
+         iNewRow = iRowSuccess;
+         if iNewFineRow > 63
+         {
+            iNewRow = iNewRow + 1;
+            iNewFineRow = iNewFineRow - FINENESS;
+         }
+
+         if Send(self,@LineOfSight,#oRoomData=oRoomData,
+                                #row_start=iRowSuccess,
+                                #col_start=iColSuccess,
+                                #fine_row_start=iFineRowSuccess,
+                                #fine_col_start=iFineColSuccess,
+                                #row_end=iNewRow,
+                                #col_end=iNewCol,
+                                #fine_row_end=iNewFineRow,
+                                #fine_col_end=iNewFineCol)
+         {
+            oElement = Create(&WallOfFire,#MaxDamage=iSpellPower/6,#Caster=who,
+                        #duration=iSteps*200,#bMS=TRUE);
+            Send(oRoom,@NewHold,#what=oElement,
+                 #new_row=iRowSuccess,#new_col=iColSuccess,
+                 #fine_row=iFineRowSuccess,#fine_col=iFineColSuccess);
+                 
+            iColSuccess = iNewCol;
+            iRowSuccess = iNewRow;
+            iFineColSuccess = iNewFineCol;
+            iFineRowSuccess = iNewFineRow;
+            iSteps = iSteps + 1;
+         }
+         else
+         {
+            break;
+         }
+         
+         iCurDist = iCurDist + FINENESS;
+      }
+
+      if iSteps > 0
+      {
+         Send(SYS,@UtilGoNearSquare,#what=who,#where=oRoom,
+                     #new_row=iRowSuccess,#new_col=iColSuccess,
+                     #fine_row=iFineRowSuccess,#fine_col=iFineColSuccess);
+         Send(who,@MsgSendUser,#message_rsc=flame_dash_dashed,
+                               #parm1=iSteps);
+         Send(self,@AddCooldown,#who=who);
       }
       else
       {
          Send(who,@MsgSendUser,#message_rsc=flame_dash_no_space);
       }
-      
-      if iSteps > 0
-      {
-         Send(SYS,@UtilGoNearSquare,#what=who,#where=oRoom,
-                     #new_row=iYSuccess,#new_col=iXSuccess,
-                     #fine_row=iFineYSuccess,#fine_col=iFineXSuccess);
-         Send(who,@MsgSendUser,#message_rsc=flame_dash_dashed,
-                               #parm1=iSteps);
-         Send(self,@AddCooldown,#who=who);
-
-         oElement = Create(&WallOfFire,#MaxDamage=iSpellPower/6,#Caster=who,
-                        #Duration=(iSpellPower+1)/20,#Illusionary=FALSE);
-         Send(oRoom,@NewHold,#what=oElement,
-              #new_row=iY,#new_col=iX,
-              #fine_row=iFineY,#fine_col=iFineX);
-      }
-         Send(who,@MsgSendUser,#message_rsc=flame_dash_failed,
-                               #parm1=iDist,
-                               #parm2=iXPercentage,
-                               #parm3=iYPercentage,
-                               #parm4=iXSign,
-                               #parm5=iYSign);
-      
 
       propagate;
    }
@@ -261,6 +289,11 @@ messages:
          if Nth(i,1) = who
          {
             SetNth(i,2,Nth(i,2)+1);
+            if Nth(i,2) >= piMaxUses
+            {
+               Send(who,@MsgSendUser,#message_rsc=flame_dash_no_longer,
+                                     #parm1=GetTimeRemaining(Nth(i,3))/1000);
+            }
             return;
          }
       }
@@ -280,7 +313,13 @@ messages:
       {
          if Nth(i,3) = timer
          {
+            if Nth(i,2) = piMaxUses
+            {
+               Send(Nth(i,1),@MsgSendUser,#message_rsc=flame_dash_can_do_now);
+            }
+
             SetNth(i,2,Nth(i,2)-1);
+            
             if Nth(i,2) <= 0
             {
                SetNth(i,1,$);
@@ -316,6 +355,226 @@ messages:
       plCooldowns = $;
       
       propagate;
+   }
+
+   LineOfSight(oRoomData=$,
+               row_start=0,col_start=0,fine_row_start=0,fine_col_start=0,
+               row_end=0,col_end=0,fine_row_end=0,fine_col_end=0)
+   "Returns TRUE if there is a line of sight between start and end"
+   {
+     local r;
+     
+     % First check if start can walk on a direct path to end.
+     % If we can't move there, we assume vision through this
+     % location is blocked as well.  This assumption is violated
+     % by, for example, fences and altitude changes in the floor.
+
+     r = Send(self,@LineOfSightInternal,#oRoomData=oRoomData,
+                                        #row_start=row_start,
+                                        #col_start=col_start,
+                                        #fine_row_start=fine_row_start,
+                                        #fine_col_start=fine_col_start,
+                                        #row_end=row_end,
+                                        #col_end=col_end,
+                                        #fine_row_end=fine_row_end,
+                                        #fine_col_end=fine_col_end);
+
+     % we also possibly check the other way around,
+     % because if end somehow DOES have LoS with start,
+     % start also must have LoS with end.
+     % This makes sure LoS is handled equally (fair) for both.
+     if r = FALSE
+     {
+        r = Send(self,@LineOfSightInternal,#oRoomData=oRoomData,
+                                           #row_start=row_end,
+                                           #col_start=col_end,
+                                           #fine_row_start=fine_row_end,
+                                           #fine_col_start=fine_col_end,
+                                           #row_end=row_start,
+                                           #col_end=col_start,
+                                           #fine_row_end=fine_row_start,
+                                           #fine_col_end=fine_col_start);
+     }
+
+     return r;
+   }
+   
+   LineOfSightInternal(oRoomData=$,
+                       row_start=0,col_start=0,fine_row_start=0,fine_col_start=0,
+                       row_end=0,col_end=0,fine_row_end=0,fine_col_end=0)
+   {
+      local r, c, r2, c2, dr, dc, iRow, iCol, iAtan, iSkip;
+
+      % try get obj1 big coordinates (source)
+      r = row_start;
+      c = col_start;
+ 
+      % no coordinates (big row/col can be $)
+      if r = $ OR c = $
+      {
+         Debug("$ coordinates in flame dash");
+
+         return FALSE;
+      }
+      else
+      {
+         % get fine values and scale to highres
+         r = ((r * FINENESS) + fine_row_start) / 16;
+         c = ((c * FINENESS) + fine_col_start) / 16;
+      }
+
+      % try get obj2 coordinates (destination)
+      iRow = row_end;
+      iCol = col_end;
+
+      % no coordinates (big row/col can be $)
+      if iRow = $ OR iCol = $
+      {
+         Debug("$ coordinates in flame dash end");
+
+         return FALSE;
+      }
+      else
+      {
+         % get fine values and scale to highres
+         iRow = ((iRow * FINENESS) + fine_row_end) / 16;
+         iCol = ((iCol * FINENESS) + fine_col_end) / 16;    
+      }
+
+      % get deltas in highres
+      dr = iRow - r;
+      dc = iCol - c;
+
+      % prepare first loop
+      r2 = r;
+      c2 = c;
+
+      % get config setting for amount of steps to skip at the end
+      % of LoS line, this modifies safespots
+      iSkip = Send(Send(SYS, @GetSettings), @GetLOSSkip);
+
+      % step from the source to the target on the highres grid.
+      % depending on the skip amount, we either must reach
+      % the destination completely (rare safespots)
+      % or an adjacent/close square is enough (no safespots)
+      while abs(dr) > iSkip OR abs(dc) > iSkip
+      {
+         % Figure out which direction we need to move
+         % our 2D ray next (=step N,NE,E,SE,S,...)
+         % We pick the best approximation of the 8 possible 
+
+         % Only north or south are special cases.
+         if dc = 0
+         {
+            if dr < 0 %N
+            {
+               r2 = r2 - 1;
+            }
+            else %S
+            {
+               r2 = r2 + 1;
+            }
+         }
+         else
+         {
+            iAtan = 1000 * dr / dc;
+         }
+
+         % right half-plane
+         if dc > 0 
+         {
+            if iAtan >= 2414 %S
+            {
+               r2 = r2 + 1;
+            }
+            else
+            {
+               if iAtan >= 414 %SE
+               {
+                  r2 = r2 + 1;
+                  c2 = c2 + 1;
+               }
+               else
+               {
+                  if iAtan >= -414 %E
+                  {
+                     c2 = c2 + 1;
+                  }
+                  else
+                  {
+                     if iAtan >= -2414 %NE
+                     {
+                        r2 = r2 - 1;
+                        c2 = c2 + 1;
+                     }
+                     else %N
+                     {
+                        r2 = r2 - 1;
+                     }
+                  }
+               }
+            }
+         }
+
+         % left half-plane
+         if dc < 0 
+         {
+            if iAtan >= 2414 %N
+            {
+               r2 = r2 - 1;
+            }
+            else
+            {
+               if iAtan >= 414 %NW
+               {
+			      r2 = r2 - 1;
+                  c2 = c2 - 1;                  
+               }
+               else
+               {
+                  if iAtan >= -414 %W
+                  {
+                     c2 = c2 - 1;
+                  }
+                  else
+                  {
+                     if iAtan >= -2414 %SW
+                     {
+			            r2 = r2 + 1;
+                        c2 = c2 - 1;                        
+                     }
+                     else %S
+                     {
+                        r2 = r2 + 1;
+                     }
+                  }
+               }
+            }
+         }
+
+         % DEBUG - Puts item on LOS line
+         % Send(SYS,@PutInRoom,#what=Create(&PlateArmor),#rid=piRoom_num,
+         %    #row=(r/4),#col=(c/4),#fine_row=((r MOD 4)*16),#fine_col=((c MOD 4)*16));
+		 
+         % these calculations turn the highres values back into row/finerow
+         % remember: 4 highres rows give a row, and a highres row has 16 finerows 
+         if NOT CanMoveInRoomHighRes(oRoomData,
+                    (r / 4), (c / 4), ((r MOD 4) * 16), ((c MOD 4) * 16),
+                    (r2 / 4) , (c2 / 4), ((r2 MOD 4) * 16), ((c2 MOD 4) * 16))
+         {
+           return FALSE;
+         }
+
+		 % set new position as old
+         r = r2;
+         c = c2;
+
+         % get deltas in highres
+         dr = iRow - r;
+         dc = iCol - c;
+      }
+
+      return TRUE;
    }
 
 end

--- a/kod/object/passive/spell/flamedash.kod
+++ b/kod/object/passive/spell/flamedash.kod
@@ -1,0 +1,322 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+FlameDash is Spell
+
+constants:
+   include blakston.khd
+
+resources:
+
+   flame_dash_name_rsc = "flame dash"
+   flame_dash_icon_rsc = fireball.bgf
+   flame_dash_desc_rsc = \
+     "Teleports you forward, leaving flames in your wake. "
+     "Repeated use of this spell can exhaust even the strongest mage."
+
+   flame_dash_max_cooldowns = \
+      "You need to rest for a moment before dashing again."
+   flame_dash_not_here = \
+      "You can't dash here!"
+   flame_dash_too_short = \
+      "You don't have enough power to dash even a step!"
+   flame_dash_dashed = \
+      "You dash %i steps!"
+   flame_dash_failed = \
+      "Tried to dash %i. %i XPerc, %i YPerc, %i XSign, %i YSign."
+   flame_dash_no_space = \
+      "You don't have enough space to dash!"
+
+classvars:
+
+   vrName = flame_dash_name_rsc
+   vrIcon = flame_dash_icon_rsc
+   vrDesc = flame_dash_desc_rsc
+
+   viCast_time = 0
+
+   viSpell_num = SID_FLAME_DASH
+   viSpell_level = 6
+   viSchool = SS_FAREN
+   viMana = 8
+   viSpellExertion = 10
+   viChance_To_Increase = 15
+   viMeditate_ratio = 20
+
+properties:
+
+   % This spell keeps track of player cooldowns.
+   plCooldowns = $
+
+   % A player can use the spell this many times in a row.
+   piMaxUses = 3
+
+   % It takes this long for one cooldown to lift.
+   piCooldownTime = 10000
+
+messages:
+
+   ResetReagents()
+   {
+      plReagents = $;
+
+      return;
+   }
+
+   GetNumSpellTargets()
+   {
+      return 0;
+   }
+
+   CanPayCosts(who=$,lTargets=$,bItemCast=FALSE)
+   {
+      local oRoom;
+      
+      oRoom = Send(who,@GetOwner);
+
+      if oRoom <> $
+         AND IsClass(oRoom,&Room)
+         AND Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
+      {
+         Send(who,@MsgSendUser,#message_rsc=flame_dash_not_here);
+         return FALSE;
+      }
+
+      % If you're at or beyond max cooldowns, can't use the spell.
+      if Send(self,@GetCooldown,#who=who) >= piMaxUses
+      {
+         Send(who,@MsgSendUser,#message_rsc=flame_dash_max_cooldowns);
+         return FALSE;
+      }
+
+      propagate;
+   }
+
+   CastSpell(who = $, iSpellPower=0)
+   {
+      local oRoom, iX, iY, iRot, iFineX, iFineY, iDist,
+                   iNewX, iNewY, iNewFineX, iNewFineY,
+                   iXPercentage, iYPercentage, iXSign, iYSign,
+                   iXDist, iYDist, oRoomData, iSteps,
+                   iXSuccess,iYSuccess,iFineXSuccess,iFineYSuccess,
+                   oElement;
+
+      oRoom = Send(who,@GetOwner);
+      if oRoom = $
+      {
+         return FALSE;
+      }
+      oRoomData = Send(oRoom,@GetRoomData);
+
+      % Can go up to 5 rows/cols (expressed in *64 fine)
+      iDist = ((iSpellPower+1)*64)/20;
+      
+      if iDist < 64
+      {
+         Send(who,@MsgSendUser,#message_rsc=flame_dash_too_short);
+         propagate;
+      }
+
+      % This spell calculates your intended destination without trigonometry.
+      % The diff you travel is split into percentages of X and Y distance.
+      % The spell then attempts to teleport you by checking with
+      % CanMoveInRoomHighRes().
+      
+      iX = Send(who,@GetCol);
+      iY = Send(who,@GetRow);
+      iFineX = Send(who,@GetFineCol);
+      iFineY = Send(who,@GetFineRow);
+      iRot = Send(who,@GetAngle);
+      iXPercentage = 100;
+      iYPercentage = 0;
+      iXSign = 1;
+      iYSign = 1;
+      
+      % iRot 0 - 4100
+      
+      if iRot >= 0
+         AND iRot <= 1025
+      {
+         iXPercentage = 100 - (100*iRot)/1025;
+         iYPercentage = (100*iRot)/1025;
+         iXSign = 1;
+         iYSign = 1;
+      }
+      
+      if iRot > 1025
+         AND iRot <= 2050
+      {
+         iXPercentage = (100*(iRot-1025))/1025;
+         iYPercentage = 100 - (100*(iRot-1025))/1025;
+         iXSign = -1;
+         iYSign = 1;
+      }
+      
+      if iRot > 2050
+         AND iRot <= 3175
+      {
+         iXPercentage = 100 - (100*(iRot-2050))/1025;
+         iYPercentage = (100*(iRot-2050))/1025;
+         iXSign = -1;
+         iYSign = -1;
+      }
+      
+      if iRot > 3175
+         AND iRot < 4100
+      {
+         iXPercentage = (100*(iRot-3175))/1025;
+         iYPercentage = 100 - (100*(iRot-3175))/1025;
+         iXSign = 1;
+         iYSign = -1;
+      }
+
+      iSteps = 0;  
+      iXDist = ((iDist*iXPercentage)/100)*iXSign;
+      iYDist = ((iDist*iYPercentage)/100)*iYSign;
+         
+      iNewX = Send(who,@GetCol) + (iXDist/FINENESS);
+      iNewY = Send(who,@GetRow) + (iYDist/FINENESS);
+      iNewFineX = iXDist - (iXDist/FINENESS);
+      iNewFineY = iYDist - (iYDist/FINENESS);
+         
+      if CanMoveInRoomHighRes(oRoomData,iX,iY,
+                              iFineX,iFineY,
+                              iNewX,iNewY,iNewFineX,iNewFineY)
+      {
+         iXSuccess = iNewX;
+         iYSuccess = iNewY;
+         iFineXSuccess = iNewFineX;
+         iFineYSuccess = iNewFineY;
+         iSteps = iSteps + 1;
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=flame_dash_no_space);
+      }
+      
+      if iSteps > 0
+      {
+         Send(SYS,@UtilGoNearSquare,#what=who,#where=oRoom,
+                     #new_row=iYSuccess,#new_col=iXSuccess,
+                     #fine_row=iFineYSuccess,#fine_col=iFineXSuccess);
+         Send(who,@MsgSendUser,#message_rsc=flame_dash_dashed,
+                               #parm1=iSteps);
+         Send(self,@AddCooldown,#who=who);
+
+         oElement = Create(&WallOfFire,#MaxDamage=iSpellPower/6,#Caster=who,
+                        #Duration=(iSpellPower+1)/20,#Illusionary=FALSE);
+         Send(oRoom,@NewHold,#what=oElement,
+              #new_row=iY,#new_col=iX,
+              #fine_row=iFineY,#fine_col=iFineX);
+      }
+         Send(who,@MsgSendUser,#message_rsc=flame_dash_failed,
+                               #parm1=iDist,
+                               #parm2=iXPercentage,
+                               #parm3=iYPercentage,
+                               #parm4=iXSign,
+                               #parm5=iYSign);
+      
+
+      propagate;
+   }
+
+   SuccessChance(who=$)
+   {
+      return TRUE;
+   }
+   
+   GetCooldown(who=$)
+   {
+      local i;
+      
+      for i in plCooldowns
+      {
+         if Nth(i,1) = who
+         {
+            return Nth(i,2);
+         }
+      }
+      
+      return 0;
+   }
+
+   AddCooldown(who=$)
+   {
+      local i;
+
+      if who = $
+      {
+         return;
+      }
+
+      for i in plCooldowns
+      {
+         if Nth(i,1) = who
+         {
+            SetNth(i,2,Nth(i,2)+1);
+            return;
+         }
+      }
+      
+      plCooldowns = Cons([who,1,
+                          CreateTimer(self,@ClearCooldown,piCooldownTime)],
+                          plCooldowns);
+
+      return;
+   }
+
+   ClearCooldown(timer=$)
+   {
+      local i;
+      
+      for i in plCooldowns
+      {
+         if Nth(i,3) = timer
+         {
+            SetNth(i,2,Nth(i,2)-1);
+            if Nth(i,2) <= 0
+            {
+               SetNth(i,1,$);
+               SetNth(i,2,0);
+               SetNth(i,3,$);
+               plCooldowns = DelListElem(plCooldowns,i);
+            }
+            else
+            {
+               SetNth(i,3,CreateTimer(self,@ClearCooldown,piCooldownTime));
+            }
+         }
+      }
+      
+      return;
+   }
+   
+   Delete()
+   {
+      local i;
+      
+      for i in plCooldowns
+      {
+         if Nth(i,3) <> $
+         {
+            DeleteTimer(Nth(i,3));
+            SetNth(i,3,$);
+            SetNth(i,2,0);
+            SetNth(i,1,$);
+            plCooldowns = DelListElem(plCooldowns,i);
+         }
+      }
+      plCooldowns = $;
+      
+      propagate;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/iceguard.kod
+++ b/kod/object/passive/spell/iceguard.kod
@@ -103,21 +103,14 @@ messages:
       propagate;
    }
 
-   CastSpell(who = $, lTargets = $, iSpellPower=0)
+   CastSpell(who = $, iSpellPower=0)
    {                   
       local oRoom, iRow, iCol, iFineRow, iFineCol, iDist,
                    iNewRow, iNewCol, iNewFineRow, iNewFineCol,
                    iRowPercentage, iColPercentage, iRowSign, iColSign,
                    iRowDist, iColDist, oRoomData, iSteps,
                    iRowSuccess, iColSuccess, iFineRowSuccess, iFineColSuccess,
-                   oElement, iRot, iCurDist, oTarget, iTargetAngle;
-
-      oTarget = First(lTargets);
-      
-      if oTarget = $
-      {
-         return FALSE;
-      }
+                   oElement, iRot, iCurDist;
 
       oRoom = Send(who,@GetOwner);
       if oRoom = $
@@ -251,13 +244,10 @@ messages:
       {
          Send(SYS,@UtilGoNearSquare,#what=who,#where=oRoom,
                      #new_row=iRowSuccess,#new_col=iColSuccess,
-                     #fine_row=iFineRowSuccess,#fine_col=iFineColSuccess,
-                     #new_angle=iTargetAngle);
+                     #fine_row=iFineRowSuccess,#fine_col=iFineColSuccess);
          Send(who,@MsgSendUser,#message_rsc=ice_guard_dashed,
                                #parm1=iSteps);
          Send(self,@AddCooldown,#who=who);
-         Post(who,@ClearAttackTimer);
-         Post(who,@UserAttack,#what=oTarget);
       }
       else
       {

--- a/kod/object/passive/spell/iceguard.kod
+++ b/kod/object/passive/spell/iceguard.kod
@@ -13,6 +13,9 @@ IceGuard is Spell
 constants:
    include blakston.khd
 
+   % What change in elevation will stop ice guard?
+   ELEVATION_RISE_MAX = 100
+
 resources:
 
    ice_guard_name_rsc = "ice guard"
@@ -112,7 +115,7 @@ messages:
                    iRowPercentage, iColPercentage, iRowSign, iColSign,
                    iRowDist, iColDist, oRoomData, iSteps,
                    iRowSuccess, iColSuccess, iFineRowSuccess, iFineColSuccess,
-                   oElement, iRot, iCurDist;
+                   oElement, iRot, iCurDist, iStartHeight, iNextHeight;
 
       oRoom = Send(who,@GetOwner);
       if oRoom = $
@@ -140,6 +143,8 @@ messages:
       iFineCol = Send(who,@GetFineCol);
       iFineRow = Send(who,@GetFineRow);
       iRot = Send(who,@GetAngle) + 2050;
+      
+      iStartHeight = GetHeight(oRoomData,iRow,iCol,iFineRow,iFineCol);
 
       if iRot > 4100
       {
@@ -227,6 +232,8 @@ messages:
                                 #col_end=iNewCol,
                                 #fine_row_end=iNewFineRow,
                                 #fine_col_end=iNewFineCol)
+            AND GetHeight(oRoomData,iNewRow,iNewCol,iNewFineRow,iNewFineCol) <=
+                   iStartHeight + ELEVATION_RISE_MAX
          {
             oElement = Create(&FogIce,#MaxDamage=iSpellPower/6,#Caster=who,
                         #duration=3000+((iSpellPower+1)/25)*1000,#bMS=TRUE);

--- a/kod/object/passive/spell/iceguard.kod
+++ b/kod/object/passive/spell/iceguard.kod
@@ -119,8 +119,13 @@ messages:
       }
       oRoomData = Send(oRoom,@GetRoomData);
 
-      % 1 full unit behind target
-      iDist = 64;
+      iDist = ((iSpellPower+1)*64)/10;
+      
+      if iDist < 64
+      {
+         Send(who,@MsgSendUser,#message_rsc=ice_guard_too_short);
+         propagate;
+      }
 
       % This spell calculates your intended destination without trigonometry.
       % The diff you travel is split into percentages of X and Y distance.

--- a/kod/object/passive/spell/iceguard.kod
+++ b/kod/object/passive/spell/iceguard.kod
@@ -1,0 +1,593 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+IceGuard is Spell
+
+constants:
+   include blakston.khd
+
+resources:
+
+   ice_guard_name_rsc = "ice guard"
+   ice_guard_icon_rsc = iexfrost.bgf
+   ice_guard_desc_rsc = \
+     "Jumps backwards, away from combat, and protects the caster. "
+     "Repeated use of this spell can exhaust even the strongest mage."
+
+   ice_guard_max_cooldowns = \
+      "You need to rest for a moment before guarding again."
+   ice_guard_not_here = \
+      "You can't guard here!"
+   ice_guard_too_short = \
+      "You don't have enough power to guard!"
+   ice_guard_dashed = \
+      "You guard %i steps!"
+   ice_guard_no_space = \
+      "You don't have enough space behind you!"
+   ice_guard_no_longer = \
+      "You are exhausted, and cannot guard again for %i seconds."
+   ice_guard_can_do_now = \
+      "You feel that you can guard again."
+   ice_guard_sound = iexfrost.wav
+
+classvars:
+
+   vrName = ice_guard_name_rsc
+   vrIcon = ice_guard_icon_rsc
+   vrDesc = ice_guard_desc_rsc
+   vrSucceed_wav = ice_guard_sound
+
+   viCast_time = 0
+
+   viSpell_num = SID_ICE_GUARD
+   viSpell_level = 6
+   viSchool = SS_FAREN
+   viMana = 8
+   viSpellExertion = 10
+   viChance_To_Increase = 15
+   viMeditate_ratio = 20
+
+properties:
+
+   % This spell keeps track of player cooldowns.
+   plCooldowns = $
+
+   % A player can use the spell this many times in a row.
+   piMaxUses = 4
+
+   % It takes this long for one cooldown to lift.
+   piCooldownTime = 60000
+
+messages:
+
+   ResetReagents()
+   {
+      plReagents = $;
+
+      return;
+   }
+
+   GetNumSpellTargets()
+   {
+      return 0;
+   }
+
+   CanPayCosts(who=$,lTargets=$,bItemCast=FALSE)
+   {
+      local oRoom;
+      
+      oRoom = Send(who,@GetOwner);
+
+      if oRoom <> $
+         AND IsClass(oRoom,&Room)
+         AND Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
+      {
+         Send(who,@MsgSendUser,#message_rsc=ice_guard_not_here);
+         return FALSE;
+      }
+
+      % If you're at or beyond max cooldowns, can't use the spell.
+      if Send(self,@GetCooldown,#who=who) >= piMaxUses
+      {
+         Send(who,@MsgSendUser,#message_rsc=ice_guard_max_cooldowns);
+         return FALSE;
+      }
+
+      propagate;
+   }
+
+   CastSpell(who = $, lTargets = $, iSpellPower=0)
+   {                   
+      local oRoom, iRow, iCol, iFineRow, iFineCol, iDist,
+                   iNewRow, iNewCol, iNewFineRow, iNewFineCol,
+                   iRowPercentage, iColPercentage, iRowSign, iColSign,
+                   iRowDist, iColDist, oRoomData, iSteps,
+                   iRowSuccess, iColSuccess, iFineRowSuccess, iFineColSuccess,
+                   oElement, iRot, iCurDist, oTarget, iTargetAngle;
+
+      oTarget = First(lTargets);
+      
+      if oTarget = $
+      {
+         return FALSE;
+      }
+
+      oRoom = Send(who,@GetOwner);
+      if oRoom = $
+      {
+         return FALSE;
+      }
+      oRoomData = Send(oRoom,@GetRoomData);
+
+      % 1 full unit behind target
+      iDist = 64;
+
+      % This spell calculates your intended destination without trigonometry.
+      % The diff you travel is split into percentages of X and Y distance.
+      % The spell then attempts to teleport you by checking with
+      % Line of Sight.
+      
+      iCol = Send(who,@GetCol);
+      iRow = Send(who,@GetRow);
+      iFineCol = Send(who,@GetFineCol);
+      iFineRow = Send(who,@GetFineRow);
+      iRot = abs(Send(who,@GetAngle)-2050);
+      iColPercentage = 100;
+      iRowPercentage = 0;
+      iColSign = 1;
+      iRowSign = 1;
+      
+      % iRot 0 - 4100
+      
+      if iRot >= 0
+         AND iRot <= 1025
+      {
+         iColPercentage = 100 - (100*iRot)/1025;
+         iRowPercentage = (100*iRot)/1025;
+         iColSign = 1;
+         iRowSign = 1;
+      }
+      
+      if iRot > 1025
+         AND iRot <= 2050
+      {
+         iColPercentage = (100*(iRot-1025))/1025;
+         iRowPercentage = 100 - (100*(iRot-1025))/1025;
+         iColSign = -1;
+         iRowSign = 1;
+      }
+      
+      if iRot > 2050
+         AND iRot <= 3175
+      {
+         iColPercentage = 100 - (100*(iRot-2050))/1025;
+         iRowPercentage = (100*(iRot-2050))/1025;
+         iColSign = -1;
+         iRowSign = -1;
+      }
+      
+      if iRot > 3175
+         AND iRot < 4100
+      {
+         iColPercentage = (100*(iRot-3175))/1025;
+         iRowPercentage = 100 - (100*(iRot-3175))/1025;
+         iColSign = 1;
+         iRowSign = -1;
+      }
+
+      iSteps = 0;
+      iCurDist = 0;
+      iColSuccess = iCol;
+      iRowSuccess = iRow;
+      iFineColSuccess = iFineCol;
+      iFineRowSuccess = iFineRow;
+      
+      while iCurDist <= iDist
+      {
+         iColDist = ((FINENESS*iColPercentage)/100)*iColSign;
+         iRowDist = ((FINENESS*iRowPercentage)/100)*iRowSign;
+
+         iNewFineCol = iFineColSuccess + iColDist;
+         iNewFineRow = iFineRowSuccess + iRowDist;
+         
+         iNewCol = iColSuccess;
+         if iNewFineCol > 63
+         {
+            iNewCol = iNewCol + 1;
+            iNewFineCol = iNewFineCol - FINENESS;
+         }
+         
+         iNewRow = iRowSuccess;
+         if iNewFineRow > 63
+         {
+            iNewRow = iNewRow + 1;
+            iNewFineRow = iNewFineRow - FINENESS;
+         }
+
+         if Send(self,@LineOfSight,#oRoomData=oRoomData,
+                                #row_start=iRowSuccess,
+                                #col_start=iColSuccess,
+                                #fine_row_start=iFineRowSuccess,
+                                #fine_col_start=iFineColSuccess,
+                                #row_end=iNewRow,
+                                #col_end=iNewCol,
+                                #fine_row_end=iNewFineRow,
+                                #fine_col_end=iNewFineCol)
+         {
+            oElement = Create(&FogIce,#MaxDamage=(iSpellPower+1)/4,#Caster=who,
+                        #duration=6000,#bMS=TRUE);
+            Send(oRoom,@NewHold,#what=oElement,
+                 #new_row=Send(who,@GetRow),#new_col=Send(who,@GetCol),
+                 #fine_row=Send(who,@GetFineRow),#fine_col=Send(who,@GetFineCol));
+
+            oElement = Create(&FogIce,#MaxDamage=(iSpellPower+1)/4,#Caster=who,
+                        #duration=6000,#bMS=TRUE);
+            Send(oRoom,@NewHold,#what=oElement,
+                 #new_row=iRowSuccess,#new_col=iColSuccess,
+                 #fine_row=iFineRowSuccess,#fine_col=iFineColSuccess);
+                 
+            iColSuccess = iNewCol;
+            iRowSuccess = iNewRow;
+            iFineColSuccess = iNewFineCol;
+            iFineRowSuccess = iNewFineRow;
+            iSteps = iSteps + 1;
+         }
+         else
+         {
+            break;
+         }
+         
+         iCurDist = iCurDist + FINENESS;
+      }
+
+      if iSteps > 0
+      {
+         Send(SYS,@UtilGoNearSquare,#what=who,#where=oRoom,
+                     #new_row=iRowSuccess,#new_col=iColSuccess,
+                     #fine_row=iFineRowSuccess,#fine_col=iFineColSuccess,
+                     #new_angle=iTargetAngle);
+         Send(who,@MsgSendUser,#message_rsc=ice_guard_dashed,
+                               #parm1=iSteps);
+         Send(self,@AddCooldown,#who=who);
+         Post(who,@ClearAttackTimer);
+         Post(who,@UserAttack,#what=oTarget);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=ice_guard_no_space);
+      }
+
+      propagate;
+   }
+
+   SuccessChance(who=$)
+   {
+      return TRUE;
+   }
+   
+   GetCooldown(who=$)
+   {
+      local i;
+      
+      for i in plCooldowns
+      {
+         if Nth(i,1) = who
+         {
+            return Nth(i,2);
+         }
+      }
+      
+      return 0;
+   }
+
+   AddCooldown(who=$)
+   {
+      local i;
+
+      if who = $
+      {
+         return;
+      }
+
+      for i in plCooldowns
+      {
+         if Nth(i,1) = who
+         {
+            SetNth(i,2,Nth(i,2)+1);
+            if Nth(i,2) >= piMaxUses
+            {
+               Send(who,@MsgSendUser,#message_rsc=ice_guard_no_longer,
+                                     #parm1=GetTimeRemaining(Nth(i,3))/1000);
+            }
+            return;
+         }
+      }
+      
+      plCooldowns = Cons([who,1,
+                          CreateTimer(self,@ClearCooldown,piCooldownTime)],
+                          plCooldowns);
+
+      return;
+   }
+
+   ClearCooldown(timer=$)
+   {
+      local i;
+      
+      for i in plCooldowns
+      {
+         if Nth(i,3) = timer
+         {
+            if Nth(i,2) = piMaxUses
+            {
+               Send(Nth(i,1),@MsgSendUser,#message_rsc=ice_guard_can_do_now);
+            }
+
+            SetNth(i,2,Nth(i,2)-1);
+            
+            if Nth(i,2) <= 0
+            {
+               SetNth(i,1,$);
+               SetNth(i,2,0);
+               SetNth(i,3,$);
+               plCooldowns = DelListElem(plCooldowns,i);
+            }
+            else
+            {
+               SetNth(i,3,CreateTimer(self,@ClearCooldown,piCooldownTime));
+            }
+         }
+      }
+      
+      return;
+   }
+   
+   Delete()
+   {
+      local i;
+      
+      for i in plCooldowns
+      {
+         if Nth(i,3) <> $
+         {
+            DeleteTimer(Nth(i,3));
+            SetNth(i,3,$);
+            SetNth(i,2,0);
+            SetNth(i,1,$);
+            plCooldowns = DelListElem(plCooldowns,i);
+         }
+      }
+      plCooldowns = $;
+      
+      propagate;
+   }
+
+   LineOfSight(oRoomData=$,
+               row_start=0,col_start=0,fine_row_start=0,fine_col_start=0,
+               row_end=0,col_end=0,fine_row_end=0,fine_col_end=0)
+   "Returns TRUE if there is a line of sight between start and end"
+   {
+     local r;
+     
+     % First check if start can walk on a direct path to end.
+     % If we can't move there, we assume vision through this
+     % location is blocked as well.  This assumption is violated
+     % by, for example, fences and altitude changes in the floor.
+
+     r = Send(self,@LineOfSightInternal,#oRoomData=oRoomData,
+                                        #row_start=row_start,
+                                        #col_start=col_start,
+                                        #fine_row_start=fine_row_start,
+                                        #fine_col_start=fine_col_start,
+                                        #row_end=row_end,
+                                        #col_end=col_end,
+                                        #fine_row_end=fine_row_end,
+                                        #fine_col_end=fine_col_end);
+
+     % we also possibly check the other way around,
+     % because if end somehow DOES have LoS with start,
+     % start also must have LoS with end.
+     % This makes sure LoS is handled equally (fair) for both.
+     if r = FALSE
+     {
+        r = Send(self,@LineOfSightInternal,#oRoomData=oRoomData,
+                                           #row_start=row_end,
+                                           #col_start=col_end,
+                                           #fine_row_start=fine_row_end,
+                                           #fine_col_start=fine_col_end,
+                                           #row_end=row_start,
+                                           #col_end=col_start,
+                                           #fine_row_end=fine_row_start,
+                                           #fine_col_end=fine_col_start);
+     }
+
+     return r;
+   }
+   
+   LineOfSightInternal(oRoomData=$,
+                       row_start=0,col_start=0,fine_row_start=0,fine_col_start=0,
+                       row_end=0,col_end=0,fine_row_end=0,fine_col_end=0)
+   {
+      local r, c, r2, c2, dr, dc, iRow, iCol, iAtan, iSkip;
+
+      % try get obj1 big coordinates (source)
+      r = row_start;
+      c = col_start;
+ 
+      % no coordinates (big row/col can be $)
+      if r = $ OR c = $
+      {
+         Debug("$ coordinates in flame dash");
+
+         return FALSE;
+      }
+      else
+      {
+         % get fine values and scale to highres
+         r = ((r * FINENESS) + fine_row_start) / 16;
+         c = ((c * FINENESS) + fine_col_start) / 16;
+      }
+
+      % try get obj2 coordinates (destination)
+      iRow = row_end;
+      iCol = col_end;
+
+      % no coordinates (big row/col can be $)
+      if iRow = $ OR iCol = $
+      {
+         Debug("$ coordinates in flame dash end");
+
+         return FALSE;
+      }
+      else
+      {
+         % get fine values and scale to highres
+         iRow = ((iRow * FINENESS) + fine_row_end) / 16;
+         iCol = ((iCol * FINENESS) + fine_col_end) / 16;    
+      }
+
+      % get deltas in highres
+      dr = iRow - r;
+      dc = iCol - c;
+
+      % prepare first loop
+      r2 = r;
+      c2 = c;
+
+      % get config setting for amount of steps to skip at the end
+      % of LoS line, this modifies safespots
+      iSkip = Send(Send(SYS, @GetSettings), @GetLOSSkip);
+
+      % step from the source to the target on the highres grid.
+      % depending on the skip amount, we either must reach
+      % the destination completely (rare safespots)
+      % or an adjacent/close square is enough (no safespots)
+      while abs(dr) > iSkip OR abs(dc) > iSkip
+      {
+         % Figure out which direction we need to move
+         % our 2D ray next (=step N,NE,E,SE,S,...)
+         % We pick the best approximation of the 8 possible 
+
+         % Only north or south are special cases.
+         if dc = 0
+         {
+            if dr < 0 %N
+            {
+               r2 = r2 - 1;
+            }
+            else %S
+            {
+               r2 = r2 + 1;
+            }
+         }
+         else
+         {
+            iAtan = 1000 * dr / dc;
+         }
+
+         % right half-plane
+         if dc > 0 
+         {
+            if iAtan >= 2414 %S
+            {
+               r2 = r2 + 1;
+            }
+            else
+            {
+               if iAtan >= 414 %SE
+               {
+                  r2 = r2 + 1;
+                  c2 = c2 + 1;
+               }
+               else
+               {
+                  if iAtan >= -414 %E
+                  {
+                     c2 = c2 + 1;
+                  }
+                  else
+                  {
+                     if iAtan >= -2414 %NE
+                     {
+                        r2 = r2 - 1;
+                        c2 = c2 + 1;
+                     }
+                     else %N
+                     {
+                        r2 = r2 - 1;
+                     }
+                  }
+               }
+            }
+         }
+
+         % left half-plane
+         if dc < 0 
+         {
+            if iAtan >= 2414 %N
+            {
+               r2 = r2 - 1;
+            }
+            else
+            {
+               if iAtan >= 414 %NW
+               {
+			      r2 = r2 - 1;
+                  c2 = c2 - 1;                  
+               }
+               else
+               {
+                  if iAtan >= -414 %W
+                  {
+                     c2 = c2 - 1;
+                  }
+                  else
+                  {
+                     if iAtan >= -2414 %SW
+                     {
+			            r2 = r2 + 1;
+                        c2 = c2 - 1;                        
+                     }
+                     else %S
+                     {
+                        r2 = r2 + 1;
+                     }
+                  }
+               }
+            }
+         }
+
+         % DEBUG - Puts item on LOS line
+         % Send(SYS,@PutInRoom,#what=Create(&PlateArmor),#rid=piRoom_num,
+         %    #row=(r/4),#col=(c/4),#fine_row=((r MOD 4)*16),#fine_col=((c MOD 4)*16));
+		 
+         % these calculations turn the highres values back into row/finerow
+         % remember: 4 highres rows give a row, and a highres row has 16 finerows 
+         if NOT CanMoveInRoomHighRes(oRoomData,
+                    (r / 4), (c / 4), ((r MOD 4) * 16), ((c MOD 4) * 16),
+                    (r2 / 4) , (c2 / 4), ((r2 MOD 4) * 16), ((c2 MOD 4) * 16))
+         {
+           return FALSE;
+         }
+
+		 % set new position as old
+         r = r2;
+         c = c2;
+
+         % get deltas in highres
+         dr = iRow - r;
+         dc = iCol - c;
+      }
+
+      return TRUE;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/iceguard.kod
+++ b/kod/object/passive/spell/iceguard.kod
@@ -18,7 +18,7 @@ resources:
    ice_guard_name_rsc = "ice guard"
    ice_guard_icon_rsc = iexfrost.bgf
    ice_guard_desc_rsc = \
-     "Jumps backwards, away from combat, and protects the caster. "
+     "Teleports you backward, leaving freezing fog in your wake. "
      "Repeated use of this spell can exhaust even the strongest mage."
 
    ice_guard_max_cooldowns = \
@@ -26,23 +26,25 @@ resources:
    ice_guard_not_here = \
       "You can't guard here!"
    ice_guard_too_short = \
-      "You don't have enough power to guard!"
+      "You don't have enough power to guard even a step!"
    ice_guard_dashed = \
       "You guard %i steps!"
    ice_guard_no_space = \
-      "You don't have enough space behind you!"
+      "You don't have enough space to guard!"
    ice_guard_no_longer = \
       "You are exhausted, and cannot guard again for %i seconds."
    ice_guard_can_do_now = \
       "You feel that you can guard again."
-   ice_guard_sound = iexfrost.wav
+
+   IceGuard_sound = ficefing.wav
 
 classvars:
 
    vrName = ice_guard_name_rsc
    vrIcon = ice_guard_icon_rsc
    vrDesc = ice_guard_desc_rsc
-   vrSucceed_wav = ice_guard_sound
+
+   vrSucceed_wav = IceGuard_sound
 
    viCast_time = 0
 
@@ -119,6 +121,7 @@ messages:
       }
       oRoomData = Send(oRoom,@GetRoomData);
 
+      % Can go up to 10 rows/cols (expressed in *64 fine)
       iDist = ((iSpellPower+1)*64)/10;
       
       if iDist < 64
@@ -219,14 +222,8 @@ messages:
                                 #fine_row_end=iNewFineRow,
                                 #fine_col_end=iNewFineCol)
          {
-            oElement = Create(&FogIce,#MaxDamage=(iSpellPower+1)/4,#Caster=who,
-                        #duration=6000,#bMS=TRUE);
-            Send(oRoom,@NewHold,#what=oElement,
-                 #new_row=Send(who,@GetRow),#new_col=Send(who,@GetCol),
-                 #fine_row=Send(who,@GetFineRow),#fine_col=Send(who,@GetFineCol));
-
-            oElement = Create(&FogIce,#MaxDamage=(iSpellPower+1)/4,#Caster=who,
-                        #duration=6000,#bMS=TRUE);
+            oElement = Create(&FogIce,#MaxDamage=iSpellPower/6,#Caster=who,
+                        #duration=3000+((iSpellPower+1)/25)*1000,#bMS=TRUE);
             Send(oRoom,@NewHold,#what=oElement,
                  #new_row=iRowSuccess,#new_col=iColSuccess,
                  #fine_row=iFineRowSuccess,#fine_col=iFineColSuccess);

--- a/kod/object/passive/spell/iceguard.kod
+++ b/kod/object/passive/spell/iceguard.kod
@@ -139,7 +139,13 @@ messages:
       iRow = Send(who,@GetRow);
       iFineCol = Send(who,@GetFineCol);
       iFineRow = Send(who,@GetFineRow);
-      iRot = abs(Send(who,@GetAngle)-2050);
+      iRot = Send(who,@GetAngle) + 2050;
+
+      if iRot > 4100
+      {
+         iRot = iRot - 4100;
+      }
+
       iColPercentage = 100;
       iRowPercentage = 0;
       iColSign = 1;

--- a/kod/object/passive/spell/lightningstrike.kod
+++ b/kod/object/passive/spell/lightningstrike.kod
@@ -13,6 +13,9 @@ LightningStrike is Spell
 constants:
    include blakston.khd
 
+   % What change in elevation will stop lightning strike?
+   ELEVATION_RISE_MAX = 15
+
 resources:
 
    lightning_strike_name_rsc = "lightning strike"
@@ -110,7 +113,8 @@ messages:
                    iRowPercentage, iColPercentage, iRowSign, iColSign,
                    iRowDist, iColDist, oRoomData, iSteps,
                    iRowSuccess, iColSuccess, iFineRowSuccess, iFineColSuccess,
-                   oElement, iRot, iCurDist, oTarget, iTargetAngle;
+                   oElement, iRot, iCurDist, oTarget, iTargetAngle,
+                   iStartHeight, iNextHeight;
 
       oTarget = First(lTargets);
       
@@ -140,6 +144,8 @@ messages:
       iFineRow = Send(oTarget,@GetFineRow);
       iTargetAngle = Send(oTarget,@GetAngle);
       iRot = iTargetAngle + 2050;
+      
+      iStartHeight = GetHeight(oRoomData,iRow,iCol,iFineRow,iFineCol);
 
       if iRot > 4100
       {
@@ -227,6 +233,8 @@ messages:
                                 #col_end=iNewCol,
                                 #fine_row_end=iNewFineRow,
                                 #fine_col_end=iNewFineCol)
+            AND GetHeight(oRoomData,iNewRow,iNewCol,iNewFineRow,iNewFineCol) <=
+                   iStartHeight + ELEVATION_RISE_MAX
          {
             oElement = Create(&WallOfLightning,#MaxDamage=(iSpellPower+1)/4,#Caster=who,
                         #duration=800,#bMS=TRUE);

--- a/kod/object/passive/spell/lightningstrike.kod
+++ b/kod/object/passive/spell/lightningstrike.kod
@@ -1,0 +1,594 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+LightningStrike is Spell
+
+constants:
+   include blakston.khd
+
+resources:
+
+   lightning_strike_name_rsc = "lightning strike"
+   lightning_strike_icon_rsc = lightnin.bgf
+   lightning_strike_desc_rsc = \
+     "Lands a wild teleporting strike on your target's back. "
+     "Repeated use of this spell can exhaust even the strongest mage."
+
+   lightning_strike_max_cooldowns = \
+      "You need to rest for a moment before striking again."
+   lightning_strike_not_here = \
+      "You can't strike here!"
+   lightning_strike_too_short = \
+      "You don't have enough power to strike even a step!"
+   lightning_strike_dashed = \
+      "You strike %i steps!"
+   lightning_strike_no_space = \
+      "Your target doesn't have enough space behind them!"
+   lightning_strike_no_longer = \
+      "You are exhausted, and cannot strike again for %i seconds."
+   lightning_strike_can_do_now = \
+      "You feel that you can strike again."
+   lightning_strike_sound = fbolt.wav
+
+classvars:
+
+   vrName = lightning_strike_name_rsc
+   vrIcon = lightning_strike_icon_rsc
+   vrDesc = lightning_strike_desc_rsc
+   vrSucceed_wav = lightning_strike_sound
+
+   viCast_time = 0
+
+   viSpell_num = SID_LIGHTNING_STRIKE
+   viSpell_level = 6
+   viSchool = SS_FAREN
+   viMana = 8
+   viSpellExertion = 10
+   viChance_To_Increase = 15
+   viMeditate_ratio = 20
+
+properties:
+
+   % This spell keeps track of player cooldowns.
+   plCooldowns = $
+
+   % A player can use the spell this many times in a row.
+   piMaxUses = 2
+
+   % It takes this long for one cooldown to lift.
+   piCooldownTime = 15000
+
+messages:
+
+   ResetReagents()
+   {
+      plReagents = $;
+
+      return;
+   }
+
+   GetNumSpellTargets()
+   {
+      return 1;
+   }
+
+   CanPayCosts(who=$,lTargets=$,bItemCast=FALSE)
+   {
+      local oRoom;
+      
+      oRoom = Send(who,@GetOwner);
+
+      if oRoom <> $
+         AND IsClass(oRoom,&Room)
+         AND Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
+      {
+         Send(who,@MsgSendUser,#message_rsc=lightning_strike_not_here);
+         return FALSE;
+      }
+
+      % If you're at or beyond max cooldowns, can't use the spell.
+      if Send(self,@GetCooldown,#who=who) >= piMaxUses
+      {
+         Send(who,@MsgSendUser,#message_rsc=lightning_strike_max_cooldowns);
+         return FALSE;
+      }
+
+      propagate;
+   }
+
+   CastSpell(who = $, lTargets = $, iSpellPower=0)
+   {                   
+      local oRoom, iRow, iCol, iFineRow, iFineCol, iDist,
+                   iNewRow, iNewCol, iNewFineRow, iNewFineCol,
+                   iRowPercentage, iColPercentage, iRowSign, iColSign,
+                   iRowDist, iColDist, oRoomData, iSteps,
+                   iRowSuccess, iColSuccess, iFineRowSuccess, iFineColSuccess,
+                   oElement, iRot, iCurDist, oTarget, iTargetAngle;
+
+      oTarget = First(lTargets);
+      
+      if oTarget = $
+      {
+         return FALSE;
+      }
+
+      oRoom = Send(who,@GetOwner);
+      if oRoom = $
+      {
+         return FALSE;
+      }
+      oRoomData = Send(oRoom,@GetRoomData);
+
+      % 1 full unit behind target
+      iDist = 64;
+
+      % This spell calculates your intended destination without trigonometry.
+      % The diff you travel is split into percentages of X and Y distance.
+      % The spell then attempts to teleport you by checking with
+      % Line of Sight.
+      
+      iCol = Send(oTarget,@GetCol);
+      iRow = Send(oTarget,@GetRow);
+      iFineCol = Send(oTarget,@GetFineCol);
+      iFineRow = Send(oTarget,@GetFineRow);
+      iTargetAngle = Send(oTarget,@GetAngle);
+      iRot = abs(iTargetAngle-2050);
+      iColPercentage = 100;
+      iRowPercentage = 0;
+      iColSign = 1;
+      iRowSign = 1;
+      
+      % iRot 0 - 4100
+      
+      if iRot >= 0
+         AND iRot <= 1025
+      {
+         iColPercentage = 100 - (100*iRot)/1025;
+         iRowPercentage = (100*iRot)/1025;
+         iColSign = 1;
+         iRowSign = 1;
+      }
+      
+      if iRot > 1025
+         AND iRot <= 2050
+      {
+         iColPercentage = (100*(iRot-1025))/1025;
+         iRowPercentage = 100 - (100*(iRot-1025))/1025;
+         iColSign = -1;
+         iRowSign = 1;
+      }
+      
+      if iRot > 2050
+         AND iRot <= 3175
+      {
+         iColPercentage = 100 - (100*(iRot-2050))/1025;
+         iRowPercentage = (100*(iRot-2050))/1025;
+         iColSign = -1;
+         iRowSign = -1;
+      }
+      
+      if iRot > 3175
+         AND iRot < 4100
+      {
+         iColPercentage = (100*(iRot-3175))/1025;
+         iRowPercentage = 100 - (100*(iRot-3175))/1025;
+         iColSign = 1;
+         iRowSign = -1;
+      }
+
+      iSteps = 0;
+      iCurDist = 0;
+      iColSuccess = iCol;
+      iRowSuccess = iRow;
+      iFineColSuccess = iFineCol;
+      iFineRowSuccess = iFineRow;
+      
+      while iCurDist <= iDist
+      {
+         iColDist = ((FINENESS*iColPercentage)/100)*iColSign;
+         iRowDist = ((FINENESS*iRowPercentage)/100)*iRowSign;
+
+         iNewFineCol = iFineColSuccess + iColDist;
+         iNewFineRow = iFineRowSuccess + iRowDist;
+         
+         iNewCol = iColSuccess;
+         if iNewFineCol > 63
+         {
+            iNewCol = iNewCol + 1;
+            iNewFineCol = iNewFineCol - FINENESS;
+         }
+         
+         iNewRow = iRowSuccess;
+         if iNewFineRow > 63
+         {
+            iNewRow = iNewRow + 1;
+            iNewFineRow = iNewFineRow - FINENESS;
+         }
+
+         if Send(self,@LineOfSight,#oRoomData=oRoomData,
+                                #row_start=iRowSuccess,
+                                #col_start=iColSuccess,
+                                #fine_row_start=iFineRowSuccess,
+                                #fine_col_start=iFineColSuccess,
+                                #row_end=iNewRow,
+                                #col_end=iNewCol,
+                                #fine_row_end=iNewFineRow,
+                                #fine_col_end=iNewFineCol)
+         {
+            oElement = Create(&WallOfLightning,#MaxDamage=(iSpellPower+1)/4,#Caster=who,
+                        #duration=800,#bMS=TRUE);
+            Send(oRoom,@NewHold,#what=oElement,
+                 #new_row=Send(who,@GetRow),#new_col=Send(who,@GetCol),
+                 #fine_row=Send(who,@GetFineRow),#fine_col=Send(who,@GetFineCol));
+
+            oElement = Create(&WallOfLightning,#MaxDamage=(iSpellPower+1)/4,#Caster=who,
+                        #duration=800,#bMS=TRUE);
+            Send(oRoom,@NewHold,#what=oElement,
+                 #new_row=iRowSuccess,#new_col=iColSuccess,
+                 #fine_row=iFineRowSuccess,#fine_col=iFineColSuccess);
+                 
+            iColSuccess = iNewCol;
+            iRowSuccess = iNewRow;
+            iFineColSuccess = iNewFineCol;
+            iFineRowSuccess = iNewFineRow;
+            iSteps = iSteps + 1;
+         }
+         else
+         {
+            break;
+         }
+         
+         iCurDist = iCurDist + FINENESS;
+      }
+
+      if iSteps > 0
+      {
+         Send(SYS,@UtilGoNearSquare,#what=who,#where=oRoom,
+                     #new_row=iRowSuccess,#new_col=iColSuccess,
+                     #fine_row=iFineRowSuccess,#fine_col=iFineColSuccess,
+                     #new_angle=iTargetAngle);
+         Send(who,@MsgSendUser,#message_rsc=lightning_strike_dashed,
+                               #parm1=iSteps);
+         Send(self,@AddCooldown,#who=who);
+         Post(who,@ClearAttackTimer);
+         Post(who,@UserAttack,#what=oTarget);
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=lightning_strike_no_space);
+      }
+
+      propagate;
+   }
+
+   SuccessChance(who=$)
+   {
+      return TRUE;
+   }
+   
+   GetCooldown(who=$)
+   {
+      local i;
+      
+      for i in plCooldowns
+      {
+         if Nth(i,1) = who
+         {
+            return Nth(i,2);
+         }
+      }
+      
+      return 0;
+   }
+
+   AddCooldown(who=$)
+   {
+      local i;
+
+      if who = $
+      {
+         return;
+      }
+
+      for i in plCooldowns
+      {
+         if Nth(i,1) = who
+         {
+            SetNth(i,2,Nth(i,2)+1);
+            if Nth(i,2) >= piMaxUses
+            {
+               Send(who,@MsgSendUser,#message_rsc=lightning_strike_no_longer,
+                                     #parm1=GetTimeRemaining(Nth(i,3))/1000);
+            }
+            return;
+         }
+      }
+      
+      plCooldowns = Cons([who,1,
+                          CreateTimer(self,@ClearCooldown,piCooldownTime)],
+                          plCooldowns);
+
+      return;
+   }
+
+   ClearCooldown(timer=$)
+   {
+      local i;
+      
+      for i in plCooldowns
+      {
+         if Nth(i,3) = timer
+         {
+            if Nth(i,2) = piMaxUses
+            {
+               Send(Nth(i,1),@MsgSendUser,#message_rsc=lightning_strike_can_do_now);
+            }
+
+            SetNth(i,2,Nth(i,2)-1);
+            
+            if Nth(i,2) <= 0
+            {
+               SetNth(i,1,$);
+               SetNth(i,2,0);
+               SetNth(i,3,$);
+               plCooldowns = DelListElem(plCooldowns,i);
+            }
+            else
+            {
+               SetNth(i,3,CreateTimer(self,@ClearCooldown,piCooldownTime));
+            }
+         }
+      }
+      
+      return;
+   }
+   
+   Delete()
+   {
+      local i;
+      
+      for i in plCooldowns
+      {
+         if Nth(i,3) <> $
+         {
+            DeleteTimer(Nth(i,3));
+            SetNth(i,3,$);
+            SetNth(i,2,0);
+            SetNth(i,1,$);
+            plCooldowns = DelListElem(plCooldowns,i);
+         }
+      }
+      plCooldowns = $;
+      
+      propagate;
+   }
+
+   LineOfSight(oRoomData=$,
+               row_start=0,col_start=0,fine_row_start=0,fine_col_start=0,
+               row_end=0,col_end=0,fine_row_end=0,fine_col_end=0)
+   "Returns TRUE if there is a line of sight between start and end"
+   {
+     local r;
+     
+     % First check if start can walk on a direct path to end.
+     % If we can't move there, we assume vision through this
+     % location is blocked as well.  This assumption is violated
+     % by, for example, fences and altitude changes in the floor.
+
+     r = Send(self,@LineOfSightInternal,#oRoomData=oRoomData,
+                                        #row_start=row_start,
+                                        #col_start=col_start,
+                                        #fine_row_start=fine_row_start,
+                                        #fine_col_start=fine_col_start,
+                                        #row_end=row_end,
+                                        #col_end=col_end,
+                                        #fine_row_end=fine_row_end,
+                                        #fine_col_end=fine_col_end);
+
+     % we also possibly check the other way around,
+     % because if end somehow DOES have LoS with start,
+     % start also must have LoS with end.
+     % This makes sure LoS is handled equally (fair) for both.
+     if r = FALSE
+     {
+        r = Send(self,@LineOfSightInternal,#oRoomData=oRoomData,
+                                           #row_start=row_end,
+                                           #col_start=col_end,
+                                           #fine_row_start=fine_row_end,
+                                           #fine_col_start=fine_col_end,
+                                           #row_end=row_start,
+                                           #col_end=col_start,
+                                           #fine_row_end=fine_row_start,
+                                           #fine_col_end=fine_col_start);
+     }
+
+     return r;
+   }
+   
+   LineOfSightInternal(oRoomData=$,
+                       row_start=0,col_start=0,fine_row_start=0,fine_col_start=0,
+                       row_end=0,col_end=0,fine_row_end=0,fine_col_end=0)
+   {
+      local r, c, r2, c2, dr, dc, iRow, iCol, iAtan, iSkip;
+
+      % try get obj1 big coordinates (source)
+      r = row_start;
+      c = col_start;
+ 
+      % no coordinates (big row/col can be $)
+      if r = $ OR c = $
+      {
+         Debug("$ coordinates in flame dash");
+
+         return FALSE;
+      }
+      else
+      {
+         % get fine values and scale to highres
+         r = ((r * FINENESS) + fine_row_start) / 16;
+         c = ((c * FINENESS) + fine_col_start) / 16;
+      }
+
+      % try get obj2 coordinates (destination)
+      iRow = row_end;
+      iCol = col_end;
+
+      % no coordinates (big row/col can be $)
+      if iRow = $ OR iCol = $
+      {
+         Debug("$ coordinates in flame dash end");
+
+         return FALSE;
+      }
+      else
+      {
+         % get fine values and scale to highres
+         iRow = ((iRow * FINENESS) + fine_row_end) / 16;
+         iCol = ((iCol * FINENESS) + fine_col_end) / 16;    
+      }
+
+      % get deltas in highres
+      dr = iRow - r;
+      dc = iCol - c;
+
+      % prepare first loop
+      r2 = r;
+      c2 = c;
+
+      % get config setting for amount of steps to skip at the end
+      % of LoS line, this modifies safespots
+      iSkip = Send(Send(SYS, @GetSettings), @GetLOSSkip);
+
+      % step from the source to the target on the highres grid.
+      % depending on the skip amount, we either must reach
+      % the destination completely (rare safespots)
+      % or an adjacent/close square is enough (no safespots)
+      while abs(dr) > iSkip OR abs(dc) > iSkip
+      {
+         % Figure out which direction we need to move
+         % our 2D ray next (=step N,NE,E,SE,S,...)
+         % We pick the best approximation of the 8 possible 
+
+         % Only north or south are special cases.
+         if dc = 0
+         {
+            if dr < 0 %N
+            {
+               r2 = r2 - 1;
+            }
+            else %S
+            {
+               r2 = r2 + 1;
+            }
+         }
+         else
+         {
+            iAtan = 1000 * dr / dc;
+         }
+
+         % right half-plane
+         if dc > 0 
+         {
+            if iAtan >= 2414 %S
+            {
+               r2 = r2 + 1;
+            }
+            else
+            {
+               if iAtan >= 414 %SE
+               {
+                  r2 = r2 + 1;
+                  c2 = c2 + 1;
+               }
+               else
+               {
+                  if iAtan >= -414 %E
+                  {
+                     c2 = c2 + 1;
+                  }
+                  else
+                  {
+                     if iAtan >= -2414 %NE
+                     {
+                        r2 = r2 - 1;
+                        c2 = c2 + 1;
+                     }
+                     else %N
+                     {
+                        r2 = r2 - 1;
+                     }
+                  }
+               }
+            }
+         }
+
+         % left half-plane
+         if dc < 0 
+         {
+            if iAtan >= 2414 %N
+            {
+               r2 = r2 - 1;
+            }
+            else
+            {
+               if iAtan >= 414 %NW
+               {
+			      r2 = r2 - 1;
+                  c2 = c2 - 1;                  
+               }
+               else
+               {
+                  if iAtan >= -414 %W
+                  {
+                     c2 = c2 - 1;
+                  }
+                  else
+                  {
+                     if iAtan >= -2414 %SW
+                     {
+			            r2 = r2 + 1;
+                        c2 = c2 - 1;                        
+                     }
+                     else %S
+                     {
+                        r2 = r2 + 1;
+                     }
+                  }
+               }
+            }
+         }
+
+         % DEBUG - Puts item on LOS line
+         % Send(SYS,@PutInRoom,#what=Create(&PlateArmor),#rid=piRoom_num,
+         %    #row=(r/4),#col=(c/4),#fine_row=((r MOD 4)*16),#fine_col=((c MOD 4)*16));
+		 
+         % these calculations turn the highres values back into row/finerow
+         % remember: 4 highres rows give a row, and a highres row has 16 finerows 
+         if NOT CanMoveInRoomHighRes(oRoomData,
+                    (r / 4), (c / 4), ((r MOD 4) * 16), ((c MOD 4) * 16),
+                    (r2 / 4) , (c2 / 4), ((r2 MOD 4) * 16), ((c2 MOD 4) * 16))
+         {
+           return FALSE;
+         }
+
+		 % set new position as old
+         r = r2;
+         c = c2;
+
+         % get deltas in highres
+         dr = iRow - r;
+         dc = iCol - c;
+      }
+
+      return TRUE;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/lightningstrike.kod
+++ b/kod/object/passive/spell/lightningstrike.kod
@@ -139,7 +139,13 @@ messages:
       iFineCol = Send(oTarget,@GetFineCol);
       iFineRow = Send(oTarget,@GetFineRow);
       iTargetAngle = Send(oTarget,@GetAngle);
-      iRot = abs(iTargetAngle-2050);
+      iRot = iTargetAngle + 2050;
+
+      if iRot > 4100
+      {
+         iRot = iRot - 4100;
+      }
+
       iColPercentage = 100;
       iRowPercentage = 0;
       iColSign = 1;

--- a/kod/object/passive/spell/makefile
+++ b/kod/object/passive/spell/makefile
@@ -58,6 +58,7 @@ BOFS = animate.bof \
        sweep.bof \
        teleportspell.bof \
        utility.bof \
-       walspell.bof
+       walspell.bof \
+       flamedash.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/spell/makefile
+++ b/kod/object/passive/spell/makefile
@@ -60,6 +60,7 @@ BOFS = animate.bof \
        utility.bof \
        walspell.bof \
        flamedash.bof \
-       lightningstrike.bof
+       lightningstrike.bof \
+       iceguard.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/spell/makefile
+++ b/kod/object/passive/spell/makefile
@@ -59,6 +59,7 @@ BOFS = animate.bof \
        teleportspell.bof \
        utility.bof \
        walspell.bof \
-       flamedash.bof
+       flamedash.bof \
+       lightningstrike.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/spell/walspell/firewall.kod
+++ b/kod/object/passive/spell/walspell/firewall.kod
@@ -79,7 +79,7 @@ messages:
       iAngle = Send(who,@GetAngle);
       iMaxDamage = iSpellPower / 6;
       iMaxDamage = Bound(iMaxDamage,1,16);
-      iDuration = (iSpellPower * 2) + 30;
+      iDuration = (iSpellPower * 2) + 30 + Random(-20,20);
       iDuration = Bound(iDuration,30,180);
 
       % Facing East

--- a/kod/object/passive/spell/walspell/ltngwall.kod
+++ b/kod/object/passive/spell/walspell/ltngwall.kod
@@ -82,7 +82,7 @@ messages:
       iAngle = Send(who,@GetAngle);
       iMaxDamage = iSpellPower / 4;
       iMaxDamage = Bound(iMaxDamage,1,25);
-      iDuration = (iSpellPower * 2) + 20;
+      iDuration = (iSpellPower * 2) + 20 + Random(-20,20);
       iDuration = Bound(iDuration,20,120);
 
       % Facing East

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -3358,6 +3358,7 @@ messages:
       Send(self,@CreateOneSpellIfNew,#num=SID_CONVEYANCE,#class=&Conveyance);
       Send(self,@CreateOneSpellIfNew,#num=SID_PHASE,#class=&Phase);
       Send(self,@CreateOneSpellIfNew,#num=SID_FLAME_DASH,#class=&FlameDash);
+      Send(self,@CreateOneSpellIfNew,#num=SID_LIGHTNING_STRIKE,#class=&LightningStrike);
 
       % Trance may be searched for frequently, leave at end of list
       Send(self,@CreateOneSpellIfNew,#num=SID_TRANCE,#class=&Trance);

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -3359,6 +3359,7 @@ messages:
       Send(self,@CreateOneSpellIfNew,#num=SID_PHASE,#class=&Phase);
       Send(self,@CreateOneSpellIfNew,#num=SID_FLAME_DASH,#class=&FlameDash);
       Send(self,@CreateOneSpellIfNew,#num=SID_LIGHTNING_STRIKE,#class=&LightningStrike);
+      Send(self,@CreateOneSpellIfNew,#num=SID_ICE_GUARD,#class=&IceGuard);
 
       % Trance may be searched for frequently, leave at end of list
       Send(self,@CreateOneSpellIfNew,#num=SID_TRANCE,#class=&Trance);

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -3357,6 +3357,7 @@ messages:
       Send(self,@CreateOneSpellIfNew,#num=SID_LOADOUT,#class=&Loadout);
       Send(self,@CreateOneSpellIfNew,#num=SID_CONVEYANCE,#class=&Conveyance);
       Send(self,@CreateOneSpellIfNew,#num=SID_PHASE,#class=&Phase);
+      Send(self,@CreateOneSpellIfNew,#num=SID_FLAME_DASH,#class=&FlameDash);
 
       % Trance may be searched for frequently, leave at end of list
       Send(self,@CreateOneSpellIfNew,#num=SID_TRANCE,#class=&Trance);


### PR DESCRIPTION
This is an example of a few new techniques.

1: Attempting to build in-map teleportation. Flame Dash attempts to leap
you forward up to 10 units, based on spellpower. 

2: This is an example of a multi-cooldown system, where you can dash
multiple times, but then have to wait if you blow them all too quickly. Players
get 3 uses on 10 second cooldowns.

3: Flame dash leaves short-lived behind firewall elements in the path
you travel. I'd like to experiment with more mechanics like these, that
actually change the battlefield temporarily.

---

Lightning Strike teleports you one unit behind your target (according
to where their back is facing) and automatically strikes with whatever
weapon you have equipped.

Lightning Strike leaves two lightning walls very briefly in your starting
and arriving positions. 

Lightning Strike has 2 uses on 15 second cooldowns.

---

Ice Guard teleports you directly backwards with the same length as 
Flame Dash.

Ice Guard leaves a trail of fog that freezes (holds) people. Lasts
many times longer than the other two, 6+ seconds.

Ice Guard has 4 uses on 60 second cooldowns. If you run out of
these, you're really out...

---

**Disclaimer**

These spells are proofs of concept. I don't intend them all to be this mana cost, vigor cost, level, or school etc.