### PR TITLE
Rod rebalance

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5621,20 +5621,6 @@ messages:
          }
       }
 
-      if NOT bShielded
-         AND what <> $
-         AND IsClass(what,&Player)
-      {
-         for oRod in Send(what,@GetHolderPassive)
-         {
-            if IsClass(oRod,&ShieldRod)
-               AND Send(oRod,@IsActive)
-            {
-               bShielded = TRUE;
-            }
-         }
-      }
-
       if bShielded
       {
          if precision

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1103,6 +1103,9 @@ properties:
    % Spectator mode?
    pbSpectatorMode = FALSE
 
+   % Rod cooldowns
+   plRodCooldowns = $
+
 messages:
 
    Constructor()
@@ -1204,6 +1207,16 @@ messages:
       Send(Send(SYS,@GetAssassinGame),@RemoveFromGame,#who=self);
       Send(Send(SYS,@GetLore),@PlayerSuicides,#who=self);
       plSchools = $;
+      
+      for i in plRodCooldowns
+      {
+         DeleteTimer(Nth(i,2));
+         SetNth(i,1,$);
+         SetNth(i,2,$);
+         plRodCooldowns = DelListElem(plRodCooldowns,i);
+      }
+      
+      plRodCooldowns = $;
 
       propagate;
    }
@@ -14993,6 +15006,56 @@ messages:
       }
 
       propagate;
+   }
+   
+   AddRodCooldown(what=$,time=1000)
+   {
+      if IsClass(what,&Rod)
+      {
+         plRodCooldowns = Cons([what,CreateTimer(self,@ClearRodCooldown,time)],
+                               plRodCooldowns);
+      }
+
+      return;
+   }
+   
+   ClearRodCooldown(timer=$)
+   {
+      local i;
+      
+      for i in plRodCooldowns
+      {
+         if Nth(i,2) = timer
+         {
+            SetNth(i,1,$);
+            SetNth(i,2,$);
+            
+            plRodCooldowns = DelListElem(plRodCooldowns,i);
+         }
+      }
+      
+      return;
+   }
+   
+   ReqRodCooldown(what=$)
+   {
+      local i;
+      
+      if what = $
+         OR NOT IsClass(what,&Rod)
+      {
+         return FALSE;
+      }
+      
+      for i in plRodCooldowns
+      {
+         if GetClass(Nth(i,1)) = GetClass(what)
+         {
+            return FALSE;
+         }
+      }
+      
+      return TRUE;
    }
 
 end

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5608,6 +5608,20 @@ messages:
          }
       }
 
+      if NOT bShielded
+         AND what <> $
+         AND IsClass(what,&Player)
+      {
+         for oRod in Send(what,@GetHolderPassive)
+         {
+            if IsClass(oRod,&ShieldRod)
+               AND Send(oRod,@IsActive)
+            {
+               bShielded = TRUE;
+            }
+         }
+      }
+
       if bShielded
       {
          if precision

--- a/kod/object/item/passitem/rod.kod
+++ b/kod/object/item/passitem/rod.kod
@@ -214,7 +214,10 @@ messages:
                 @SecondaryDurationEffectExpire,piSecondaryEffectDuration);
       }
       
-      Send(poOwner,@AddRodCooldown,#what=self,#time=piEffectDuration);
+      if piEffectDuration > 0
+      {
+         Send(poOwner,@AddRodCooldown,#what=self,#time=piEffectDuration);
+      }
 
       Send(poOwner,@MsgSendUser,#message_rsc=use_success_msg);
       Send(Send(poOwner,@GetOwner),@SomethingWaveRoom,#what=poOwner,

--- a/kod/object/item/passitem/rod.kod
+++ b/kod/object/item/passitem/rod.kod
@@ -214,7 +214,7 @@ messages:
                 @SecondaryDurationEffectExpire,piSecondaryEffectDuration);
       }
       
-      if piEffectDuration > 0
+      if vbDurationEffect
       {
          Send(poOwner,@AddRodCooldown,#what=self,#time=piEffectDuration);
       }

--- a/kod/object/item/passitem/rod.kod
+++ b/kod/object/item/passitem/rod.kod
@@ -44,6 +44,8 @@ resources:
       "Your rod's secondary effect has expired."
 
    rod_cant_use_yet = "You cannot use that item yet."
+   rod_cooldown = \
+      "You've used a %s too recently!"
 
 classvars:
 
@@ -153,6 +155,13 @@ messages:
          return FALSE;
       }
       
+      if NOT Send(what,@ReqRodCooldown,#what=self)
+      {
+         Send(what,@MsgSendUser,#message_rsc=rod_cooldown,
+                                #parm1=Send(self,@GetName));
+         return FALSE;
+      }
+      
       if NOT Send(what,@IsOkayAttackTime,#time=piRodUseDelay)
       {
          Send(what,@MsgSendUser,#message_rsc=rod_cant_use_yet);
@@ -204,6 +213,8 @@ messages:
          ptSecondaryActiveTimer = CreateTimer(self,
                 @SecondaryDurationEffectExpire,piSecondaryEffectDuration);
       }
+      
+      Send(poOwner,@AddRodCooldown,#what=self,#time=piEffectDuration);
 
       Send(poOwner,@MsgSendUser,#message_rsc=use_success_msg);
       Send(Send(poOwner,@GetOwner),@SomethingWaveRoom,#what=poOwner,

--- a/kod/object/item/passitem/rod.kod
+++ b/kod/object/item/passitem/rod.kod
@@ -69,16 +69,18 @@ classvars:
    vbSecondaryDurationEffect = FALSE
    viSecondaryEffectDuration = 0
 
-   viRodUseDelay = 1000 % Milliseconds
+   viRodUseDelay = 500 % Milliseconds
 
 properties:
 
    vrDesc = Rod_desc_rsc
 
    % For rods with durations
+   piEffectDuration = 0
    ptActiveTimer = $
    pbActive = FALSE
 
+   piSecondaryEffectDuration = 0
    ptSecondaryActiveTimer = $
    pbSecondaryActive = FALSE
 
@@ -92,6 +94,8 @@ messages:
       Send(self,@SetMaxHits,#number=viStartMaxHits);
 
       piRodUseDelay = viRodUseDelay;
+      piEffectDuration = viEffectDuration + piRodUseDelay;
+      piSecondaryEffectDuration = viSecondaryEffectDuration + piRodUseDelay;
 
       propagate;
    }
@@ -185,7 +189,7 @@ messages:
          }
 
          pbActive = TRUE;
-         ptActiveTimer = CreateTimer(self,@DurationEffectExpire,viEffectDuration);
+         ptActiveTimer = CreateTimer(self,@DurationEffectExpire,piEffectDuration);
       }
 
       if vbSecondaryDurationEffect
@@ -198,7 +202,7 @@ messages:
 
          pbSecondaryActive = TRUE;
          ptSecondaryActiveTimer = CreateTimer(self,
-                @SecondaryDurationEffectExpire,viSecondaryEffectDuration);
+                @SecondaryDurationEffectExpire,piSecondaryEffectDuration);
       }
 
       Send(poOwner,@MsgSendUser,#message_rsc=use_success_msg);
@@ -271,6 +275,9 @@ messages:
       {
          piRodUseDelay = iTime;
       }
+
+      piEffectDuration = viEffectDuration + piRodUseDelay;
+      piSecondaryEffectDuration = viSecondaryEffectDuration + piRodUseDelay;
 
       return;
    }

--- a/kod/object/item/passitem/rod/healrod.kod
+++ b/kod/object/item/passitem/rod/healrod.kod
@@ -38,10 +38,14 @@ classvars:
    vrGoodDesc = healWand_desc_rsc
    use_success_msg = healWand_success_rsc
 
+   viStartHits = 0
+   viStartMaxHits = 7
+   viConsumesHits = 7
+
 properties:
 
-   piHeal_min = 4
-   piHeal_max = 8
+   piHeal_min = 20
+   piHeal_max = 40
 
 messages:
 

--- a/kod/object/item/passitem/rod/shieldrod.kod
+++ b/kod/object/item/passitem/rod/shieldrod.kod
@@ -54,7 +54,6 @@ classvars:
 
    vbDurationEffect = TRUE
    viEffectDuration = 5000
-   viRodUseDelay = 2000 % Milliseconds
 
 properties:
 

--- a/kod/object/item/passitem/rod/shieldrod.kod
+++ b/kod/object/item/passitem/rod/shieldrod.kod
@@ -54,6 +54,7 @@ classvars:
 
    vbDurationEffect = TRUE
    viEffectDuration = 5000
+   viRodUseDelay = 2000 % Milliseconds
 
 properties:
 

--- a/kod/object/item/passitem/rod/vamprod.kod
+++ b/kod/object/item/passitem/rod/vamprod.kod
@@ -44,6 +44,8 @@ classvars:
    use_success_wav = vampireRod_success_wav_rsc
    use_success_msg = vampireRod_success_rsc
 
+   viRodUseDelay = 50 % Milliseconds
+
 properties:
 
 messages:


### PR DESCRIPTION
Rods were recently given a delay, which is probably a good thing. Here's a shot
at improving what we're intended to do with them.

* Set base rod delay to 500ms. (As you'll see below, this really isn't
an important number anymore)

* Added base rod delay into effect durations, so players will never be
penalized for rod delays, now or in the future. A base delay of 500 ms
adds 500 ms to all effect durations.

* Heal rods can store only 1 total use (7 charges required). They now
heal five times as much (20-40) in that single use, instead of healing
4-8 five times. In essence, this removes the "spammy" nature of wands
once and for all without devaluing the health they give. They were also
trivializing building a bit, so their kills required were upped from 5
to 7 (40% more kills required). If builders are carrying 5, they will
still be able to use a 20-40 heal for 5 of the 7 mobs they're fighting.
Getting a 20-40 heal for every single mob might have been too much.

* Duration rods, like Shield and Power rods, now have a cooldown for their
rod type equal to their duration. If you Power rod for 5 seconds, you can't
use another for 5 seconds after that.

* Vamp rod given 50 ms delay. These don't do anything particularly
combat related.