### PR TITLE
Might proposal

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5415,7 +5415,7 @@ messages:
    {
       local i, j, iResistance, oSoldierShield, gainchance, color_rsc,
             iDuration, oSpell, oGort,iLimit, origdamage, oWeapon, shrunken,
-            bAttackerEmpowered, bShielded, oRod;
+            bAttackerEmpowered, bShielded, oRod, oAttackerWeapon;
 
       if NOT precision
       {
@@ -5595,6 +5595,21 @@ messages:
       if bAttackerEmpowered
       {
          damage = damage * 135 / 100;
+      }
+
+      % Increase final damage by Might if using a melee weapon
+      % Boost up to 35 percent (no overlap with Rod of Power)
+      if NOT bAttackerEmpowered
+         AND what <> $
+         AND IsClass(what,&Player)
+      {
+         oAttackerWeapon = Send(what,@GetWeapon);
+         if oAttackerWeapon <> $
+            AND NOT IsClass(oAttackerWeapon,&RangedWeapon)
+            AND NOT IsClass(oAttackerWeapon,&TouchAttackSpell)
+         {
+            damage = damage * (100 + (Send(what,@GetMight)/2)) / 100;
+         }
       }
 
       % Look for active shield rods in inventory, reduce final damage to 1 if any active


### PR DESCRIPTION
We've thought about this for a LONG time. Personally, as a builder, I
just won't bother with Might as long as it's a tiny bit of damage hiding
somewhere in base weapon attacks. I know this, and that's why I came up
with this idea here.

This pull adds Might as a FINAL damage modifer for melee weapons, up to
and exactly equal to a Rod of Power (+35% at 70 Might). They do not
overlap. You either get up to 35% from Might, your get the full 35% from
Rod of Power. Ranged and spells continue to function the same with Rod
of Power.

This pull has not currently removed base stat effects. Agility does
still affect scimitar and axe, might affects hammer and mace, aim
affects mystic sword. Then might affects ALL of them with the final
damage bonus (so might is double counted for hammer/mace, yes). This is
purely a buff to existing weapons at this time.

That may change during testing.

The idea here is to make melee weapons terrifying in the hands of
someone with very high stats. 70 might + 50 agility better hit hard with
a scimitar, that's half of their available points alone.

**I would like to knock points off base weapon damage if this damage is 
too high, and/or improve defense options** - we really need melee
weapons to be scary in the right hands the way splash spells
and bows are. At the same time, we're not ruining current builds
or playstyles, since this is purely a buff. I gotta say, melee weapons
just are not scary at all right now. Mystic swords especially used
to be king, but now feel silly.

We can also rebalance monster resists. For example, some people
are dealing 60+ to the Ghost with Rods of Power because of its intense
weakness to holy damage. With this change, we can lower some of those
severe weaknesses and still have the same effect as before.

---

Example numbers for Might's new effect at 70:

Damage -> Final damage
10 -> 13.5   (+3.5)
15 -> 20.25  (+5.25)
20 -> 27  (+7)
25 -> 33.75 (+8.75)