### PR TITLE
Fix m59bind.exe not being copied by VS build.

### DIFF
--- a/keybind/m59bind.csproj
+++ b/keybind/m59bind.csproj
@@ -97,6 +97,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>copy /y "$(ProjectDir)\$(OutDir)$(TargetName).exe" "$(SolutionDir)run\localclient"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Will now copy the output exe to .\run\localclient.