### PR TITLE
Fix some PE descriptions not showing up, fix axe/ss range, change rod values to 103-tested ones.

### DIFF
--- a/kod/object/item/passitem/rod.kod
+++ b/kod/object/item/passitem/rod.kod
@@ -68,7 +68,7 @@ classvars:
    vbSecondaryDurationEffect = FALSE
    viSecondaryEffectDuration = 0
 
-   viRodUseDelay = 1000 % Milliseconds
+   viRodUseDelay = 500 % Milliseconds
 
 properties:
 
@@ -81,7 +81,7 @@ properties:
    ptSecondaryActiveTimer = $
    pbSecondaryActive = FALSE
 
-   piRodUseDelay = 1000 % Milliseconds
+   piRodUseDelay = 500 % Milliseconds
 
 messages:
 

--- a/kod/object/item/passitem/rod/shieldrod.kod
+++ b/kod/object/item/passitem/rod/shieldrod.kod
@@ -55,7 +55,7 @@ classvars:
    viConsumesHits = 5
 
    vbDurationEffect = TRUE
-   viEffectDuration = 5000
+   viEffectDuration = 3000
 
 properties:
 

--- a/kod/object/item/passitem/weapon/axe.kod
+++ b/kod/object/item/passitem/weapon/axe.kod
@@ -52,8 +52,6 @@ classvars:
    viInventory_group = 3
    viBroken_group = 2
 
-   viRange = 3 * FINENESS
-
 properties:
 
    piAttack_type = ATCK_WEAP_NONMAGIC+ATCK_WEAP_SLASH

--- a/kod/object/item/passitem/weapon/shrtswrd.kod
+++ b/kod/object/item/passitem/weapon/shrtswrd.kod
@@ -50,6 +50,8 @@ classvars:
    vrWeapon_window_overlay = shortsword_window_overlay_rsc
    vrWeapon_overlay = shortsword_player_overlay
 
+   viRange = 3 * FINENESS
+
 properties:
 
    piAttack_type = ATCK_WEAP_NONMAGIC+ATCK_WEAP_THRUST

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -368,6 +368,13 @@ messages:
       return;
    }
 
+   EffectDesc(who=$)
+   {
+      AddPacket(4, spell_blank);
+
+      return;
+   }
+
    Delete()
    {
       Send(SYS,@DeleteSpell,#what=self);

--- a/kod/object/passive/spell/persench.kod
+++ b/kod/object/passive/spell/persench.kod
@@ -270,11 +270,6 @@ messages:
       return defense_power;
    }
 
-   EffectDesc(who=$)
-   {
-      return;
-   }
-
    SendTimeDesc(who=$)
    {
       local i, iDuration, oList;

--- a/kod/object/passive/spell/roomench.kod
+++ b/kod/object/passive/spell/roomench.kod
@@ -61,11 +61,6 @@ messages:
       propagate;
    }
 
-   EffectDesc(who=$)
-   {
-      propagate;
-   }
-
    SendStatsDesc(who=$)
    {
       if who <> $


### PR DESCRIPTION
* EffectDesc needs to add a blank resource if the spell itself doesn't add
anything here, otherwise descriptions won't display correctly if they
don't have effect description additions.

* Axe and ss range values were swapped in the recent update, this changes them back.

* Add the 103-tested values for rod use delay (500ms, down from 1000ms) and shield rod duration (3s, down from 5s) to code to avoid having to set them each reload/recreate.