### PR TITLE
Fix error in keybind build when building from makefile.

### DIFF
--- a/keybind/m59bind.csproj
+++ b/keybind/m59bind.csproj
@@ -98,7 +98,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /y "$(ProjectDir)\$(OutDir)$(TargetName).exe" "$(SolutionDir)run\localclient"</PostBuildEvent>
+    <PostBuildEvent>copy /y "$(ProjectDir)\$(OutDir)$(TargetName).exe" "$(ProjectDir)\..\run\localclient"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
$(SolutionDir) is undefined in the makefile build, so $(ProjectDir)\..\ must be used instead.