### PR TITLE
Add message to fix players when changing spell level. Training point system modifications.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -238,7 +238,7 @@ resources:
    
    player_training_inform = "You now have ~B%i~B training points!"
    player_reached_maxtraining = \
-      "You now have ~B1000~B training points and can not gain any more!  "
+      "You now have ~B%i~B training points and can not gain any more!  "
       "Cast the Meditate spell and say the name of a spell or skill out loud "
       "to use your points to train it."
    player_gained_training = "You have gained ~B%i~B training points!"
@@ -2328,7 +2328,7 @@ messages:
 
       if iTimespan > 16*60*60
       {
-         if piTraining_points = 1000
+         if piTraining_points >= 1000
          {
             return;
          }
@@ -8962,6 +8962,7 @@ messages:
          % and also got the killing blow (no double points from single mobs).
          if gain > 0
             AND killing_blow
+            AND piTraining_points < 1000
          {
             piTraining_points = piTraining_points + 1
                + (Send(what,@GetBoostedLevel)
@@ -8994,14 +8995,14 @@ messages:
          {
             if piInform
             {
-               Send(self,@MsgSendUser,#message_rsc=player_reached_maxtraining);
+               Send(self,@MsgSendUser,#message_rsc=player_reached_maxtraining,
+                  #parm1=piTraining_points);
                piInform = FALSE;
             }
-            piTraining_points = 1000;
          }
          else
          {
-            if piTraining_points mod 100 = 0
+            if piTraining_points MOD 100 = 0
                AND piTraining_points <> 0
                AND piInform
             {
@@ -9169,14 +9170,27 @@ messages:
       return piTraining_points;
    }
 
-   AddTrainingPoints(points=0,report=TRUE)
+   AddTrainingPoints(points=0,report=TRUE,bCap=TRUE)
    {
       if points = 0
       {
          return;
       }
 
-      points = bound(points,-piTraining_points,1000 - piTraining_points);
+      if bCap
+      {
+         if piTraining_points <= 1000
+         {
+            points = bound(points,-piTraining_points,1000 - piTraining_points);
+         }
+         else if points > 0
+         {
+               % We're respecting the 1000 point cap, have more than 1000
+               % points and are trying to add more. Don't add the points,
+               % return out.
+               return;
+         }
+      }
 
       if report AND points > 0
       {
@@ -9193,12 +9207,14 @@ messages:
       piTraining_points = piTraining_points + points;
 
       if piTraining_points < 1000
+         OR NOT bCap
       {
          piInform = TRUE;
       }
       else
       {
-         Send(self,@MsgSendUser,#message_rsc=player_reached_maxtraining);
+         Send(self,@MsgSendUser,#message_rsc=player_reached_maxtraining,
+               #parm1=piTraining_points);
          piInform = FALSE;
       }
 
@@ -9213,7 +9229,7 @@ messages:
 
       ptReward_timer = CreateTimer(self,@GetDailyTrainingReward,24*60*60*1000);
 
-      if piTraining_points = 1000
+      if piTraining_points >= 1000
       {
          return;
       }

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6895,6 +6895,38 @@ messages:
       return iList;
    }
 
+   FixSpellLevelChange(iSID=0)
+   "Removes a spell from one level and adds it to another for all players "
+   "who have the spell, and also have the second level."
+   {
+      local i, oSpell, iPercent, iTP;
+
+      oSpell = Send(self,@FindSpellByNum,#num=iSID);
+
+      foreach i in plUsers
+      {
+         if Send(i,@HasSpell,#num=iSID)
+         {
+            iPercent = Send(i,@GetSpellAbility,#spell_num=iSID);
+            Send(i,@RemoveSpell,#num=iSID);
+            if Send(i,@PlayerCanLearn,#spell_num=iSID) = PLAYER_LEARN_SUCCESS
+            {
+               Send(i,@AddSpell,#num=iSID,#iability=iPercent);
+               Debug("Readded spell ",Send(oSpell,@GetName)," to ",
+                     Send(i,@GetTrueName));
+            }
+            else
+            {
+               iTP = Send(oSpell,@GetMeditateRatio);
+               Send(i,@AddTrainingPoints,#points=iTP * iPercent,#bCap=FALSE);
+               Debug("Added ",iTP * iPercent," TP to ",Send(i,@GetTrueName));
+            }
+         }
+      }
+
+      return;
+   }
+
    AdminListPlayersOverHP(hp=$)
    {
       local i;


### PR DESCRIPTION
FixSpellLevelChange will remove a spell from players and readd it if
they can learn it. Can be used when changing a spell level to make sure
only players who can learn the new level of the spell will have it. If
the spell isn't readded, the player is given the equivalent number of
training points for the % they had in the spell.

Added some code to the training point system in Player to get around the
1000 point cap if necessary. The cap will still be adhered to except if bCap
is sent with a FALSE value (i.e. by FixSpellLevelChange). The only other
difference is players can get above 1000 with their last kill that maxes their
training points (i.e. 1001, 1002, 1003 etc). The reasoning for this behavior
is that if the player receives some large TP reward (i.e. quest or tough
monster kill) they should receive the whole bonus and not have it cut off
at 1000 TP.
