### PR TITLE
Increment BOF version to 6.

### DIFF
--- a/blakcomp/blakcomp.h
+++ b/blakcomp/blakcomp.h
@@ -30,7 +30,7 @@
 #include "util.h"
 #include "table.h"
 
-#define BOF_VERSION 5
+#define BOF_VERSION 6
 
 #define IDBASE        10000      /* Lowest # of user-defined id.  Builtin ids have lower #s */
 #define RESOURCEBASE  20000      /* Lowest # of user-defined resource. */

--- a/blakserv/blakserv.h
+++ b/blakserv/blakserv.h
@@ -34,6 +34,8 @@
 
 #define MAX_DEPTH 2000
 
+#define BOF_VERSION 6
+
 enum
 {
    USER_CLASS = 1,

--- a/blakserv/loadkod.c
+++ b/blakserv/loadkod.c
@@ -126,10 +126,11 @@ Bool LoadBofName(char *fname)
    }
    
    int version;
-   if (fread(&version, 1, 4, f) != 4 || version != 5)
+   if (fread(&version, 1, 4, f) != 4 || version != BOF_VERSION)
 	{
-		eprintf("LoadBofName %s can't understand bof version != 5\n",fname);
-      fclose(f);
+		eprintf("LoadBofName %s can't understand bof version %i\n",
+			fname, version);
+		fclose(f);
 		return False;
 	}
    


### PR DESCRIPTION
Recent Blakod language changes mean there may be incompatibility when
using bof files built with previous versions of the compiler.