### PR TITLE
IPv6 support in blakserv

### DIFF
--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -4289,7 +4289,7 @@ void AdminHangupUser(int session_id,admin_parm_type parms[],
 	HangupSession(hangup_session);
 }
 
-extern block_node* FindBlock(struct in_addr* piaPeer);
+extern block_node* FindBlock(struct in6_addr* piaPeer);
 
 /*
  * AdminBlockIP - Block an IP address from accessing this server
@@ -4298,18 +4298,20 @@ extern block_node* FindBlock(struct in_addr* piaPeer);
 void AdminBlockIP(int session_id,admin_parm_type parms[],
                   int num_blak_parm,parm_node blak_parm[])                  
 {
-	struct in_addr blocktoAdd;
+	struct in6_addr blocktoAdd;
 	char *arg_str = (char *)parms[0];
-	
+	char ip[46];
+
 	aprintf("This command will only affect specified IPs until the server reboots\n");
 
-	if( ( blocktoAdd.s_addr = inet_addr( arg_str ) ) != -1 ) {
+	if (inet_pton(AF_INET6, arg_str, &blocktoAdd) != -1) {
+		inet_ntop(AF_INET6, &blocktoAdd, ip, sizeof(ip));
 		if(FindBlock( &blocktoAdd ) == NULL )  {
 			AddBlock(-1, &blocktoAdd);
-			aprintf("IP %s blocked\n",inet_ntoa( blocktoAdd ) );
+			aprintf("IP %s blocked\n", ip);
 		} else {
 			DeleteBlock( &blocktoAdd );
-			aprintf("IP %s has been unblocked\n" ,inet_ntoa( blocktoAdd ) );
+			aprintf("IP %s has been unblocked\n", ip);
 		}
 	}  else {
 		aprintf("Couldn`t build IP address bad format %s\n",arg_str );

--- a/blakserv/blakserv.h
+++ b/blakserv/blakserv.h
@@ -125,6 +125,7 @@ enum
 #define NOMINMAX
 #include <windows.h>
 #include <winsock2.h>
+#include <Ws2tcpip.h>
 #include "resource.h"
 #include <crtdbg.h>
 #include <io.h>

--- a/blakserv/blakserv.vcxproj
+++ b/blakserv/blakserv.vcxproj
@@ -43,7 +43,6 @@
     <TargetName>blakserv</TargetName>
     <IntDir>$(Configuration)\</IntDir>
     <ExtensionsToDeleteOnClean>$(ExtensionsToDeleteOnClean)</ExtensionsToDeleteOnClean>
-   
     <CustomBuildAfterTargets>
     </CustomBuildAfterTargets>
     <CustomBuildBeforeTargets>
@@ -54,7 +53,6 @@
     <TargetName>blakserv</TargetName>
     <IntDir>$(Configuration)\</IntDir>
     <ExtensionsToDeleteOnClean>$(ExtensionsToDeleteOnClean)</ExtensionsToDeleteOnClean>
-   
     <CustomBuildAfterTargets>
     </CustomBuildAfterTargets>
     <CustomBuildBeforeTargets>
@@ -78,7 +76,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>wsock32.lib;winmm.lib;comctl32.lib;libmysql.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>wsock32.lib;winmm.lib;comctl32.lib;libmysql.lib;libcurl.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
       <AdditionalLibraryDirectories>$(SolutionDir)\lib;</AdditionalLibraryDirectories>
@@ -134,7 +132,7 @@ copy $(SolutionDir)bin\libcurl.dll $(SolutionDir)run\server</Command>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>wsock32.lib;winmm.lib;comctl32.lib;libmysql.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>wsock32.lib;winmm.lib;comctl32.lib;libmysql.lib;libcurl.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <AdditionalLibraryDirectories>$(SolutionDir)\lib;</AdditionalLibraryDirectories>

--- a/blakserv/block.h
+++ b/blakserv/block.h
@@ -16,15 +16,15 @@
 typedef struct block_node_struct
 {
    int iExpires;
-   struct in_addr iaPeer;
+   struct in6_addr iaPeer;
    struct block_node_struct *next;
 } block_node;
 
-void AddBlock(int iSeconds, struct in_addr* piaPeer);
-void DeleteBlock(struct in_addr* piaPeer);
+void AddBlock(int iSeconds, struct in6_addr* piaPeer);
+void DeleteBlock(struct in6_addr* piaPeer);
 void DeleteAllBlocks(void);
 
-bool CheckBlockList(struct in_addr* piaPeer);
+bool CheckBlockList(struct in6_addr* piaPeer);
 
 void BuildBannedIPBlocks( char *filename );
 

--- a/blakserv/config.c
+++ b/blakserv/config.c
@@ -68,7 +68,7 @@ config_table_type config_table[] =
 { SOCKET_GROUP,           F, "[Socket]",      CONFIG_GROUP, "" },
 { SOCKET_PORT,            F, "Port",          CONFIG_INT,   "5959" },
 { SOCKET_MAINTENANCE_PORT,F, "MaintenancePort",CONFIG_INT,  "9998" },
-{ SOCKET_MAINTENANCE_MASK,F, "MaintenanceMask",CONFIG_STR,  "208.192.72.0" },
+{ SOCKET_MAINTENANCE_MASK,F, "MaintenanceMask",CONFIG_STR,  "::ffff:127.0.0.1" },
 { SOCKET_DNS_LOOKUP,      T, "DNSLookup",     CONFIG_BOOL,  "No" },
 { SOCKET_NAGLE,           F, "Nagle",         CONFIG_BOOL,  "Yes" },
 { SOCKET_BLOCK_TIME,      T, "BlockTime",     CONFIG_INT,   "300" }, /* seconds */

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -518,7 +518,8 @@ void StartAsyncSocketAccept(SOCKET sock,int connection_type)
 		eprintf("StartAsyncSocketAccept got error %i\n",val);
 }
 
-/* this is executed in our thread, actually */
+/* this is executed in our thread, actually.
+   this needs modifications to work with IPv6 */
 HANDLE StartAsyncNameLookup(char *peer_addr,char *buf)
 {
 	HANDLE ret_val;

--- a/blakserv/makefile
+++ b/blakserv/makefile
@@ -12,7 +12,7 @@ BLAKSERVLINKFLAGS = /STACK:0x180000 /map /debug /SUBSYSTEM:WINDOWS",5.01"
 
 SOURCEDIR = .
 
-LIBS = gdi32.lib user32.lib wsock32.lib winmm.lib comctl32.lib libmysql.lib libcurl.lib
+LIBS = gdi32.lib user32.lib wsock32.lib winmm.lib comctl32.lib libmysql.lib libcurl.lib ws2_32.lib
 
 OBJS =  \
 	$(OUTDIR)\main.obj \

--- a/blakserv/session.c
+++ b/blakserv/session.c
@@ -166,14 +166,6 @@ session_node * GetSessionByID(int session_id)
 		return NULL;
 }
 
-int GetIPBySessionId(int session_id)
-{
-   if ((num_sessions > 0) && (session_id <= num_sessions))
-      return sessions[session_id].conn.addr.s_addr;
-      
-   return 0;
-}
-
 session_node * GetSessionByAccount(account_node *a)
 {
 	int i;

--- a/blakserv/session.h
+++ b/blakserv/session.h
@@ -55,7 +55,7 @@ typedef struct
    
    char name[100];
 
-   struct in_addr addr;
+   struct in6_addr addr;
 } connection_node;
 
 typedef struct
@@ -173,7 +173,6 @@ void ForEachSession(void (*callback_func)(session_node *s));
 int GetUsedSessions(void);
 const char * GetStateName(session_node *s);
 session_node *GetSessionByID(int session_id);
-int GetIPBySessionId(int session_id);
 void SetSessionState(session_node *s,int state);
 void SetSessionTimer(session_node *s,int seconds);
 void ClearSessionTimer(session_node *s);

--- a/blakserv/synched.c
+++ b/blakserv/synched.c
@@ -302,11 +302,21 @@ void SynchedProtocolParse(session_node *s,client_msg *msg)
 }
 
 int num_with_same_ip;
-struct in_addr check_addr;
+struct in6_addr check_addr;
 void CheckIPAddress(session_node *s)
 {
-   if (s->conn.addr.s_addr == check_addr.s_addr)
-      ++num_with_same_ip;
+	BOOL equal = 1;
+	for (int i = 0; i < sizeof(check_addr.u.Byte); i++)
+	{
+		if (s->conn.addr.u.Byte[i] != check_addr.u.Byte[i])
+		{
+			equal = 0;
+			break;
+		}
+	}
+	
+	if (equal)
+		++num_with_same_ip;
 }
 
 void SynchedAcceptLogin(session_node *s,char *name,char *password)

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -10134,13 +10134,37 @@ messages:
       ClearTempString();
       
       AppendTempString(Nth(lIP,1));
-      AppendTempString(".");
+      AppendTempString(":");
       AppendTempString(Nth(lIP,2));
-      AppendTempString(".");
+      AppendTempString(":");
       AppendTempString(Nth(lIP,3));
-      AppendTempString(".");
+      AppendTempString(":");
       AppendTempString(Nth(lIP,4));
-      
+      AppendTempString(":");
+      AppendTempString(Nth(lIP,5));
+      AppendTempString(":");
+      AppendTempString(Nth(lIP,6));
+      AppendTempString(":");
+      AppendTempString(Nth(lIP,7));
+      AppendTempString(":");
+      AppendTempString(Nth(lIP,8));
+      AppendTempString(":");
+      AppendTempString(Nth(lIP,9));
+      AppendTempString(":");
+      AppendTempString(Nth(lIP,10));
+      AppendTempString(":");      
+      AppendTempString(Nth(lIP,11));
+      AppendTempString(":");
+      AppendTempString(Nth(lIP,12));
+      AppendTempString(":");
+      AppendTempString(Nth(lIP,13));
+      AppendTempString(":");
+      AppendTempString(Nth(lIP,14));
+      AppendTempString(":");
+      AppendTempString(Nth(lIP,15));
+      AppendTempString(":");
+      AppendTempString(Nth(lIP,16));
+
       SetString(sReturn,GetTempString());
       
       return sReturn;

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -7638,6 +7638,18 @@ messages:
                AND Nth(lIP,2) = Nth(j,2)
                AND Nth(lIP,3) = Nth(j,3)
                AND Nth(lIP,4) = Nth(j,4)
+               AND Nth(lIP,5) = Nth(j,5)
+               AND Nth(lIP,6) = Nth(j,6)
+               AND Nth(lIP,7) = Nth(j,7)
+               AND Nth(lIP,8) = Nth(j,8)
+               AND Nth(lIP,9) = Nth(j,9)
+               AND Nth(lIP,10) = Nth(j,10)
+               AND Nth(lIP,11) = Nth(j,11)
+               AND Nth(lIP,12) = Nth(j,12)
+               AND Nth(lIP,13) = Nth(j,13)
+               AND Nth(lIP,14) = Nth(j,14)
+               AND Nth(lIP,15) = Nth(j,15)
+               AND Nth(lIP,16) = Nth(j,16)
             {
                bFound = TRUE;
             }


### PR DESCRIPTION
Changes:
Blakserv is now initializing an IPv6 socket with IPv4 support ("dual stack socket"), rather than an IPv4 socket only. IPv6 addresses have 16 bytes (128-Bit) rather than the 4 bytes (32-Bit) of IPv4. Connected IPv4 addresses are also written in IPv6 notation.

Examples of connected IPv4 clients:

    ::ffff:127.0.0.1 (localhost IPv4 connection)
    ::ffff:153.25.125.2 (external IPv4 connection)

As you can see this is a mix of hexadecimal (ffff) IPv6 and decimal (127) IPv4 notation.
It is recommended to keep the notation to this in files like "banned.txt" or console commands. However internally these are all represented by 16 bytes (no matter which separator char is used).

So the GetIPString() KOD function will always return a possibly slighty different notation, like:

    0:0:0:0:0:0:0:0:0:0:255:255:127:0:0:1 (localhost IPv4 connection)

Note: There are no changes on the legacy clientside yet, the OgreClient however is able to successfully connect using IPv6.
