### PR TITLE
Moving truth and spellbane to a more reasonable place

### DIFF
--- a/kod/object/passive/spell/radiusench/jala/hinder/truth.kod
+++ b/kod/object/passive/spell/radiusench/jala/hinder/truth.kod
@@ -38,7 +38,7 @@ classvars:
    viSpell_num = SID_TRUTH
 
    viSchool = SS_JALA
-   viSpell_level = 1
+   viSpell_level = 4
 
    viHinderedSchool = SS_RIIJA
 

--- a/kod/object/passive/spell/radiusench/jala/spelbane.kod
+++ b/kod/object/passive/spell/radiusench/jala/spelbane.kod
@@ -53,7 +53,7 @@ classvars:
 
    viSpell_num = SID_SPELLBANE
    viSchool = SS_JALA
-   viSpell_level = 3
+   viSpell_level = 5
    viBaseRange = 2
 
    viMana = 12          % Mana is amount used upon inititiation


### PR DESCRIPTION
This change is to both organize Jala and make two spells more usefull. Curedntly truth (the hinder spell for riija) is level one, being level one its sp cannot reach a useable level while wearing pvp appropriate gear. Moving this spell up two levels will help it compete with the so of riija spells. Spellbane is also being moved up two levels for similar reasons, the previous change to Jala's range makes this spell more effective on its own so moving it to level five (previously in three) so that this spells level will match its power and usefulness. Spellbane is more appropriately placed in level five. With these two moves Jala's spells per level will move from: 4,3,5,2,2,1 to a much better looking: 3,3,4,3,3,1.