### PR TITLE
Allow GetTimeZoneOffset() to return correct DST offset.

### DIFF
--- a/blakserv/time.c
+++ b/blakserv/time.c
@@ -46,8 +46,10 @@ int GetTimeZoneOffset()
       bprintf("GetTimeZoneOffset got invalid timezone data, returning 0.");
       return 0;
    }
-
-   return (int)t1.Bias * 60;
+   if (retval == TIME_ZONE_ID_DAYLIGHT)
+      return (int)(t1.Bias + t1.DaylightBias) * 60;
+   else
+      return (int)t1.Bias * 60;
 #else
    // Need to implement timezone offset for Linux.
    return 0;


### PR DESCRIPTION
Function needs to return DaylightBias instead of Bias if DST is active.