### PR TITLE
Small patcher beautification

### DIFF
--- a/patcher/ClientPatcher/ClientPatchForm.Designer.cs
+++ b/patcher/ClientPatcher/ClientPatchForm.Designer.cs
@@ -353,7 +353,7 @@
             this.Controls.Add(this.btnPlay);
             this.Controls.Add(this.pbProgress);
             this.Controls.Add(this.txtLog);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "ClientPatchForm";
             this.Text = "OpenMeridian Client Patcher";

--- a/patcher/ClientPatcher/ClientPatchForm.Designer.cs
+++ b/patcher/ClientPatcher/ClientPatchForm.Designer.cs
@@ -136,9 +136,9 @@
             this.gbOptions.Controls.Add(this.btnStartModify);
             this.gbOptions.Controls.Add(this.btnRemove);
             this.gbOptions.Controls.Add(this.btnAdd);
-            this.gbOptions.Location = new System.Drawing.Point(300, 12);
+            this.gbOptions.Location = new System.Drawing.Point(300, 14);
             this.gbOptions.Name = "gbOptions";
-            this.gbOptions.Size = new System.Drawing.Size(522, 321);
+            this.gbOptions.Size = new System.Drawing.Size(520, 318);
             this.gbOptions.TabIndex = 10;
             this.gbOptions.TabStop = false;
             this.gbOptions.Text = "Options";

--- a/patcher/ClientPatcher/ClientPatchForm.Designer.cs
+++ b/patcher/ClientPatcher/ClientPatchForm.Designer.cs
@@ -353,6 +353,7 @@
             this.Controls.Add(this.btnPlay);
             this.Controls.Add(this.pbProgress);
             this.Controls.Add(this.txtLog);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "ClientPatchForm";
             this.Text = "OpenMeridian Client Patcher";

--- a/patcher/ClientPatcher/ClientPatchForm.Designer.cs
+++ b/patcher/ClientPatcher/ClientPatchForm.Designer.cs
@@ -90,7 +90,8 @@
             this.label1.Text = "Server Selection";
             // 
             // ddlServer
-            // 
+            //
+            this.ddlServer.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ddlServer.FormattingEnabled = true;
             this.ddlServer.Location = new System.Drawing.Point(15, 57);
             this.ddlServer.Name = "ddlServer";


### PR DESCRIPTION
Makes 3 changes to the patcher:

1) Sets the *DropDownStyle* of the "Select Server" combobox to *DropDownList*. This will prevent users from typing in there. This mode fits better for its purpose I think.

2) Disable resizing of the main-window by setting *FormBorderStyle* to *FixedSingle*. Since the elements in the window are not designed with "docking" (don't autosize), this is probably the better variant for now.

3) Slightly adjust the size of the "Options" to not overlap with container lines.