### PR TITLE
Purge revamp - remove spellpower instead of buffs directly.

### DIFF
--- a/kod/object/passive/spell/persench.kod
+++ b/kod/object/passive/spell/persench.kod
@@ -64,6 +64,11 @@ classvars:
 
    viPersonal_ench = TRUE
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 100
+
    viDefensive = FALSE
    viOffensive = FALSE
    viResistanceType = 0
@@ -237,6 +242,11 @@ messages:
    GetStateValue()
    {
       return $;
+   }
+
+   GetPurgeFactor()
+   {
+      return viPurgeFactor;
    }
 
    GetLastCall()

--- a/kod/object/passive/spell/persench/anon.kod
+++ b/kod/object/passive/spell/persench/anon.kod
@@ -60,6 +60,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 80
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/bless.kod
+++ b/kod/object/passive/spell/persench/bless.kod
@@ -68,6 +68,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 80
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/cloak.kod
+++ b/kod/object/passive/spell/persench/cloak.kod
@@ -57,6 +57,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 75
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/deflect.kod
+++ b/kod/object/passive/spell/persench/deflect.kod
@@ -81,6 +81,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 40
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/denial.kod
+++ b/kod/object/passive/spell/persench/denial.kod
@@ -59,6 +59,10 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 5
 
 messages:
 

--- a/kod/object/passive/spell/persench/detevil.kod
+++ b/kod/object/passive/spell/persench/detevil.kod
@@ -63,6 +63,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 90
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/detgood.kod
+++ b/kod/object/passive/spell/persench/detgood.kod
@@ -64,6 +64,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 80
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/dethlink.kod
+++ b/kod/object/passive/spell/persench/dethlink.kod
@@ -65,6 +65,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 40
+
 messages:
 
    ResetReagents()
@@ -76,6 +81,13 @@ messages:
       return;
    }
 
+   GetStateValue(iSpellpower=$,target=$,who=$)
+   {
+      Send(target,@AddAttackModifier,#what=self);
+
+      return iSpellpower;
+   }
+
    CastSpell(who=$,iSpellPower=0,lTargets=$)
    {
       % If it's only self cast, spoof self as target for following code
@@ -85,13 +97,6 @@ messages:
       }
 
       propagate;
-   }
-
-   GetStateValue(iSpellpower=$,target=$,who=$)
-   {
-      Send(target,@AddAttackModifier,#what=self);
-
-      return iSpellpower;
    }
 
    GiveKilledBenefits(caster=$,victim=$)

--- a/kod/object/passive/spell/persench/detinvis.kod
+++ b/kod/object/passive/spell/persench/detinvis.kod
@@ -52,6 +52,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 30
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/eagleyes.kod
+++ b/kod/object/passive/spell/persench/eagleyes.kod
@@ -78,6 +78,11 @@ properties:
    % give the player a chance to completely resist a blinding spell?
    piResistPercent = 5
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 30
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/eavesdrp.kod
+++ b/kod/object/passive/spell/persench/eavesdrp.kod
@@ -60,6 +60,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 5
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/focus.kod
+++ b/kod/object/passive/spell/persench/focus.kod
@@ -56,6 +56,11 @@ classvars:
    vbCanCastOnOthers = FALSE
 
 properties:
+ 
+ % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 5
 
 messages:
 

--- a/kod/object/passive/spell/persench/freeact.kod
+++ b/kod/object/passive/spell/persench/freeact.kod
@@ -76,6 +76,11 @@ properties:
    % give the player a chance to completely resist hold?
    piResistPercent = 15
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 40
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/gaze.kod
+++ b/kod/object/passive/spell/persench/gaze.kod
@@ -72,6 +72,10 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 10
 
 messages:
 

--- a/kod/object/passive/spell/persench/gort.kod
+++ b/kod/object/passive/spell/persench/gort.kod
@@ -78,6 +78,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 20
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/haste.kod
+++ b/kod/object/passive/spell/persench/haste.kod
@@ -66,6 +66,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 90
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/invis.kod
+++ b/kod/object/passive/spell/persench/invis.kod
@@ -64,6 +64,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 20
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/karahol.kod
+++ b/kod/object/passive/spell/persench/karahol.kod
@@ -75,6 +75,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 20
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/mshield.kod
+++ b/kod/object/passive/spell/persench/mshield.kod
@@ -59,6 +59,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 50
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/nightv.kod
+++ b/kod/object/passive/spell/persench/nightv.kod
@@ -54,6 +54,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 80
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/resist.kod
+++ b/kod/object/passive/spell/persench/resist.kod
@@ -34,6 +34,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 40
+
 messages:
 
    CanPayCosts(who=$,lTargets=$)

--- a/kod/object/passive/spell/persench/resist/resmagic.kod
+++ b/kod/object/passive/spell/persench/resist/resmagic.kod
@@ -54,6 +54,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 30
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/respois.kod
+++ b/kod/object/passive/spell/persench/respois.kod
@@ -61,6 +61,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 80
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/shadform.kod
+++ b/kod/object/passive/spell/persench/shadform.kod
@@ -59,6 +59,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 60
+
 messages:
 
    ResetReagents()

--- a/kod/object/passive/spell/persench/strength.kod
+++ b/kod/object/passive/spell/persench/strength.kod
@@ -66,6 +66,11 @@ classvars:
 
 properties:
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 80
+
 messages:
 
    ResetReagents()
@@ -76,7 +81,6 @@ messages:
 
       return;
    }
-
 
    GetStateValue(who=$,iSpellPower=0,Target=$)
    {

--- a/kod/object/passive/spell/persench/touchatk.kod
+++ b/kod/object/passive/spell/persench/touchatk.kod
@@ -104,6 +104,11 @@ properties:
    plPrerequisites = $
    plReagents = $
 
+   % The effectiveness of purge on the target spell as a percentage.
+   % 100 will cause purge to remove its entire spellpower, 0 will
+   % prevent purge from removing this spell.
+   viPurgeFactor = 15
+
 messages:
 
    ImproveStroke(who=$,target=$)

--- a/kod/object/passive/spell/purge.kod
+++ b/kod/object/passive/spell/purge.kod
@@ -31,7 +31,8 @@ resources:
    Purge_name_rsc = "purge"
    Purge_icon_rsc = ipurge.bgf
    Purge_desc_rsc = \
-      "Strips helpful personal enchantments off of the target. "
+      "Reduces the effectiveness of the target's helpful personal enchantments.  "
+      "With enough power, it can even remove the enchantment completely.  "
       "Requires five emeralds and two purple mushrooms to cast."
    
    Purge_on = \
@@ -66,6 +67,9 @@ classvars:
 
 properties:
 
+   pbPurgeNoRemove = FALSE
+   pbRemoveWithPercentChance = FALSE
+
 messages:
 
    ResetReagents()
@@ -85,6 +89,8 @@ messages:
    CanPayCosts(who=$,lTargets=$,bItemCast=FALSE)
    {
       local target, i, lEnchantment, bHasEnchantment, oSpell;
+
+      bHasEnchantment = FALSE;
 
       % Can cast spell if the 1 target item is a user
       if Length(lTargets) <> 1
@@ -108,7 +114,6 @@ messages:
 
       % The target must have an enchantment
       lEnchantment = Send(target,@GetEnchantmentList);
-      bHasEnchantment = IsClass(who,&DM);
 
       if lEnchantment <> $
       {
@@ -128,7 +133,7 @@ messages:
 
       if NOT bHasEnchantment
       {
-         Send(who,@MsgSendUser,#message_rsc=Purge_not_enchanted, 
+         Send(who,@MsgSendUser,#message_rsc=Purge_not_enchanted,
                #parm1=Send(target,@GetDef),#parm2=Send(target,@GetName));
 
          return FALSE;
@@ -214,65 +219,91 @@ messages:
    }
 
    DoPurge(who=$,iChance=$)
-   "Remove positive enchantments on who with a given chance to remove each one."
+   "Recasts the target's PEs at the new spellpower, or removes them at/below 0 spellpower."
    {
-      local iNumEnchantments, lEnchantments, iModifiedChance, oEnchantment,
-            oSpell, lList, bRemovedSomething;
+      local i, lEnchantments, iSpellPower, oTimer, iTime, oSpell, iCastPower, iNewPower, bRemovedSomething;
+
+      iSpellPower = iChance;
 
       % Can't do this to nobody or to non-players.
-      if who = $
-         OR NOT IsClass(who,&Player)
+      if who = $ OR NOT IsClass(who,&Player)
       {
          return FALSE;
       }
 
-      % Chance of $ means that we want to remove it all.
-      if iChance = $
+      bRemovedSomething = FALSE;
+
+      % A spellpower of $ or 100 means that we want to remove it all.
+      if iSpellPower = $
+         OR iSpellPower = 100
       {
          Send(who,@RemoveAllPersonalEnchantments);
+         bRemovedSomething = TRUE;
 
          return TRUE;
       }
 
-      bRemovedSomething = FALSE;
-      lEnchantments = $;
-      lList = Send(who,@GetEnchantmentList);
+      lEnchantments = Send(who,@GetEnchantmentList);
 
-      foreach oEnchantment in lList
+      foreach i in lEnchantments
       {
-         oSpell = Nth(oEnchantment,2);
+         oSpell = Nth(i,2);
 
-         if Send(oSpell,@IsPersonalEnchantment)
+         if IsClass(oSpell,&PersonalEnchantment)
             AND Send(oSpell,@CanBeRemovedByPlayer)
             AND NOT Send(oSpell,@IsHarmful)
          {
-            lEnchantments = cons(oSpell,lEnchantments);
-         }
-      }
+            % Get the timer, so we can put it back on later.
+            oTimer = Nth(i,1);
+            iTime = GetTimeRemaining(oTimer);
 
-      iNumEnchantments = length(lEnchantments);
+            % Get the cast power from the target, as it checks the right
+            % location in the list.
+            iCastPower = Send(who,@GetCastPower,#what=oSpell);
 
-      % Anti-clumpy code: If there is at least two enchantments on a player
-      % and the chance to dispell is greater than 60%, then auto-remove one
-      % enchantment.
-      if iNumEnchantments >= MIN_ENCHANTMENTS_FOR_AUTOREMOVE
-         AND iChance >= MIN_CHANCE_FOR_AUTOREMOVE
-      {
-         oEnchantment = Nth(lEnchantments,random(1,iNumEnchantments));
-         Send(who,@RemoveEnchantment,#what=oEnchantment);
-         lEnchantments = DelListElem(lEnchantments,oEnchantment);
-         iNumEnchantments = iNumEnchantments - 1;
-         bRemovedSomething = TRUE;
-      }
+            % Calculate the new spellpower and time of the enchantment.
+            iNewPower = iCastPower - (iSpellPower * Send(oSpell,@GetPurgeFactor)) / 100;
 
-      iModifiedChance = iChance;
+            % If purge removing buffs is turned off, bind the new spellpower at 1
+            if pbPurgeNoRemove
+               OR pbRemoveWithPercentChance
+            {
+               iNewPower = Bound(iNewPower,1,99);
+            }
+            else
+            {
+               iNewPower = Bound(iNewPower,$,99);
+            }
 
-      foreach oEnchantment in lEnchantments
-      {
-         if iChance = $ OR iModifiedChance > random(1,100)
-         {
-            Send(who,@RemoveEnchantment,#what=oEnchantment);
-            bRemovedSomething = TRUE;
+            % Start the new enchantment with the time left and the new state,
+            % but only if iNewPower is greater than 0.
+            if iNewPower > 0
+            {
+               % If we have percent chance removal instead, we either remove the buff or we don't.
+               if pbRemoveWithPercentChance = TRUE
+               {
+                  if ((iSpellPower * Send(oSpell,@GetPurgeFactor))/100) > Random(1,100)
+                  {
+                     Send(who,@RemoveEnchantment,#what=oSpell,#report=TRUE);
+                     bRemovedSomething = TRUE;
+                  }
+
+                  continue;
+               }
+
+               % Remove the current enchantment, but don't report.
+               Send(who,@RemoveEnchantment,#what=oSpell,#report=FALSE);
+
+               Send(who,@StartEnchantment,#what=oSpell,#iSpellPower=iNewPower,
+                     #state=(Send(oSpell,@GetStateValue,#who=who,#iSpellPower=iNewPower,#target=who)),
+                     #time=iTime,#lastcall=Send(oSpell,@GetLastCall),#addIcon=Send(oSpell,@GetAddIcon));
+            }
+            else
+            {
+               % Remove the current enchantment and report.
+               Send(who,@RemoveEnchantment,#what=oSpell,#report=TRUE);
+               bRemovedSomething = TRUE;
+            }
          }
       }
 


### PR DESCRIPTION
This version of purge is really three different versions that can be enabled via object properties.

Purge 1: The default setting uses purge's spellpower to determine how much spellpower to take away from the target's buffs. Each buff has a viPurgeFactor which is used as a percentage effectiveness of purge. For instance Bless has a factor of 80, so 80% of the Purge spellpower is taken from the buff, and the buff is recast on the target with that spellpower and the remaining duration when Purge was cast. When target buff spellpower hits 0, the buff is removed.

Purge 2: Same as above, but the buff removal can be turned off by setting pbPurgeNoRemove to TRUE in-game. This will mean Purge doesn't remove buffs at all, but instead can take them to 1 spellpower, and the amount of Purges the caster uses is dependent on how much time, or mana they have and how low they want to force the target's buffs to go. Perhaps not as good an option as Purge 1, but here for testing.

Purge 3: This version can be turned on by setting pbRemoveWithPercentChance to TRUE (this overrides the setting for the second version of Purge) in-game and functions much like Purge does on 103 in that buffs are either removed or they aren't. Purge spellpower is multiplied by viPurgeFactor which determines the % chance that the buff will be removed. Using Bless again as the example, a 99 spellpower Purge has a 79% chance of removing Bless, and a 75 spellpower Purge has a 60% chance.

Personally I want to use the default (Purge 1) but I have included the other two as testing options.