### PR TITLE
Temporary Enemy & Ally System

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -3558,3 +3558,7 @@
    % Survival options
    OPT_NATURAL = 1    % Rooms with natural monster spawn only
    OPT_PVP_ON = 2     % Players can fight
+
+   % Combat grouping constants
+   CGROUP_ALLY = 1
+   CGROUP_ENEMY = 2

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4709,6 +4709,7 @@ messages:
                }
                Send(self,@SetPlayerFlag,#flag=PFLAG_OUTLAW,#value=TRUE);
                Send(self,@EvaluatePKStatus,#dbug=TRUE);
+               Send(self,@ClearAllCombatGroupings);
             }
          }
       }
@@ -6049,7 +6050,9 @@ messages:
                   Send(self,@CheckFactionAttack,#what=what);
 
                   % Apply penalties for someone NOT holding a token
+                  % and NOT in an Enemy combat group
                   if Send(what,@FindUsing,#class=&Token) = $
+                     AND NOT Send(self,@IsInCombatGroup,#who=what)
                   {
                      if (piFlags & PFLAG_MURDERER)
                      {
@@ -6062,6 +6065,7 @@ messages:
                         Send(self,@SetPlayerFlag,#flag=PFLAG_MURDERER,#value=TRUE);
                         Send(self,@SetPlayerFlag,#flag=PFLAG_OUTLAW,#value=FALSE);
                         Send(self,@EvaluatePKStatus,#dbug=TRUE);
+                        Send(self,@ClearAllCombatGroupings);
                      }
 
                      % Does the lucky murderer win a Revenant?
@@ -15031,7 +15035,18 @@ messages:
       {
          return;
       }
-      
+
+      % This system only matters when both players are innocent.
+      % Oranges/reds can be attacked by anyone.
+      % With their safeties off, they can also attack anyone.
+      if Send(who,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+         OR Send(who,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+         OR (piFlags & PFLAG_MURDERER)
+         OR (piFlags & PFLAG_OUTLAW)
+      {
+         return;
+      }
+
       if type=CGROUP_ENEMY
       {
          % Refresh enemy timer if they're already there

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -803,6 +803,18 @@ resources:
    bad_line_of_sight = \
       "Your hindered line of sight makes a successful hit more difficult."
 
+   combat_group_add_ally = \
+      "The law recognizes the assistance of %s on your behalf."
+   combat_group_add_enemy = \
+      "The law recognizes your temporary grievance with %s!"
+   combat_group_added_ally = \
+      "The law recognizes your assistance on the behalf of %s."
+   combat_group_added_enemy = \
+      "The law recognizes that %s has a temporary grievance with you!"
+   combat_group_remove_enem = \
+      "The time for your grievance with %s has passed."
+   combat_group_removed_enem = \
+      "The grievance %s held with you has expired under the eyes of the law."
       
    pvp_notify_wav = gong.wav
 
@@ -1098,6 +1110,55 @@ properties:
    piRemainingPhaseTime = 60000 * 8
    ptCanPhaseTimer = $
 
+   % Combat allies and enemies lists
+   % These keep track of who has helped or hindered in the last ten minutes.
+   % Greatly simplifies combat rules. If you interfere, you're in the fight.
+   % Those you interfere with have initiative on you.
+   % E.g. you major heal someone who is engaged in 1v1.
+   % His opponent may strike you without going outlaw.
+   % You may NOT strike him the same way just yet.
+   %    But once he strikes you, then you are free to fight back.
+   % 
+   % Specifically:
+   %
+   % Healing or buffing a stranger makes you count as their ally.
+   %    It also adds you as an enemy to all of their current enemies.
+   % Healing or buffing an ally refreshes the ally timer.
+   % Healing or buffing an enemy makes you count as their ally AND their enemy.
+   %    This will prevent any silly gaming of the system, and only hinder you.
+   %    It's entirely possible your own guild or soldier allies will 
+   %    turn on you and purposely or accidentally kill you.
+   %
+   % Hitting a stranger makes you their enemy.
+   % Hitting a stranger or enemy also gives their enemies to you as allies.
+   %    Therefore, your beneficial AEs/REs will help others who are fighting
+   %    your current enemy. E.g. you are a Jonas soldier fighting alongside a
+   %    Jonas soldier against a Duke soldier. You are not guilded with your
+   %    Jonas partner, but hitting the Duke soldier will give you the Jonas
+   %    partner as an ally, and he will then receive ally benefits from you.
+   %    This applies mostly to Radius Enchantments (both styles).
+   % Hitting a stranger or enemy also gives their allies to you as enemies.
+   %    Therefore, you can attack someone who has healed or buffed your enemy.
+   %    E.g. a 70 hp mule heals a Duke soldier. If you, as a Jonas soldier,
+   %    hit the Duke soldier, you can then also hit the 70 hp mule.
+   %    The 70 hp mule cannot attack you, though, until you attack him.
+   %    If you don't want to get attacked by random alts, be careful of how
+   %    you apply area attacks. Players can jump in by healing your enemy,
+   %    getting hit by you, and then attacking you. (this is, however,
+   %    preferable to a system in which bystanders can heal enemies without
+   %    repercussion).
+   %
+   % Don't understand it? No problem. Keep your safety on and expect
+   %    a beatdown if you interfere with a fight - and you'll be correct.
+   %
+   % Stored as [player, timer, indirect boolean]
+   % Timer is refreshed upon any new action.
+   plAllies = $
+   plEnemies = $
+   
+   piAllyTimeOut = 600000
+   piEnemyTimeOut = 600000
+
 messages:
 
    Constructor()
@@ -1190,6 +1251,8 @@ messages:
          DeleteTimer(ptBondedItemReport);
          ptBondedItemReport = $;
       }
+
+      Send(self,@ClearAllCombatGroupings);
 
       Send(SYS,@SystemRemoveFromChampionLists,#oldchamp = self);
       Send(Send(SYS,@GetLibrary),@DeleteCompletedQuest,#who=self,#id=-1);
@@ -4161,7 +4224,7 @@ messages:
    "Will not let a person attack someone who isn't pkill_enabled."
    "Will not let a person who isn't pkill_enabled attack another person."
    {
-      local oRoom, oGuild, oVictimGuild;
+      local oRoom, oGuild, oVictimGuild, i;
 
       % Default location to check is where we are.
       oRoom = poOwner;
@@ -4465,11 +4528,60 @@ messages:
          }
       }
 
+      % Victim was previously entered into enemy combat group
+      % That means we can continue fighting WITHOUT checking
+      % status and safety! This will allow us to attack players
+      % we could not normally attack because they helped our enemies!
+      % Placement here gives all guild, room, arena etc rules priority.
+      % No funky combat where it shouldn't be happening.
+      if actual
+         AND victim <> self
+         AND Send(self,@IsInCombatGroup,#who=victim)
+      {
+         Send(victim,@AddCombatGrouping,#who=self);
+         Send(self,@AddCombatGrouping,#who=victim);
+
+         foreach i in Send(victim,@GetCombatGroup)
+         {
+            Send(self,@AddCombatGrouping,#who=i,#type=CGROUP_ALLY,
+                  #indirect=TRUE);
+         }
+         foreach i in Send(victim,@GetCombatGroup,#type=CGROUP_ALLY)
+         {
+            Send(self,@AddCombatGrouping,#who=i,#indirect=TRUE);
+         }
+
+         return TRUE;
+      }
+
       % Finally, check status and safety.
       if NOT Send(self,@CheckStatusAndSafety,#victim=victim,
                   #report=report,#actual=actual,#minion=minion)
       {
          return FALSE;
+      }
+      
+      % Successful attack without any special conditions (arena, etc)
+      % Victim has been cleared for combat by status and safety.
+      % Add self as an enemy to victim's combat groupings
+      % Add victim as an enemy to our combat groupings
+      % Add victim's enemies to our allies list
+      % Add victim's allies to our enemies list
+      if actual
+         AND victim <> self
+      {
+         Send(victim,@AddCombatGrouping,#who=self);
+         Send(self,@AddCombatGrouping,#who=victim);
+
+         foreach i in Send(victim,@GetCombatGroup)
+         {
+            Send(self,@AddCombatGrouping,#who=i,#type=CGROUP_ALLY,
+                  #indirect=TRUE);
+         }
+         foreach i in Send(victim,@GetCombatGroup,#type=CGROUP_ALLY)
+         {
+            Send(self,@AddCombatGrouping,#who=i,#indirect=TRUE);
+         }
       }
 
       % Stop any rescue attempts if the user makes an attack.
@@ -11904,6 +12016,8 @@ messages:
          }
       }
 
+      Send(self,@ClearAllCombatGroupings);
+
       % Reset death costs to 0.
       piDeathCost = 0;
 
@@ -14905,6 +15019,283 @@ messages:
       }
 
       propagate;
+   }
+
+   AddCombatGrouping(who=$,type=CGROUP_ENEMY,indirect=FALSE)
+   {
+      local lAlly, lEnemy;
+
+      if who = $
+         OR who = self
+         OR IsClass(who,&DM)
+      {
+         return;
+      }
+      
+      if type=CGROUP_ENEMY
+      {
+         % Refresh enemy timer if they're already there
+         if plEnemies <> $
+            AND Send(self,@IsInCombatGroup,#who=who)
+         {
+            foreach lEnemy in plEnemies
+            {
+               if First(lEnemy) = who
+               {
+                  if IsTimer(Nth(lEnemy,2))
+                  {
+                     DeleteTimer(Nth(lEnemy,2));
+                  }
+                  SetNth(lEnemy,2,$);
+                  SetNth(lEnemy,2,CreateTimer(self,@RemoveCombatGrouping,
+                        piEnemyTimeOut));
+                  return;
+               }
+            }
+         }
+      
+         plEnemies = Cons([who, CreateTimer(self,@RemoveCombatGrouping,
+                           piEnemyTimeOut), indirect],plEnemies);
+
+         if indirect
+         {
+            Send(self,@MsgSendUser,#message_rsc=combat_group_add_enemy,
+                  #parm1=Send(who,@GetName));
+            Send(who,@MsgSendUser,#message_rsc=combat_group_added_enemy,
+                  #parm1=Send(self,@GetName));
+
+            if Send(who,@GetOwner) = poOwner
+            {
+               Post(self,@SomethingChanged,#what=who);
+            }
+         }
+         
+         return;
+      }
+
+      if type=CGROUP_ALLY
+      {
+         % Refresh ally timer if they're already there
+         if plAllies <> $
+            AND Send(self,@IsInCombatGroup,#who=who,#type=CGROUP_ALLY)
+         {
+            foreach lAlly in plAllies
+            {
+               if First(lAlly) = who
+               {
+                  if IsTimer(Nth(lAlly,2))
+                  {
+                     DeleteTimer(Nth(lAlly,2));
+                  }
+                  SetNth(lAlly,2,$);
+                  SetNth(lAlly,2,CreateTimer(self,@RemoveCombatGrouping,
+                        piAllyTimeOut));
+                  return;
+               }
+            }
+         }
+      
+         plAllies = Cons([who, CreateTimer(self,@RemoveCombatGrouping,
+                          piAllyTimeOut), indirect],plAllies);
+         
+         if indirect
+         {
+            Send(self,@MsgSendUser,#message_rsc=combat_group_add_ally,
+                  #parm1=Send(who,@GetName));
+            Send(who,@MsgSendUser,#message_rsc=combat_group_added_ally,
+                  #parm1=Send(self,@GetName));
+
+            if Send(who,@GetOwner) = poOwner
+            {
+               Post(self,@SomethingChanged,#what=who);
+            }
+         }
+         
+         return;
+      }
+
+      return;
+   }
+   
+   RemoveCombatGrouping(who=$,timer=$)
+   {
+      local lAlly, lEnemy;
+      
+      if timer <> $
+      {
+         foreach lEnemy in plEnemies
+         {
+            if Nth(lEnemy,2) = timer
+            {
+               % Was this an indirect grievance?
+               % Only report indirects to avoid spam.
+               % Direct grievances should be obvious already.
+               if Nth(lEnemy,3) = TRUE
+               {
+                  Send(self,@MsgSendUser,#message_rsc=combat_group_remove_enem,
+                        #parm1=Send(First(lEnemy),@GetName));
+                  Send(First(lEnemy),@MsgSendUser,
+                        #message_rsc=combat_group_removed_enem,
+                        #parm1=Send(self,@GetName));
+
+                  if Send(First(lEnemy),@GetOwner) = poOwner
+                  {
+                     Post(self,@SomethingChanged,#what=First(lEnemy));
+                  }
+               }
+
+               SetNth(lEnemy,1,$);
+               SetNth(lEnemy,2,$);
+               plEnemies = DelListElem(plEnemies,lEnemy);
+
+               return;
+            }
+         }
+
+         foreach lAlly in plAllies
+         {
+            if Nth(lAlly,2) = timer
+            {
+               if Send(First(lAlly),@GetOwner) = poOwner
+               {
+                  Post(self,@SomethingChanged,#what=First(lAlly));
+               }
+               SetNth(lAlly,1,$);
+               SetNth(lAlly,2,$);
+               plAllies = DelListElem(plAllies,lAlly);
+               return;
+            }
+         }
+      }
+
+      if who <> $
+      {
+         foreach lEnemy in plEnemies
+         {
+            if First(lEnemy) = who
+            {
+               DeleteTimer(Nth(lEnemy,2));
+               SetNth(lEnemy,1,$);
+               SetNth(lEnemy,2,$);
+               plEnemies = DelListElem(plEnemies,lEnemy);
+
+               if Send(who,@GetOwner) = poOwner
+               {
+                  Post(self,@SomethingChanged,#what=who);
+               }
+
+               return;
+            }
+         }
+
+         foreach lAlly in plAllies
+         {
+            if First(lAlly) = who
+            {
+               DeleteTimer(Nth(lAlly,2));
+               SetNth(lAlly,1,$);
+               SetNth(lAlly,2,$);
+               plAllies = DelListElem(plAllies,lAlly);
+
+               if Send(who,@GetOwner) = poOwner
+               {
+                  Post(self,@SomethingChanged,#what=who);
+               }
+
+               return;
+            }
+         }
+      }
+
+      return;
+   }
+   
+   ClearAllCombatGroupings()
+   {
+      local lAlly, lEnemy;
+      
+      foreach lAlly in plAllies
+      {
+         Send(First(lAlly),@RemoveCombatGrouping,#who=self,#type=CGROUP_ALLY);
+         if IsTimer(Nth(lAlly,2))
+         {
+            DeleteTimer(Nth(lAlly,2));
+         }
+         SetNth(lAlly,1,$);
+         SetNth(lAlly,2,$);
+         plAllies = DelListElem(plAllies,lAlly);
+      }
+
+      foreach lEnemy in plEnemies
+      {
+         Send(First(lEnemy),@RemoveCombatGrouping,#who=self);
+         if IsTimer(Nth(lEnemy,2))
+         {
+            DeleteTimer(Nth(lEnemy,2));
+         }
+         SetNth(lEnemy,1,$);
+         SetNth(lEnemy,2,$);
+         plEnemies = DelListElem(plEnemies,lEnemy);
+      }
+
+      return;
+   }
+   
+   GetCombatGroup(type=CGROUP_ENEMY)
+   {
+      local lAlly, lAllies, lEnemy, lEnemies;
+
+      if type = CGROUP_ENEMY
+      {
+         lEnemies = $;
+         foreach lEnemy in plEnemies
+         {
+            lEnemies = Cons(First(lEnemy),lEnemies);
+         }
+         return lEnemies;
+      }
+
+      if type = CGROUP_ALLY
+      {
+         lAllies = $;
+
+         foreach lAlly in plAllies
+         {
+            lAllies = Cons(First(lAlly),lAllies);
+         }
+         return lAllies;
+      }
+
+      return $;
+   }
+   
+   IsInCombatGroup(who=$, type=CGROUP_ENEMY)
+   {
+      local lEnemy, lAlly;
+      
+      if type = CGROUP_ENEMY
+      {
+         foreach lEnemy in plEnemies
+         {
+            if First(lEnemy) = who
+            {
+               return TRUE;
+            }
+         }
+      }
+
+      if type = CGROUP_ALLY
+      {
+         foreach lAlly in plAllies
+         {
+            if First(lAlly) = who
+            {
+               return TRUE;
+            }
+         }
+      }
+
+      return FALSE;
    }
 
 end

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2812,6 +2812,18 @@ messages:
                }
             }
 
+            % Draw a green halo for any friendly player
+            if Send(self,@IsInCombatGroup,#who=what,#type=CGROUP_ALLY)
+            {
+               iFlags = (iFlags | MM_PLAYER_IS_FRIEND);
+            }
+
+            % Draw a red halo for combat group enemies
+            if Send(self,@IsInCombatGroup,#who=what,#type=CGROUP_ENEMY)
+            {
+               iFlags = (iFlags | MM_PLAYER_IS_ENEMY);
+            }
+
             % Draw a red halo for any attackable player.
             if NOT IsClass(self,&DM)
                AND Send(self,@AllowPlayerAttack,#victim=what,

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1130,7 +1130,7 @@ messages:
    CheckPlayerHelp(who=$, lTargets=$)
    "Checks to see if the player can cast the beneficial spell on said targets."
    {
-      local oObject;
+      local oObject, oEnemy;
 
       % If lTargets is $, then we're casting an room-effect spell, let it go.
       if lTargets <> $
@@ -1174,6 +1174,19 @@ messages:
                     #parm2=Send(oObject,@GetName));
 
                return FALSE;
+            }
+
+            % Successful targeted beneficial spell.
+            % Add us as an ally to the target's combat groupings.
+            % Add us as enemy to all THEIR enemies!
+            if IsClass(oObject,&Player)
+               AND oObject <> who
+            {
+               Send(oObject,@AddCombatGrouping,#who=who,#type=CGROUP_ALLY);
+               foreach oEnemy in Send(oObject,@GetCombatGroup)
+               {
+                  Send(oEnemy,@AddCombatGrouping,#who=who,#indirect=TRUE);
+               }
             }
          }
       }

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -96,6 +96,7 @@ classvars:
    viAffectsEnemies = FALSE     % Hostile, can cause outlaw status
    viAffectsInnocents = FALSE   % Unaffiliated white characters
    viAffectsNewbies = FALSE     % Angeled characters
+   viAffectsCombatAllies = FALSE% Affects those who participate alongside you
 
    viCasterPersist = FALSE      % If true, spell will 'follow' caster between rooms
 
@@ -521,6 +522,12 @@ messages:
       if IsClass(target,&User)
          AND IsClass(source,&User)
       {
+         if viAffectsCombatAllies
+             AND Send(source,@IsInCombatGroup,#who=target,#type=CGROUP_ALLY)
+         {
+            return TRUE;
+         }
+         
          oSourceGuild = Send(source,@GetGuild);
          oTargetGuild = Send(target,@GetGuild);
 

--- a/kod/object/passive/spell/radiusench/antimag.kod
+++ b/kod/object/passive/spell/radiusench/antimag.kod
@@ -74,6 +74,7 @@ classvars:
 
    viAffectsGuildmates = TRUE
    viAffectsEnemies = TRUE
+   viAffectsCombatAllies = TRUE
 
    viCasterPersist = TRUE
 

--- a/kod/object/passive/spell/radiusench/jala/hinder.kod
+++ b/kod/object/passive/spell/radiusench/jala/hinder.kod
@@ -46,6 +46,7 @@ classvars:
 
    viAffectsGuildmates = TRUE
    viAffectsEnemies = TRUE
+   viAffectsCombatAllies = TRUE
 
 properties:
 

--- a/kod/object/passive/spell/radiusench/jala/jig.kod
+++ b/kod/object/passive/spell/radiusench/jala/jig.kod
@@ -63,6 +63,7 @@ classvars:
    viAffectsEnemies = TRUE
    viAffectsNewbies = TRUE
    viAffectsAllies = TRUE
+   viAffectsCombatAllies = TRUE
 
 properties:
 

--- a/kod/object/passive/spell/radiusench/jala/manaconv.kod
+++ b/kod/object/passive/spell/radiusench/jala/manaconv.kod
@@ -62,6 +62,7 @@ classvars:
 
    viAffectsGuildmates = TRUE
    viAffectsEnemies = TRUE
+   viAffectsCombatAllies = TRUE
 
 properties:
 

--- a/kod/object/passive/spell/radiusench/jala/spelbane.kod
+++ b/kod/object/passive/spell/radiusench/jala/spelbane.kod
@@ -64,6 +64,7 @@ classvars:
 
    viAffectsGuildmates = TRUE
    viAffectsEnemies = TRUE
+   viAffectsCombatAllies = TRUE
 
 properties:
 

--- a/kod/object/passive/spell/radiusench/sandstor.kod
+++ b/kod/object/passive/spell/radiusench/sandstor.kod
@@ -83,6 +83,7 @@ classvars:
 
    viAffectsGuildmates = TRUE
    viAffectsEnemies = TRUE
+   viAffectsCombatAllies = TRUE
 
    viCasterPersist = TRUE
    

--- a/kod/object/passive/spell/radiusench/truce.kod
+++ b/kod/object/passive/spell/radiusench/truce.kod
@@ -71,6 +71,7 @@ classvars:
    viAffectsGuildmates = TRUE
    viAffectsEnemies = TRUE
    viAffectsNewbies = TRUE
+   viAffectsCombatAllies = TRUE
 
    viCasterPersist = TRUE
 

--- a/kod/object/passive/spell/radiusench/umbrella.kod
+++ b/kod/object/passive/spell/radiusench/umbrella.kod
@@ -67,6 +67,7 @@ classvars:
 
    viAffectsGuildmates = TRUE
    viAffectsEnemies = TRUE
+   viAffectsCombatAllies = TRUE
 
 properties:
    

--- a/kod/object/passive/spell/radiusench/winds.kod
+++ b/kod/object/passive/spell/radiusench/winds.kod
@@ -76,6 +76,7 @@ classvars:
 
    viAffectsGuildmates = TRUE
    viAffectsEnemies = TRUE
+   viAffectsCombatAllies = TRUE
 
    viCasterPersist = TRUE
    


### PR DESCRIPTION
For quite some time, the game has needed a universal fix for the
overlapping combat systems we have. This is that fix.

Every innocent player now has a list of Allies and Enemies. All allies will show up
as green halos. All enemies will, naturally, show up as red halos.

In essence, interfering in ongoing combat by buffing or healing someone
will make you an enemy to that player's enemies. For example, if I heal
Daenks while he is fighting Keen, I'll see:

"The law recognizes that Keen has a temporary grievance with you!"

At this point, I cannot attack Keen - but he can attack me. I am a red halo
to him. If he attacks me, then I will be able to fight back, and he will become
a red halo to me as well. In this manner, we give the initiative to the combatants,
not to the interfering sideline players. I can't jump into your fight simply by healing
somebody.

If I go inside and wait ten minutes, I'll see:

"The grievance Keen held with you has expired under the eyes of the law."

And he will no longer be able to attack me.

Of course, continued interference or fighting refreshes all timers.

This system would not have been possible in the past, when imping buffs
required standing in Streets and buffing everyone who walked by, but almost
all buffs are self-castable now and that behavior isn't really a thing anymore.

Angeled characters, unguildeds, and so on are all exempt from this system.
It also does not apply in arenas, chaos zones, or guild halls. There are no
special tricks - you must satisfy all other conditions to take up a grievance.

I'm sure some guilded newbies will be tricked into buffing someone so that they can
be attacked - but they'll be warned by a text message, and hopefully learn
their lesson after the first time. That lesson being "Don't heal and buff
random people, or you'll become part of their affairs." If somehow they haven't
been told of this system or warned by guildmates. We can counter this effect
with education. Perhaps even a Positive safety setting that prevents you from
healing and buffing others until you are aware of the risks.

This system should make ongoing combat system overlaps much less of
a nuisance. Shields, war, red/white, have become the start of a chaotic mess.
We can add more systems in the future without worrying about it thanks to this
allies and enemies system. I'm already thinking we can add official KOS lists
to the game the way players intended back in the wild west days. For example,
a guild could pay a significant sum of shillings (or something) to actually add a
player to their KOS list, and then be able to attack them even if everybody is
white. Then anybody who helped or interfered would be immediately caught up
in the battle without an issue. It would not need to be an entire new messy
system with specific checks all over the place. The *goal* is to make combat
crazy, fast-paced, and fluid. "Somebody's jumping my bud! GET THEM!" (without
you needing to get a shield, or turn off your safety, or anything else).
I can see it now: you pissed off a guild enough that they paid 1 million shillings
to KOS you. All their guildmembers can hunt you down and attack you, and the
KOS only expires once you die to one of them. Sounds grand. At the same time,
this doesn't mean that you alone will be slaughtered while your friends stand
around doing nothing. They can heal / buff / purify and get dirty once things
get out of hand.

The ally system also allowed me to add viAffectsCombatAllies to radius enchants.
Once you attack someone that someone else is already fighting, you become
their ally, and their radius enchants will include you. This is both positive (helpful)
and negative (for spells like AMA, jala hinder songs, and so on). So players do 
not get a choice to opt out.

A great example of this:

Two whites from different guilds are fighting a red. Currently, one white can use AMA and he
and the red will be affected by AMA. The second white will not. That's a fairly
insane situation in which the red cannot really win.

Under this new system, the first white's AMA still won't affect the second white -
until the second white hits the red (any offensive spell or attack). Then the whites become allies, and the first white's AMA now affects the second white for ten minutes. Balance has returned, because the system is correctly accounting for all allies and enemies among whites that aren't in the same guild, shield allies, war allies, and any other situation.

In chaotic systems, you can be both an ally and enemy to the same person. This won't cause any duplication of spell effects, though. All that matters is that this system permits rather than denies; being an ally of someone doesn't hinder you attacking them.

**This system doesn't apply to outlaws and murderers. They can already
be attacked by anyone, anyone that buffs or heals them already
turns outlaw, and, with their safeties off, they can already attack anyone
applicable.** In addition, "whole battlefield" spells that affect enemies
and guildmates will naturally also affect any murderers and outlaws that
are fighting together, since they are enemies to each other technically.
The only way around that is to guild together, since guildmates can't
attack each other, and then they're included in guildmates. No issue.

Examples / specifics below.

% These keep track of who has helped or hindered in the last ten minutes.
% Greatly simplifies combat rules. If you interfere, you're in the fight.
% Those you interfere with have initiative on you.
% E.g. you major heal someone who is engaged in 1v1.
% His opponent may strike you without going outlaw.
% You may NOT strike him the same way just yet.
%    But once he strikes you, then you are free to fight back.
%
% Specifically:
%
% Healing or buffing a stranger makes you count as their ally.
%    It also adds you as an enemy to all of their current enemies.
% Healing or buffing an ally refreshes the ally timer.
% Healing or buffing an enemy makes you count as their ally AND their enemy.
%    This will prevent any silly gaming of the system, and only hinder you.
%    It's entirely possible your own guild or soldier allies will
%    turn on you and purposely or accidentally kill you.
%
% Hitting a stranger makes you their enemy.
% Hitting a stranger or enemy also gives their enemies to you as allies.
%    Therefore, your beneficial AEs/REs will help others who are fighting
%    your current enemy. E.g. you are a Jonas soldier fighting alongside a
%    Jonas soldier against a Duke soldier. You are not guilded with your
%    Jonas partner, but hitting the Duke soldier will give you the Jonas
%    partner as an ally, and he will then receive ally benefits from you.
%    This applies mostly to Radius Enchantments (both styles).
%
% Hitting a stranger or enemy also gives their allies to you as enemies.
%    Therefore, you can attack someone who has healed or buffed your enemy.
%    E.g. a 70 hp mule heals a Duke soldier. If you, as a Jonas soldier,
%    hit the Duke soldier, you can then also hit the 70 hp mule.
%    The 70 hp mule cannot attack you, though, until you attack him.
%    If you don't want to get attacked by random alts, be careful of how
%    you apply area attacks. Players can jump in by healing your enemy,
%    getting hit by you, and then attacking you. (this is, however,
%    preferable to a system in which bystanders can heal enemies without
%    repercussion).
%
% Don't understand it? No problem. Keep your safety on and expect
%    a beatdown if you interfere with a fight - and you'll be correct.
%
% Stored as [player, timer, indirect boolean]
% Timer is refreshed upon any new action.