### PR TITLE
Experience system

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -3622,3 +3622,7 @@
    % Survival options
    OPT_NATURAL = 1    % Rooms with natural monster spawn only
    OPT_PVP_ON = 2     % Players can fight
+   
+   % Experience system
+   EXPERIENCE_SYSTEM_CLASSIC = 1
+   EXPERIENCE_SYSTEM_MODERN = 2

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -835,6 +835,7 @@ properties:
    % This is used to determine raises in hit points only.
    poKill_target = $
    piGain_chance = 0
+   piExperience = 0
 
    % This keeps track of training points that players accumulate when 
    % killing mobs.
@@ -5999,7 +6000,7 @@ messages:
       }
 
       Send(what,@Killed,#what=self,#stroke_obj=stroke_obj);
-      Send(self,@DrawHPChance);
+      % Send(self,@DrawHPChance);
 
       % Report to shrunken head
       shrunken = Send(self,@FindHolding,#class=&ShrunkenHead);
@@ -8785,8 +8786,9 @@ messages:
    "stamina, all the way down to half for those with high staminas."
    {
       local i, dodgeskill, oSkill, monster_level, gain, gainmult, roll,
-            oWeapon, lBuilderGroup, bGainedHP;
+            oWeapon, lBuilderGroup, bGainedHP, iExperienceSystem;
 
+      iExperienceSystem = Send(SETTINGS_OBJECT,@GetExperienceSystem);
       gain = 0;
       roll = FALSE;
       bGainedHP = FALSE;
@@ -8829,106 +8831,221 @@ messages:
 
          if monster_level > piBase_Max_health
          {
+            if iExperienceSystem = EXPERIENCE_SYSTEM_MODERN
+               AND Send(SETTINGS_OBJECT,@GetCapModernExperience)
+            {
+               % Cap XP so player doesn't advance too quickly.
+               monster_level = Send(self,@GetBaseMaxHealth);
+            }
+
             if killing_blow
                AND ((piFlags & PFLAG_TOOK_DAMAGE)
                   OR (piFlags & PFLAG_DODGED))
             {
-               % Player took damage and landed killing blow
-               gain = 2;
-               roll = TRUE;
-            }
-            else
-            {
-               % Player either did not take damage, but did killing blow (mage),
-               %  or did take damage, did not land killing blow, or
-               %  it's a group member kill.
-               
-               gain = 1;
-
-               % We still roll for a tougher if we killed the monster but
-               % didn't take damage or dodge, if we helped kill the monster,
-               % or if it was a group member kill and the setting for group
-               % member toughers is set to TRUE.
-               if NOT group_member_kill
-                  OR Send(SETTINGS_OBJECT,@GetGroupTougherSetting)
+               if iExperienceSystem = EXPERIENCE_SYSTEM_CLASSIC
                {
+                  % Player took damage and landed killing blow
+                  gain = 2;
                   roll = TRUE;
                }
-               
-               % Inform the player that a group kill successfully garnered XP.
-               if group_member_kill
-                  AND group_member <> $
-                  AND gain = 1
+               else if iExperienceSystem = EXPERIENCE_SYSTEM_MODERN
                {
-                  Send(self,@MsgSendUser,#message_rsc=group_experience_rsc,
-                        #parm1=Send(group_member,@GetName),
-                        #parm2=Send(what,@GetName));
+                  % We killed and fought a stronger monster.
+                  % Full XP.
+                  gain = monster_level;
                }
-               
-               % Give an informative message about non-group
-               % kills that are still shared
-               if NOT killing_blow
-                  AND NOT group_member_kill
-                  AND group_member <> $
+            }
+            else
+            {
+               if iExperienceSystem = EXPERIENCE_SYSTEM_CLASSIC
                {
-                  Send(self,@MsgSendUser,#message_rsc=group_experience_rsc,
-                        #parm1=Send(group_member,@GetName),
-                        #parm2=Send(what,@GetName));
+                  % Player either did not take damage, but did killing blow,
+                  %  or did take damage, did not land killing blow, or
+                  %  it's a group member kill.
+               
+                  gain = 1;
+
+                  % We still roll for a tougher if we killed the monster but
+                  % didn't take damage or dodge, if we helped kill the monster,
+                  % or if it was a group member kill and the setting for group
+                  % member toughers is set to TRUE.
+                  if NOT group_member_kill
+                     OR Send(SETTINGS_OBJECT,@GetGroupTougherSetting)
+                  {
+                     roll = TRUE;
+                  }
+               
+                  % Inform the player that a group kill successfully garnered XP.
+                  if group_member_kill
+                     AND group_member <> $
+                     AND gain = 1
+                  {
+                     Send(self,@MsgSendUser,#message_rsc=group_experience_rsc,
+                           #parm1=Send(group_member,@GetName),
+                           #parm2=Send(what,@GetName));
+                  }
+               
+                  % Give an informative message about non-group
+                  % kills that are still shared
+                  if NOT killing_blow
+                     AND NOT group_member_kill
+                     AND group_member <> $
+                  {
+                     Send(self,@MsgSendUser,#message_rsc=group_experience_rsc,
+                           #parm1=Send(group_member,@GetName),
+                           #parm2=Send(what,@GetName));
+                  }
+               }
+               else if iExperienceSystem = EXPERIENCE_SYSTEM_MODERN
+               {
+                  % Player either did not take damage, but did killing blow,
+                  %  or did take damage, did not land killing blow, or
+                  %  it's a group member kill.
+                  %
+                  % Half XP.
+                  gain = monster_level/2;
+               
+                  % Inform the player that a group kill successfully garnered XP.
+                  if group_member_kill
+                     AND group_member <> $
+                  {
+                     Send(self,@MsgSendUser,#message_rsc=group_experience_rsc,
+                           #parm1=Send(group_member,@GetName),
+                           #parm2=Send(what,@GetName));
+                  }
+               
+                  % Give an informative message about non-group
+                  % kills that are still shared
+                  if NOT killing_blow
+                     AND NOT group_member_kill
+                     AND group_member <> $
+                  {
+                     Send(self,@MsgSendUser,#message_rsc=group_experience_rsc,
+                           #parm1=Send(group_member,@GetName),
+                           #parm2=Send(what,@GetName));
+                  }
                }
             }
          }
          else
          {
-            % Monster was equal or close to player level.  Small bonus,
-            %  no roll chance.
-            if (monster_level + 5) > piBase_Max_health
-               AND IsClass(what,&monster) AND killing_blow 
-               AND ((piFlags & PFLAG_TOOK_DAMAGE)
-                  OR (piFlags & PFLAG_DODGED))
+            if iExperienceSystem = EXPERIENCE_SYSTEM_CLASSIC
             {
-               gain = 1;
-            }
-            else
-            {
-               % Monster was too easy for player to kill!
-               if random(1,100) < 30 AND killing_blow
+               % Monster was equal or close to player level.  Small bonus,
+               %  no roll chance.
+               if (monster_level + 5) > piBase_Max_health
+                  AND IsClass(what,&monster) AND killing_blow 
+                  AND ((piFlags & PFLAG_TOOK_DAMAGE)
+                     OR (piFlags & PFLAG_DODGED))
                {
-                  Send(self,@MsgSendUser,#message_rsc=player_spits);
+                  gain = 1;
+               }
+               else
+               {
+                  % Monster was too easy for player to kill!
+                  if random(1,100) < 30 AND killing_blow
+                  {
+                     Send(self,@MsgSendUser,#message_rsc=player_spits);
+                  }
+               }
+            }
+            else if iExperienceSystem = EXPERIENCE_SYSTEM_MODERN
+            {
+               % Monster was equal or close to player level. Small bonus.
+               if (monster_level + 5) > piBase_Max_health
+                  AND IsClass(what,&monster) AND killing_blow 
+                  AND ((piFlags & PFLAG_TOOK_DAMAGE)
+                     OR (piFlags & PFLAG_DODGED))
+               {
+                  gain = monster_level/4;
+               }
+               else
+               {
+                  % Monster was too easy for player to kill!
+                  if random(1,100) < 30 AND killing_blow
+                  {
+                     Send(self,@MsgSendUser,#message_rsc=player_spits);
+                  }
                }
             }
          }
 
-         % Give newbies a little bonus.
-         if piBase_Max_health < Send(SETTINGS_OBJECT,@GetPKillEnableHP)
+         if iExperienceSystem = EXPERIENCE_SYSTEM_CLASSIC
          {
-            gain = gain + 1;
-         }
-         else
-         {
-            % Give solo pkill-enabled builders a little bonus, for
-            % appropriate monsters. This will roughly equal building 
-            % with one other player in the room. Bonus requires that the 
-            % player is fighting normally (no firewalls / distance killing)
-            lBuilderGroup = Send(poOwner,@GetBuilderGroup);
-            if (lBuilderGroup = $
-                  OR Length(lBuilderGroup) = 1
-                  OR (FindListElem(lBuilderGroup,self) = 0
-                     AND (piPreferences & ~CF_GROUPING)))
-               AND NOT group_member_kill
-               AND killing_blow
-               AND (monster_level + 5) > piBase_Max_health
-               AND ((piFlags & PFLAG_TOOK_DAMAGE)
-                  OR (piFlags & PFLAG_DODGED))
+            % Give newbies a little bonus.
+            if piBase_Max_health < Send(SETTINGS_OBJECT,@GetPKillEnableHP)
             {
                gain = gain + 1;
             }
+            else
+            {
+               % Give solo pkill-enabled builders a little bonus, for
+               % appropriate monsters. This will roughly equal building 
+               % with one other player in the room. Bonus requires that the 
+               % player is fighting normally (no firewalls / distance killing)
+               lBuilderGroup = Send(poOwner,@GetBuilderGroup);
+               if (lBuilderGroup = $
+                     OR Length(lBuilderGroup) = 1
+                     OR (FindListElem(lBuilderGroup,self) = 0
+                        AND (piPreferences & ~CF_GROUPING)))
+                  AND NOT group_member_kill
+                  AND killing_blow
+                  AND (monster_level + 5) > piBase_Max_health
+                  AND ((piFlags & PFLAG_TOOK_DAMAGE)
+                     OR (piFlags & PFLAG_DODGED))
+               {
+                  gain = gain + 1;
+               }
+            }
          }
-         
-         % Give a bonus for Survival Rooms
-         if Send(what,@GetBoostedLevel) > 0
+         else if iExperienceSystem = EXPERIENCE_SYSTEM_MODERN
          {
-            gain = gain + (Send(what,@GetBoostedLevel)
-                 / Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalXP));
+            % Give newbies a little bonus.
+            if piBase_Max_health < Send(SETTINGS_OBJECT,@GetPKillEnableHP)
+            {
+               gain = gain * 150 / 100;
+            }
+            else
+            {
+               % Give solo pkill-enabled builders a little bonus, for
+               % appropriate monsters. This will roughly equal building 
+               % with one other player in the room. Bonus requires that the 
+               % player is fighting normally (no firewalls / distance killing)
+               lBuilderGroup = Send(poOwner,@GetBuilderGroup);
+               if (lBuilderGroup = $
+                     OR Length(lBuilderGroup) = 1
+                     OR (FindListElem(lBuilderGroup,self) = 0
+                        AND (piPreferences & ~CF_GROUPING)))
+                  AND NOT group_member_kill
+                  AND killing_blow
+                  AND (monster_level + 5) > piBase_Max_health
+                  AND ((piFlags & PFLAG_TOOK_DAMAGE)
+                     OR (piFlags & PFLAG_DODGED))
+               {
+                  gain = gain * 150 / 100;
+               }
+            }
+         }
+
+         if iExperienceSystem = EXPERIENCE_SYSTEM_CLASSIC
+         {
+            % Give a bonus for Survival Rooms
+            if Send(what,@GetBoostedLevel) > 0
+            {
+               gain = gain + (Send(what,@GetBoostedLevel)
+                    / Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                            @GetSurvivalXP));
+            }
+         }
+         else if iExperienceSystem = EXPERIENCE_SYSTEM_MODERN
+         {
+            % Give a bonus for Survival Rooms
+            if Send(what,@GetBoostedLevel) > 0
+            {
+               gain = gain + (Send(what,@GetBoostedLevel) * 10
+                    / Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                            @GetSurvivalXP));
+            }
          }
 
          % If they're cheesing the situation by fighting wussy monsters
@@ -8944,7 +9061,14 @@ messages:
                      @GetHPGainMultiplier),1,500);
          gain = gain * gainmult;
 
-         piGain_chance = piGain_chance + gain;
+         if iExperienceSystem = EXPERIENCE_SYSTEM_CLASSIC
+         {
+            piGain_chance = piGain_chance + gain;
+         }
+         else if iExperienceSystem = EXPERIENCE_SYSTEM_MODERN
+         {
+            bGainedHP = Send(self,@AddExperience,#iAmount=gain);
+         }
 
          % Here, we work out if the player deserves a training point.
          % They qualify if they got at least one gain point from the monster,
@@ -9013,7 +9137,9 @@ messages:
 
       % Draw the tougher chance bar. Send this here because RollForTougher
       % will also draw it, no need to do so twice.
+      % The modern experience system also draws at AddExperience.
       if NOT roll
+         AND NOT iExperienceSystem = EXPERIENCE_SYSTEM_MODERN
       {
          Post(self,@DrawHPChance);
       }
@@ -9127,11 +9253,150 @@ messages:
       return piGain_chance;
    }
 
+   AddExperience(iAmount=$)
+   {
+      local oShrunken;
+
+      if iAmount <> $
+         AND iAmount <> 0
+      {
+         % Can't gain XP if at max health
+         if piBase_Max_health >= 100+Send(self,@GetStamina)
+         {
+            return FALSE;
+         }
+         
+         piExperience = piExperience + iAmount;
+
+         if pbLogged_on
+         {
+            if iAmount > 0
+            {
+               Send(self,@MsgSendUser,#message_rsc=player_experience_gained,
+                  #parm1=iAmount);
+            }
+            else
+            {
+               Send(self,@MsgSendUser,#message_rsc=player_experience_lost,
+                  #parm1=iAmount);
+            }
+
+            Post(self,@DrawHPChance);
+         }
+         
+         if piExperience >= Send(self,@GetExperienceNeeded)
+         {
+            % In case of overages, give them all deserved HP boosts.
+            % But don't do all the other stuff multiple times.
+            while piExperience >= Send(self,@GetExperienceNeeded)
+            {
+               piExperience = piExperience - Send(self,@GetExperienceNeeded);
+               Send(self,@GainBaseMaxHealth,#amount=1);
+               
+               % Just reached max health!
+               if Send(self,@GetExperienceNeeded) = 0
+               {
+                  piExperience = 0;
+                  break;
+               }                  
+            }
+            if Send(self,@CheckLog)
+            {
+               Debug("LOG:  ",vrName," gained a health point: ",
+                     piMax_health,pibase_max_health);
+            }
+
+            Send(self,@EvaluatePKStatus);
+
+            if pbLogged_on
+            {
+               Send(self,@MsgSendUser,#message_rsc=player_improve_maxhealth);
+               Send(self,@WaveSendUser,#what=self,
+                     #wave_rsc=player_tougher_wav_rsc);
+
+               % Boost the player to max health, and give them 200 vigor.
+               Send(self,@MsgSendUser,
+                     #message_rsc=player_improve_health_invigorate);
+               piHealth = piMax_Health * 100;
+               Send(self,@DrawHealth);
+               Send(self,@EatSomething,#nutrition=200);
+               Post(self,@DrawOffense);
+               Post(self,@DrawDefense);
+               Post(self,@DrawHPChance);
+
+               % Report to shrunken head, if they have one.
+               oShrunken = Send(self,@FindHolding,#class=&ShrunkenHead);
+               if oShrunken <> $
+               {
+                  Send(oShrunken,@Tougher,#hp=pibase_max_health);
+               }
+            }
+            return TRUE;
+         }
+      }
+
+      return FALSE;
+   }
+   
+   GetExperience()
+   {
+      return piExperience;
+   }
+
+   GetExperienceNeeded()
+   {
+      local iExperienceNeeded;
+      
+      if piBase_Max_health >= 100+Send(self,@GetStamina)
+      {
+         return 0;
+      }
+
+%     Classic system says:
+%     "A player will need, on average, to kill a number of monsters equal to"
+%     "their maxhealth to gain a HP.  This number is reduced by the player's"
+%     "stamina, all the way down to half for those with high staminas."
+      
+      % +1 because it's for the next hit point.
+      % Your base max health squared because you will have to kill,
+      % for example, 150 150-hp monsters to get your 150th hit point.
+      % Monsters give experience equal to their level.
+      iExperienceNeeded = (piBase_Max_health+1) * (piBase_Max_health+1);
+      
+      % Reduce experience needed by up to half at 50 stamina.
+      % No bound so that Staminas up to 70 still help.
+      iExperienceNeeded = iExperienceNeeded * (100-Send(self,@GetStamina))/100;
+      
+      iExperienceNeeded = bound(iExperienceNeeded,1,$);
+      
+      return iExperienceNeeded;
+   }
+
+   ConvertGainChanceToXP(iAmount=0)
+   {
+      local iExperience;
+      
+      % Two gain chance points is equivalent to one full kill of an equal
+      % level monster.
+      
+      iExperience = Send(self,@GetBaseMaxHealth);
+      iExperience = iExperience * iAmount / 2;
+      
+      return iExperience;
+   }
+
    AddGainChance(iAmount=$)
    {
       if iAmount <> $
          AND iAmount <> 0
       {
+         if Send(SETTINGS_OBJECT,@GetExperienceSystem) = EXPERIENCE_SYSTEM_MODERN
+         {
+            iAmount = Send(self,@ConvertGainChanceToXP,#iAmount=iAmount);
+            Send(self,@AddExperience,#iAmount=iAmount);
+            return;
+         }
+         
          piGain_chance = piGain_chance + iAmount;
 
          if pbLogged_on

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -8630,8 +8630,18 @@ messages:
 
    SendStatHPChance()
    {
-      local iHPChance_Send, highmark;
+      local iHPChance_Send, highmark, iExperienceSystem, iExperienceNeeded;
 
+      iExperienceSystem = Send(SETTINGS_OBJECT,@GetExperienceSystem);
+      
+      if iExperienceSystem = EXPERIENCE_SYSTEM_MODERN
+      {
+         iExperienceNeeded = Send(self,@GetExperienceNeeded);
+         AddPacket(1,4, 4,user_stat_hpgainchance, 1,STAT_VALUE, 1,STAT_INTEGER,
+               4,piExperience, 4,0, 4,iExperienceNeeded, 4,iExperienceNeeded);
+         return;
+      }
+      
       highmark = Send(self,@GetHighMark);
 
 

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -243,6 +243,11 @@ properties:
 
    % Percent of mana required/used for broadcasting. Default 0 (no cost).
    piBroadcastManaPercent = 0
+   
+   % What type of experience system do we use?
+   piExperienceSystem = EXPERIENCE_SYSTEM_MODERN
+   % Do we cap modern experience at player's own max health to tightly emulate old system?
+   piCapModernExperience = TRUE
 
    % Jasper vault access
    pbJasperVault = FALSE
@@ -643,6 +648,16 @@ messages:
    GetBroadcastManaCost()
    {
       return piBroadcastManaPercent;
+   }
+   
+   GetExperienceSystem()
+   {
+      return piExperienceSystem;
+   }
+   
+   GetCapModernExperience()
+   {
+      return piCapModernExperience;
    }
 
    JasperVaultOpen()


### PR DESCRIPTION
Puts in a setting for a modern experience system.

Monsters give experience equal to their level. The same bonuses as before apply (+50% solo builder bonus, +50% newbie bonus). The same requirements also apply (killing blow, getting hit, landing hits) with the same divisors. In fact, if you are killing monsters that are exactly your level, the system should be exactly the same.

But because monsters give experience equal to their level, there *would be* an improvement in building speed. If you are 80 hp killing 100 hp tusked skeletons, you are getting 100 xp per, not 80. If you kill avars, you'll get 120 xp per. This seems like a positive feature to me. If not, we can bound experience given at your health to make the system exactly equal, on average, to classic. I.e. kill 80 level 80 monsters to get your 80th hp. 100 level 100 monsters to get your 100th hp, and so on. The setting "piCapModernXp" handles this behavior (defaults to ON, so that we are closely emulating the old system). While it's on, you can't go kill avars at 50 hp and get 120 xp per avar base. You will get 50 xp per avar base, max. then 51, 52, etc.

My one concern is shadowbeasts and the like that are level 200 to indicate boss monsters. We might do something about those, or leave them as they are. Right now, the 'cap' setting handles any issues like that.

Group member kills are 1/2 xp, and monsters you're about done with are 1/4th XP. Monsters that are too low provide no XP.

Stamina reduces the XP needed for the next level the same way it did before.

Your tougher chance bar, under this system, fills with XP up to the amount you need. You then get a tougher.

The AddExperience (iAmount) function in player is where all XP gains and toughers are handled. You can have events, boss monsters, and so on just Send(player,@AddExperience,#iAmount=whatever) and they will gain multiple HPs as appropriate (no spam, only sends messages and sounds once).