### PR TITLE
Convert roomdata storage from linked list to table.

### DIFF
--- a/blakserv/roomdata.h
+++ b/blakserv/roomdata.h
@@ -21,6 +21,13 @@ typedef struct roomdata_struct
    struct roomdata_struct *next;
 } roomdata_node;
 
+typedef struct roomdata_rsc_struct
+{
+   int resource_id;
+   int roomdata_id;
+   struct roomdata_rsc_struct *next;
+} roomdata_rsc_node;
+
 enum
 {
    ROOM_FLAG_WALKABLE = 0x01


### PR DESCRIPTION
This list needed to be traversed every time a room ID lookup was needed,
thus was much better suited to a table.

Also added a separate table containing the resource id and room id, to
enable fast lookup of which rooms have been loaded by resource id (used
for rented rooms and survival arena, so they don't make duplicate rooms
but use existing data).