### PR TITLE
Qor Priestess Blood Rite

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/temples/qorprst.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/temples/qorprst.kod
@@ -13,6 +13,10 @@ QorPriestess is Temples
 constants:
 
    include blakston.khd
+   
+   NEEDED_BLOOD = 6
+   NEEDED_BERRY = 6
+   NEEDED_TOOTH = 3
 
 resources:
 
@@ -24,7 +28,10 @@ resources:
       "The perfect servant of Qor the Vile.  Shadows deepen where this "
       "malevolent woman stands.  She has a devious sensuality that she will "
       "exploit to turn men and women to succumb to the dark will of Qor.  "
-      "If she can not seduce others to Qor, she would rather see them dead."
+      "If she can not seduce others to Qor, she would rather see them dead. "
+      "She has the ability to teach the magics of Qor, to sell potions of "
+      "forgetfulness for hated Shal'ille spells, and to perform "
+      "blood rites to empower weapons."
 
    Qor_forget_potion_sale = \
       "~I~rYou can indeed buy %s%s.  Qor will be glad to strip you of the "
@@ -50,6 +57,25 @@ resources:
    qorpriestess_teach = \
       "Through the darkness of Qor, you can learn %s%s%s%s%s%s%s%s%s%s%s%s "
       "at that level."
+
+   blood_rite_prompt = "blood rite"
+   blood_rite_wav = qunbond.wav
+   qor_priestess_blood_rite = \
+      "~r~IAccept Qor's gift of pain.~n"
+   qor_priestess_blood_rite_needed_items = \
+      "~r~IBring me %i vials of magical blood, %i entroot berries, and "
+      "%i orc teeth, and you shall have Qor's gift.~n"
+   qor_priestess_blood_rite_need_weapon = \
+      "~r~IWield an unenchanted melee weapon so that it may receive Qor's "
+      "gift.~n"
+   blood_rite_cursed = \
+      "Your %s takes on a pale red aura."
+   blood_rite_blind = \
+      "Q's insignia blazes itself upon your %s."
+   blood_rite_hold = \
+      "Your %s begins emitting a Zjiriaesque glow."
+   blood_rite_vamp = \
+      "A draining darkness surrounds your %s."
 
 classvars:
    vrTeach_message = qorpriestess_teach
@@ -221,6 +247,96 @@ messages:
          }
 
          return FALSE;
+      }
+
+      propagate;
+   }
+
+   SomeoneSaid(what=$,type=$,string=$)
+   {
+      local oBlood, oBerry, oTooth, oWeapon, iRandom, ItemAtt;
+
+      if type = SAY_YELL OR NOT IsClass(what,&User)
+      {
+          propagate;
+      }
+
+      if StringContain(string,blood_rite_prompt)
+         AND what <> $
+         AND IsClass(what,&User)
+      {
+         oBlood = Send(what,@FindHolding,#class=&ShamanBlood);
+         oBerry = Send(what,@FindHolding,#class=&EntrootBerry);
+         oTooth = Send(what,@FindHolding,#class=&OrcTooth);
+
+         if oBlood = $
+            OR oBerry = $
+            OR oTooth = $
+            OR Send(oBlood,@GetNumber) < NEEDED_BLOOD
+            OR Send(oBerry,@GetNumber) < NEEDED_BERRY
+            OR Send(oTooth,@GetNumber) < NEEDED_TOOTH
+         {
+            Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_RESOURCE,
+		          #string=qor_priestess_blood_rite_needed_items,
+                  #parm1=NEEDED_BLOOD,
+                  #parm2=NEEDED_BERRY,
+                  #parm3=NEEDED_TOOTH);
+            propagate;
+         }
+         
+         oWeapon = Send(what,@GetWeapon);
+         if oWeapon = $
+            OR NOT IsClass(oWeapon,&Weapon)
+            OR IsClass(oWeapon,&RangedWeapon)
+            OR Send(oWeapon,@HasAnyAttribute)
+         {
+            Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_RESOURCE,
+		          #string=qor_priestess_blood_rite_need_weapon);
+            propagate;
+         }
+
+         Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_RESOURCE,
+		       #string=qor_priestess_blood_rite);
+
+         iRandom = Random(1,10);
+
+         if iRandom = 1
+         {
+            ItemAtt = WA_VAMPER;
+            Send(what,@MsgSendUser,#message_rsc=blood_rite_vamp,
+                  #parm1=Send(oWeapon,@GetName));
+         }
+
+         if iRandom = 2
+         {
+            ItemAtt = WA_BLINDER;
+            Send(what,@MsgSendUser,#message_rsc=blood_rite_blind,
+                  #parm1=Send(oWeapon,@GetName));
+         }
+
+         if iRandom = 3
+         {
+            ItemAtt = WA_PARALYZER;
+            Send(what,@MsgSendUser,#message_rsc=blood_rite_hold,
+                  #parm1=Send(oWeapon,@GetName));
+         }
+
+         if iRandom >= 4
+         {
+            ItemAtt = WA_CURSED;
+            Send(what,@MsgSendUser,#message_rsc=blood_rite_cursed,
+                  #parm1=Send(oWeapon,@GetName));
+         }
+
+         Send(poOwner,@SomethingWaveRoom,#what=self,#wave_rsc=blood_rite_wav);
+
+         Send(oBlood,@SubtractNumber,#number=NEEDED_BLOOD);
+         Send(oBerry,@SubtractNumber,#number=NEEDED_BERRY);
+         Send(oTooth,@SubtractNumber,#number=NEEDED_TOOTH);
+         Send(what,@TryUnuseItem,#what=oWeapon);
+         Send(Send(SYS,@FindItemAttByNum,#Num=ItemAtt),@AddToItem,
+               #oItem=oWeapon);
+         Send(oWeapon,@RevealHiddenAttributes);
       }
 
       propagate;

--- a/kod/object/passive/itematt/weapatt/waparal.kod
+++ b/kod/object/passive/itematt/weapatt/waparal.kod
@@ -30,7 +30,7 @@ resources:
    include waparal.lkod
 
    weapattParalyzer_desc = \
-      " A glow that can only be described as Zjiriaesqe surrounds the weapon."
+      " A glow that can only be described as Zjiriaesque surrounds the weapon."
    Paralyzer_dm = "Paralyzer"
    paralyzer_fail_use = "You are not ready to use %s%s."
    holder_worked = "%s%s seems rooted to the very ground!"


### PR DESCRIPTION
While we discussed Blood Inheritance, it occurred to me that it could easily be an NPC ability. We've talked about adding more NPC interactivity in the past, and I think this is a good chance to do that. I would like to create at least one interaction like this for most NPCs. For example, the Shal priestess could remove curses from items. The Riija priestess could add GMT or Vertigo procs to weapons. Fehr'loi Qan could mend armor, and so on.

So if you guys like this, I would love to go ahead and do a whole round of them. Give lots more item & npc interactions.

Saying Blood Rite to Zuxana prompts her to tell you to equip an unenchanted melee weapon and/or bring 6 blood, 6 berries, and 3 teeth. Fulfill these conditions, and she will enchant your equipped weapon with a random enchantment. The weapon unequips, gives you a text message about what you got, and is revealed (no pop up). The chances are 10% for Hold, 10% for Blind, 10% for vamp, and 70% cursed.

**This is exactly functionally equivalent to the current Blood Inheritance spell.** The necessity for three Qor 5s is a one-time sunk cost for BI, and therefore not actually part of a per-unit equation. Some players may have access to three Qor 5s, and thus that cost is zero for them. Others may build mules purely with training points, and the cost of building Qor 5 mules isn't that high to begin with. To compound this matter: we always want to move away from mule-based mechanisms. There's much more value to be had in something cool and lore-ish like having the Qor Priestess enchant your weapon (and thus going out in the world and doing something etc) than there is in sitting in a room using 20 hp alts to make weapons. I would like to remove as many mule-based mechanisms as possible, for example: the Kraanan Priestess can give Hunts for the same price. The Shal Priestess could do old Bonds for the same price (if we keep old bond). 

Also added to Zuxana's bio: She has the ability to teach the magics of Qor, to sell potions of forgetfulness for hated Shal'ille spells, and to perform blood rites to empower weapons.

This seems like a good practice for NPCs - put 'prompts' for their spoken commands in their bio.