### PR TITLE
Add "swarm brain" for mobs that always need to aggro.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1558,6 +1558,8 @@
    BRAIN_GUARD             = 5
    BRAIN_NONAGGRESSIVE     = 6
    BRAIN_KARMA_AGGRESSIVE  = 7
+   BRAIN_SWARM             = 8
+   BRAIN_MAX_NUM           = 8
 
    % AI Behaviors
    % Mob cannot be attacked.

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -498,7 +498,7 @@ properties:
 
 messages:
 
-   Constructor(template=FALSE, color=0, piSurvivalLevel=0)
+   Constructor(template=FALSE, color=0, piSurvivalLevel=0, iBrain = 0)
    "Simple enough, we create a monster. If they are questworthy, we note it."
    {
       local iStatPoints, iMin, iMax;
@@ -537,7 +537,14 @@ messages:
 
       Send(self,@TryAddToQuestEngine);
 
-      poBrain = Send(SYS,@FindBrainByNum,#num=viBrain_type);
+      if (iBrain > 0 AND iBrain <= BRAIN_MAX_NUM)
+      {
+         poBrain = Send(SYS,@FindBrainByNum,#num=iBrain);
+      }
+      else
+      {
+         poBrain = Send(SYS,@FindBrainByNum,#num=viBrain_type);
+      }
       
       piState = piState & ESTATE_ZERO_MASK;
       Send(poBrain,@MobConstructor,#mob=self);

--- a/kod/object/passive/brain/makefile
+++ b/kod/object/passive/brain/makefile
@@ -5,6 +5,7 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\brain.bof
-BOFS = revbrain.bof blindb.bof paralyze.bof guardb.bof karmaagg.bof nonagg.bof
+BOFS = revbrain.bof blindb.bof paralyze.bof guardb.bof karmaagg.bof nonagg.bof \
+       swarmbrain.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/brain/swarmbrain.kod
+++ b/kod/object/passive/brain/swarmbrain.kod
@@ -1,0 +1,54 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+SwarmBrain is Brain
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+classvars:
+
+   viBrain_num = BRAIN_SWARM
+
+properties:
+
+   piDefault_behavior = 0
+
+   % The higher this is, the more likely the monster
+   % will pick the highest level player in the room.
+   piPlayer_factor = 10
+
+   % Any monster flagged with this is much more likely to
+   % engage in very deadly behavior.  Used to make orcs deadly.
+   piHyperAggressive_factor = 60
+
+   % The higher this is, the less likely monsters will 'swarm'.
+   piChaser_factor = 0
+
+   % The higher this number is, the more likely a wizard hater
+   % will chase after wizards.
+   piWizard_factor = 25
+
+   % THe higher this number, the more likely a karma hater
+   % will choose someone of the opposite karma.
+   piKarma_factor = 25
+
+   % These two variables control how much hatred is removed
+   % by invisibility and shadow form.
+   piInvis_reduction = 100
+   piShadForm_reduction = 60
+
+messages:
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -3659,6 +3659,7 @@ messages:
    RecreateAllBrains()
    {
       plBrains = $;
+      plBrains = Cons(Create(&SwarmBrain),plBrains);
       plBrains = Cons(Create(&Brain),plBrains);
 
       return;


### PR DESCRIPTION
Same as normal brain, except sets the property for reducing hatred on players that already have aggro to 0. Kept the other (identical) properties to show current customization points.