### PR TITLE
Fix client not being able to move right to edge of things bbox.

### DIFF
--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -110,6 +110,7 @@ static int worstDistance = 0;
 
 /* local function prototypes */
 static void CheckPlayerMove();
+static bool IsInRoom(int x, int y, room_type *room);
 static void BounceUser(int dt);
 static int MoveObjectAllowed(room_type *room, int old_x, int old_y, int *new_x, int *new_y, int z);
 static WallData *IntersectNode(BSPnode *node, int old_x, int old_y, int new_x, int new_y, int z);
@@ -358,7 +359,7 @@ void UserMovePlayer(int action)
          col = x / FINENESS;
 
       // See if trying to move off room.
-      if (!IsInRoom(row, col, current_room))
+      if (!IsInRoom(x, y, &current_room))
       {
          // Delay between consecutive attempts to move off room
          if (now - move_off_room_time >= MOVE_OFF_ROOM_INTERVAL) // current time 
@@ -466,6 +467,18 @@ void UserMovePlayer(int action)
    SoundSetListenerPosition(player.x, player.y, player.angle);
 
    RedrawAll();
+}
+
+bool IsInRoom(int x, int y, room_type *room)
+{
+   if (!room)
+      return False;
+
+   if (x <= room->ThingsBox.Min.X || x >= room->ThingsBox.Max.X
+      || y <= room->ThingsBox.Min.Y || y >= room->ThingsBox.Max.Y)
+      return False;
+
+   return True;
 }
 
 void SlideAlongWall(WallData *wall, int xOld, int yOld, int *xNew, int *yNew)

--- a/clientd3d/move.h
+++ b/clientd3d/move.h
@@ -16,9 +16,6 @@
 #define CLIMB_VELOCITY_0   (FINENESS * 9 / 2)	// climb velocity set to be 3x faster than fall, to keep people from seeing through the floor
 #define FALL_VELOCITY_0    (-FINENESS * 2 / 3)
 
-#define IsInRoom(row, col, room) \
-((row) >= 0 && (row) < (room).rows && (col) >= 0 && (col) < (room).cols)
-
 void ResetPlayerPosition(void);
 
 void UserMovePlayer(int action);

--- a/clientd3d/room.h
+++ b/clientd3d/room.h
@@ -12,6 +12,20 @@
 #ifndef _ROOM_H
 #define _ROOM_H
 
+#define FINENESSKODTOROO(x) ((x) * 16.0f)      // scales a value from KOD fineness to ROO fineness
+
+typedef struct V2
+{
+   float X;
+   float Y;
+} V2;
+
+typedef struct BoundingBox2D
+{
+   V2 Min;
+   V2 Max;
+} BoundingBox2D;
+
 /* Room contents to draw */
 typedef struct
 {
@@ -30,7 +44,8 @@ typedef struct
    WallDataList walls;    // Array of walls in use
    Sector *sectors;       // Array of sectors in use
    Sidedef *sidedefs;     // Array of sidedefs in use
-   
+   BoundingBox2D ThingsBox; // Bounding box of room
+
    int num_nodes, num_walls, num_sectors, num_sidedefs;
 
    int security;          /* Security number, unique to each roo file, to ensure that client


### PR DESCRIPTION
The client could only move to the edge of the max row/cols, whereas now it needs to be able to move to the fineunit edge. The client will now load the things in the same manner as the server, and use them for room boundary checking. The server will move the player to the next screen when they hit the boundary.