### PR TITLE
Add BP_STOP_WAVE protocol to stop playing a sound, fix up looping sound infrastructure and add sound to StartRain().

### DIFF
--- a/blakcomp/function.c
+++ b/blakcomp/function.c
@@ -53,7 +53,7 @@ function_type Functions[] = {
                                          ASETTINGS, ANONE},
 {"SendListByClass",     SENDLISTMSGBYCLASS, AEXPRESSION, AEXPRESSION, AEXPRESSION,
                                             AEXPRESSION, ASETTINGS, ANONE},
-{"SendListByClassBreak",SENDLISTMSGBYCLASS, AEXPRESSION, AEXPRESSION, AEXPRESSION,
+{"SendListByClassBreak",SENDLISTMSGBYCLASSBREAK, AEXPRESSION, AEXPRESSION, AEXPRESSION,
                                             AEXPRESSION, ASETTINGS, ANONE},
 {"Random",              RANDOM,          AEXPRESSION,   AEXPRESSION,  ANONE},
 {"SaveGame",            SAVEGAME,        ANONE},

--- a/clientd3d/audio.c
+++ b/clientd3d/audio.c
@@ -440,7 +440,7 @@ BOOL SoundPlayFile(char* file, BYTE flags, int x, int y)
    return TRUE;
 }
 
-BOOL SoundStopFile(char* file)
+BOOL SoundStopFile(char* file, ID obj)
 {
    // abort cases
    if (!config.play_sound || !file)
@@ -478,7 +478,7 @@ BOOL SoundPlayResource(ID rsc, BYTE flags, int x, int y)
    return SoundPlayFile(file, flags, x, y);
 }
 
-BOOL SoundStopResource(ID rsc)
+BOOL SoundStopResource(ID rsc, ID obj)
 {
    // nothing to do if sound disabled
    if (!config.play_sound)
@@ -491,7 +491,7 @@ BOOL SoundStopResource(ID rsc)
       return FALSE;
 
    // call variant with filename parameter
-   return SoundStopFile(file);
+   return SoundStopFile(file, obj);
 }
 
 BOOL SoundSetVolume()

--- a/clientd3d/audio.h
+++ b/clientd3d/audio.h
@@ -37,7 +37,7 @@ M59EXPORT BOOL SoundStopAll(BYTE flags = 0);
 M59EXPORT BOOL SoundPlayFile(char* file, BYTE flags, int x = 0, int y = 0);
 M59EXPORT BOOL SoundStopFile(char* file);
 M59EXPORT BOOL SoundPlayResource(ID rsc, BYTE flags, int x = 0, int y = 0);
-M59EXPORT BOOL SoundStopResource(ID rsc);
+M59EXPORT BOOL SoundStopResource(ID rsc, ID obj);
 M59EXPORT BOOL SoundSetVolume();
 M59EXPORT BOOL SoundSetListenerPosition(int x, int y, int angle);
 

--- a/clientd3d/audio.h
+++ b/clientd3d/audio.h
@@ -35,7 +35,9 @@ M59EXPORT BOOL MusicSetVolume();
 M59EXPORT BOOL SoundStop(irrklang::ISound* soundid);
 M59EXPORT BOOL SoundStopAll(BYTE flags = 0);
 M59EXPORT BOOL SoundPlayFile(char* file, BYTE flags, int x = 0, int y = 0);
+M59EXPORT BOOL SoundStopFile(char* file);
 M59EXPORT BOOL SoundPlayResource(ID rsc, BYTE flags, int x = 0, int y = 0);
+M59EXPORT BOOL SoundStopResource(ID rsc);
 M59EXPORT BOOL SoundSetVolume();
 M59EXPORT BOOL SoundSetListenerPosition(int x, int y, int angle);
 

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -85,6 +85,7 @@ static handler_struct game_handler_table[] = {
 { BP_PLAY_WAVE,         HandlePlayWave },
 { BP_PLAY_MIDI,         HandlePlayMidi },
 { BP_PLAY_MUSIC,        HandlePlayMusic },
+{ BP_STOP_WAVE,         HandleStopWave },
 { BP_EFFECT,            HandleEffect },
 { BP_SHOOT,             HandleShoot },
 { BP_RADIUS_SHOOT,      HandleRadiusShoot },
@@ -1346,6 +1347,19 @@ Bool HandlePlayWave(char *ptr,long len)
    maxvol = config.sound_volume;
    
    GamePlaySound(rsc, obj, flags, row, col, radius, maxvol);
+   return True;
+}
+/********************************************************************/
+Bool HandleStopWave(char *ptr,long len)
+{
+   ID rsc;
+
+   if (len != SIZE_ID)
+      return False;
+
+   Extract(&ptr, &rsc, SIZE_ID);
+
+   SoundStopResource(rsc);
    return True;
 }
 /********************************************************************/

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -1352,14 +1352,15 @@ Bool HandlePlayWave(char *ptr,long len)
 /********************************************************************/
 Bool HandleStopWave(char *ptr,long len)
 {
-   ID rsc;
+   ID rsc, obj;
 
-   if (len != SIZE_ID)
+   if (len != 2 * SIZE_ID)
       return False;
 
    Extract(&ptr, &rsc, SIZE_ID);
+   Extract(&ptr, &obj, SIZE_ID);
 
-   SoundStopResource(rsc);
+   SoundStopResource(rsc, obj);
    return True;
 }
 /********************************************************************/

--- a/clientd3d/server.h
+++ b/clientd3d/server.h
@@ -101,6 +101,7 @@ Bool HandleWithdrawalList(char *ptr,long len);
 Bool HandlePlayWave(char *ptr,long len);
 Bool HandlePlayMidi(char *ptr,long len);
 Bool HandlePlayMusic(char *ptr,long len);
+Bool HandleStopWave(char *ptr,long len);
 Bool HandleQuit(char *ptr, long len);
 Bool HandleGameResync(char *ptr, long len);
 Bool HandleClasses(char *ptr,long len);

--- a/include/proto.h
+++ b/include/proto.h
@@ -173,6 +173,7 @@ enum {
    BP_PLAY_WAVE             = 170,
    BP_PLAY_MUSIC            = 171,
    BP_PLAY_MIDI             = 172,
+   BP_STOP_WAVE             = 173,
 
    BP_LOOK_NEWSGROUP        = 180,
    BP_ARTICLES              = 181,

--- a/kod/include/protocol.khd
+++ b/kod/include/protocol.khd
@@ -118,6 +118,7 @@
    BP_PLAY_WAVE             = 170
    BP_PLAY_MUSIC            = 171
    BP_PLAY_MIDI             = 172
+   BP_STOP_WAVE             = 173
 
    BP_LOOK_NEWSGROUP        = 180
    BP_ARTICLES              = 181

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3999,12 +3999,12 @@ messages:
       return;
    }
 
-   WaveSendUserStop(wave_rsc = $)
+   WaveSendUserStop(wave_rsc = $, source_obj = 0)
    % Sends a message to the client to stop playing a wav using the resource ID.
    {
       if (wave_rsc <> $) and (pbLogged_on)
       {
-         AddPacket(1,BP_STOP_WAVE, 4,wave_rsc);
+         AddPacket(1,BP_STOP_WAVE, 4,wave_rsc, 4,source_obj);
          SendPacket(poSession);
       }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3999,6 +3999,18 @@ messages:
       return;
    }
 
+   WaveSendUserStop(wave_rsc = $)
+   % Sends a message to the client to stop playing a wav using the resource ID.
+   {
+      if (wave_rsc <> $) and (pbLogged_on)
+      {
+         AddPacket(1,BP_STOP_WAVE, 4,wave_rsc);
+         SendPacket(poSession);
+      }
+
+      return;
+   }
+
    SendRoomMusic(music_rsc = $)
    {
       if pbLogged_on

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -161,6 +161,8 @@ resources:
    room_necro_sound = necloop2.wav
    room_beach_sound = ocean.wav
 
+   room_rain_sound = rain.wav
+
    no_use_jig = \
       "You can't wield that - it would interfere with your funky moves!"
 
@@ -697,7 +699,7 @@ messages:
 
    AddLoopingSound(lSoundData = $)
    {
-      local iRadius, iMaxVol, oObject;
+      local iRadius, iMaxVol;
 
       if lSoundData <> $
       {
@@ -716,17 +718,33 @@ messages:
             iMaxVol = Nth(lSoundData,5);
          }
 
-         foreach oObject in plActive
-         {
-            if IsClass(first(oObject),&User)
-            {
-               Send(first(oObject),@WaveSendUser,#wave_rsc=First(lSoundData),
-                    #flags=SOUND_LOOP,
-                    #row=Nth(lSoundData,2),#col=Nth(lSoundData,3),
-                    #cutoff_radius=iRadius,#max_volume=iMaxVol);
-           }
-        }
+         SendListByClass(plActive,1,&User,@WaveSendUser,#wave_rsc=First(lSoundData),
+               #flags=SOUND_LOOP,#row=Nth(lSoundData,2),#col=Nth(lSoundData,3),
+               #cutoff_radius=iRadius,#max_volume=iMaxVol);
       }
+
+      return;
+   }
+
+   RemoveLoopingSound(sound_rsc = $)
+   "Removes a looping sound by resource."
+   {
+      local i;
+
+      if (sound_rsc = $)
+      {
+         return;
+      }
+
+      foreach i in plLooping_sounds
+      {
+         if (First(i) = sound_rsc)
+         {
+            plLooping_sounds = DelListElem(plLooping_sounds,i);
+         }
+      }
+
+      SendListByClass(plActive,1,&User,@WaveSendUserStop,#wave_rsc=sound_rsc);
 
       return;
    }
@@ -734,15 +752,24 @@ messages:
    RemoveObjectLoopingSound(what = $)
    "Removes a looping sound added by an object."
    {
-      local lSoundData;
+      local i, lSounds;
 
-      foreach lSoundData in plLooping_sounds
+      % List of sounds getting removed, may be more than one.
+      lSounds = $;
+
+      foreach i in plLooping_sounds
       {
-         if length(lSoundData) > 5
-            AND Nth(lSoundData,6) = what
+         if Length(i) > 5
+            AND Nth(i,6) = what
          {
-            plLooping_sounds = DelListElem(plLooping_sounds,lSoundData);
+            lSounds = Cons(First(i),lSounds);
+            plLooping_sounds = DelListElem(plLooping_sounds,i);
          }
+      }
+
+      foreach i in lSounds
+      {
+         SendListByClass(plActive,1,&User,@WaveSendUserStop,#wave_rsc=i);
       }
 
       return;
@@ -3712,6 +3739,7 @@ messages:
       {
          Send(self,@EndSandstorm);
       }
+      Send(self,@AddLoopingSound,#lSoundData=[room_rain_sound, 1, 1, 300, 100]);
 
       Send(self,@SetRoomFlag,#flag=ROOM_RAINING,#value=TRUE);
       Send(self,@WeatherChanged);
@@ -3724,6 +3752,7 @@ messages:
       if Send(self,@CheckRoomFlag,#flag=ROOM_RAINING)
       {
          Send(self,@SetRoomFlag,#flag=ROOM_RAINING,#value=FALSE);
+         Send(self,@RemoveLoopingSound,#sound_rsc=room_rain_sound);
          Send(self,@WeatherChanged);
       }
 

--- a/kod/util/nodeattk.kod
+++ b/kod/util/nodeattk.kod
@@ -225,7 +225,9 @@ messages:
 
       % Check the wait time, see if we're up for attacking the node again!
       piWaitTime = piWaitTime - 1;
-      if piWaitTime <= 0 AND poAttackedNode = $
+      if piWaitTime <= 0
+         AND poAttackedNode = $
+         AND ptAttack = $
       {
          % Generate a wait between a minute and 4 hours
          ptAttack = CreateTimer(self,@StartAttackTimer,Random(60,14400)*1000);
@@ -366,6 +368,11 @@ messages:
 
       % Set timer for when everyone will be alerted, and send message to node
       %  holders. Convert minutes to milliseconds.
+      if (ptAttack <> $)
+      {
+         DeleteTimer(ptAttack);
+         ptAttack = $;
+      }
       ptAttack = CreateTimer(self,@WarnAllTimer,(piAttackDuration*60000)/3);
       lAllItems = Send(SYS,@GetUsersLoggedOn);
       foreach oItem in lAllItems


### PR DESCRIPTION
BP_STOP_WAVE will instruct the client to stop playing a given sound resource.

Added the rain.wav sound to room.kod, plays when rain is active. StartRain() adds the sound to the room's looping sounds, EndRain() removes it. AddLoopingSound() and RemoveLoopingSound() will update the players in the room.