### PR TITLE
Damage Dealt Tracking

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -192,6 +192,13 @@ properties:
    
    % Reputation hashtable for monster territory/influence system
    phReputation = $
+
+   % Keeps track of who damaged this battler recently, and for how much.
+   % Used to determine who logged / killed this monster or player.
+   % Form [damager, amount, timer]
+   plHurtMeRecently = $
+   % 20 seconds default for players, 60 for monsters
+   piHurtMeTime = 20000
    
 messages:
 
@@ -243,6 +250,21 @@ messages:
             Send(i,@Delete);
          }
          plApparitionList = $;
+      }
+      
+      if plHurtMeRecently <> $
+      {
+         foreach i in plHurtMeRecently
+         {
+            if IsTimer(Nth(i,3))
+            {
+               DeleteTimer(Nth(i,3));
+            }
+            SetNth(i,1,$);
+            SetNth(i,2,$);
+            SetNth(i,3,$);
+            plHurtMeRecently = DelListElem(plHurtMeRecently,i);
+         }
       }
 
       propagate;
@@ -1770,6 +1792,68 @@ messages:
          AddTableEntry(phReputation,faction,value);
       }
       
+      return;
+   }
+   
+   GetHurtMeRecentlyAmount(who=$)
+   {
+      local i;
+      
+      foreach i in plHurtMeRecently
+      {
+         if Nth(i,1) = who
+         {
+            return Nth(i,2);
+         }
+      }
+
+      return 0;
+   }
+   
+   AddHurtMeRecently(who=$,amount=0)
+   {
+      local i;
+      
+      foreach i in plHurtMeRecently
+      {
+         if Nth(i,1) = who
+         {
+            if Nth(i,2) + amount > 100000
+            {
+               % Somebody is doing something stupid. Let's return this.
+               % Catch for players botting attacks on alts, shenanigans.
+               return;
+            }
+            SetNth(i,2,Nth(i,2)+amount);
+            DeleteTimer(Nth(i,3));
+            SetNth(i,3,CreateTimer(self,@RemoveHurtMeRecently,piHurtMeTime));
+            return;
+         }
+      }
+      
+      plHurtMeRecently = Cons([who,amount,CreateTimer(self,
+                               @RemoveHurtMeRecently,piHurtMeTime)],
+                               plHurtMeRecently);
+      
+      return;
+   }
+
+   RemoveHurtMeRecently(timer=$)
+   {
+      local i;
+      
+      foreach i in plHurtMeRecently
+      {
+         if Nth(i,3) = timer
+         {
+            SetNth(i,1,$);
+            SetNth(i,2,$);
+            SetNth(i,3,$);
+            plHurtMeRecently = DelListElem(plHurtMeRecently,i);
+            return;
+         }
+      }
+
       return;
    }
    

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -496,6 +496,9 @@ properties:
    piReputationGroup = REP_NEUTRAL
    plReputationEnemies = $
 
+   % 20 seconds default for players, 60 for monsters
+   piHurtMeTime = 60000
+
 messages:
 
    Constructor(template=FALSE, color=0, piSurvivalLevel=0, iBrain = 0)
@@ -2258,6 +2261,8 @@ messages:
          Post(what,@MsgPlayerHitResisted,#what=what,#resistance=iResist,
               #target=self,#color_rsc=monster_color_blue_rsc);
       }
+      
+      Send(self,@AddHurtMeRecently,#who=what,#amount=iDamage);
 
       return iDamage;
    }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5673,6 +5673,8 @@ messages:
       {
          Send(shrunken,@DamageTaken,#what=what,#amount=damage/100);
       }
+      
+      Send(self,@AddHurtMeRecently,#who=what,#amount=damage);
 
       return damage;
    }


### PR DESCRIPTION
I know we've got lots of pulls in 1.0.16.0 but this is vital and pretty simple.

plHurtMeRecently keeps track of who dealt damage to players and monsters
recently. Each new instance of damage resets the timer. 20 seconds for
players, 60 seconds for monsters. When the timer runs out, you're no longer
in the list of who hurt this battler recently.

This'll help us know who actually logged or killed a player or monster. We can 
compare sum damage dealt and say, with certainty, something like:

[server message] Gar was just logged by Keen.

or if boss mobs get taken down, each player gets rewarded based on 
how much damage they dealt.