### PR TITLE
Add utility message to set the game year

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -2744,6 +2744,13 @@ messages:
       return piBorn_year;
    }
 
+   SetBirthYear(year=0)
+   {
+      piBorn_Year = year;
+
+      return;
+   }
+
    ResetCharacter()
    "Setup default stuff"
    {

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -4755,6 +4755,26 @@ messages:
       return piYear;
    }
 
+   SetYear(year=0)
+   {
+      local i, oldYear, adjust;
+
+      oldYear = piYear;
+      piYear = year;
+      adjust = piYear - oldYear;
+
+      foreach i in plUsers
+      {
+         if (Send(i,@GetLastLoginTime) <> 0)
+         {
+            Send(i,@SetBirthYear,#year=Send(i,@GetBirthYear) + adjust);
+         }
+      }
+      
+      return;
+      
+   }
+
    ClearAllQuests()
    {
       if poQuestEngine <> $


### PR DESCRIPTION
Users will soon be able to see the game year through the time command.  For lore reasons and possible future use, the year should be later than the years already recorded in various places such as the princess castle library. latest recorded date there is 715.