### PR TITLE
Add piFloodCount property for better information on packet floods

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -539,6 +539,9 @@ properties:
    % What order do you want your inventory sorted in?
    plClassOrderPreferences = $
 
+   % keep track of how much this player triggers flood protection
+   piFloodCount = 0
+
 messages:
 
    Constructor(name = $,icon = $)
@@ -1139,6 +1142,8 @@ messages:
          if piPacketsPerSecond > INCOMING_PACKET_THROTTLE
             AND NOT Send(self,@PlayerIsImmortal)
          {
+            piFloodCount++;
+
             % Don't go on if marked as spammer
             return;
          }


### PR DESCRIPTION
There is currently no way to see how much a player goes over the maximum packet count per second.  This property tracks the number of packets a player has sent that were rejected by the server due to flooding.