### PR TITLE
Removed some unused variables

### DIFF
--- a/blakserv/ccode.c
+++ b/blakserv/ccode.c
@@ -4565,8 +4565,8 @@ int C_RecordStat(int object_id,local_var_type *local_vars,
 				int num_name_parms,parm_node name_parm_array[])
 {	
 	val_type stat_type, stat1, stat2, stat3, stat4, stat5, stat6, stat7, stat8, stat9, stat10, stat11, stat12, stat13;
-	resource_node *r_who_damaged, *r_who_attacker, *r_weapon, *r_victim, *r_cause, *r_killer, *r_room, *r_attack,
-      *r_name, *r_home, *r_bind, *r_guild, *r_leader, *r_ghall;
+	resource_node *r_who_damaged, *r_who_attacker, *r_weapon, *r_victim, *r_killer, *r_room, *r_attack,
+      *r_name, *r_home, *r_bind, *r_leader, *r_ghall;
 
    session_node *session;
    string_node *snod;


### PR DESCRIPTION
Removed some unused variables that were causing the nmake build to fail due to warnings treated as errors