### PR TITLE
Add an admin command to clear out unused accounts and compact IDs.

### DIFF
--- a/blakserv/account.c
+++ b/blakserv/account.c
@@ -541,3 +541,32 @@ void DeleteAccountAndAssociatedUsersByID(int account_id)
 	      account_id);
    }
 }
+
+// Deletes an account and associated users if account has never been logged in.
+void DeleteAccountIfUnused(account_node *a)
+{
+   if (a->last_login_time == 0)
+      DeleteAccountAndAssociatedUsersByID(a->account_id);
+}
+
+// Compacts the accounts if any have been removed. Called by
+// AdminDeleteUnusedAccounts after deleting unused accounts.
+void CompactAccounts()
+{
+   account_node *a;
+   int new_number = 1;
+
+   a = accounts;
+
+   while (a != NULL)
+   {
+      if (a->account_id != new_number)
+      {
+         ChangeUserAccountID(a->account_id, new_number);
+         a->account_id = new_number;
+      }
+      ++new_number;
+      a = a->next;
+   }
+   SetNextAccountID(new_number);
+}

--- a/blakserv/account.h
+++ b/blakserv/account.h
@@ -49,6 +49,8 @@ void AccountLogoff(account_node *a);
 void DoneLoadAccounts(void);
 void ForEachAccount(void (*callback_func)(account_node *a));
 void DeleteAccountAndAssociatedUsersByID(int account_id);
+void DeleteAccountIfUnused(account_node *a);
+void CompactAccounts(void);
 
 Bool SuspendAccountAbsolute(account_node *a, int suspend_time);
 Bool SuspendAccountRelative(account_node *a, int hours);

--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -122,6 +122,8 @@ void AdminShowAccount(int session_id,admin_parm_type parms[],
                       int num_blak_parm,parm_node blak_parm[]);
 void AdminShowAccountHeader(void);
 void AdminShowOneAccount(account_node *a);
+void AdminDeleteUnusedAccounts(int session_id, admin_parm_type parms[],
+                               int num_blak_parm, parm_node blak_parm[]);
 void AdminShowResource(int session_id,admin_parm_type parms[],
                        int num_blak_parm,parm_node blak_parm[]);
 void AdminPrintResource(resource_node *r);
@@ -425,6 +427,7 @@ admin_table_type admin_create_table[] =
 admin_table_type admin_delete_table[] =
 {
 	{ AdminDeleteAccount, {I,N}, F, A|M,NULL, 0, "account","Delete account & user by ID" },
+	{ AdminDeleteUnusedAccounts, { N }, F, A | M, NULL, 0, "unused", "Delete unused accounts" },
 	{ AdminDeleteTimer,   {I,N}, F, A|M, NULL, 0, "timer",  "Delete timer by ID" },
 	{ AdminDeleteUser,    {I,N}, F, A|M, NULL, 0, "user",   "Delete user by object ID" },
 };
@@ -1851,7 +1854,7 @@ void AdminShowOneAccount(account_node *a)
 }
 
 void AdminShowResource(int session_id,admin_parm_type parms[],
-                       int num_blak_parm,parm_node blak_parm[])                       
+                       int num_blak_parm,parm_node blak_parm[])
 {
 	int rsc_id;
 	resource_node *r;
@@ -4668,6 +4671,33 @@ void AdminReloadGame(int session_id,admin_parm_type parms[],
 	SendTopLevelBlakodMessage(GetSystemObjectID(),LOADED_GAME_MSG,0,NULL);
 	
 	aprintf("done.\n");
+}
+
+// Uses the accounts_in_game global.
+void AdminDeleteUnusedAccounts(int session_id, admin_parm_type parms[],
+   int num_blak_parm, parm_node blak_parm[])
+{
+   // Make sure no one in game, because after deleting accounts
+   // we compact the numbers.
+   AdminHangupAll(session_id, parms, num_blak_parm, blak_parm);
+
+   accounts_in_game = 0;
+   ForEachSession(AdminReloadGameEachSession);
+   if (accounts_in_game > 0)
+   {
+      aprintf("Cannot delete unused accounts because %i %s in game.\n",
+         accounts_in_game, accounts_in_game == 1 ? "person is" : "people are");
+      return;
+   }
+
+   int beforeAcct = GetActiveAccountCount();
+
+   aprintf("Number of accounts before is: %i.\n", beforeAcct);
+   ForEachAccount(DeleteAccountIfUnused);
+   CompactAccounts();
+   int afterAcct = GetActiveAccountCount();
+   aprintf("Number of accounts after is: %i, deleted %i accounts.\n",
+      afterAcct, beforeAcct - afterAcct);
 }
 
 void AdminReloadGameEachSession(session_node *s)

--- a/blakserv/user.c
+++ b/blakserv/user.c
@@ -323,3 +323,15 @@ user_node * GetUserByName(char *username)
    return GetUserByObjectID(ret_val.v.data);
 }
 
+void ChangeUserAccountID(int account_id, int new_account_id)
+{
+   user_node *u;
+
+   u = users;
+   while (u != NULL)
+   {
+      if (u->account_id == account_id)
+         u->account_id = new_account_id;
+      u = u->next;
+   }
+}

--- a/blakserv/user.h
+++ b/blakserv/user.h
@@ -36,5 +36,6 @@ void ForEachUser(void (*callback_func)(user_node *u));
 void ForEachUserByAccountID(void (*callback_func)(user_node *u),int account_id);
 user_node * GetFirstUserByAccountID(int account_id);
 user_node * GetUserByName(char *username);
+void ChangeUserAccountID(int account_id, int new_account_id);
 
 #endif


### PR DESCRIPTION
The admin command "delete unused" will remove any unused accounts (i.e.
any that have never been logged on before) and compact the account
numbers to reclaim previously used ones.

Kicks off all users before carrying out the delete/compact to avoid any
potential issues with sessions.