### PR TITLE
No Conveyance in Halls

### DIFF
--- a/kod/object/active/holder/room/ghall.kod
+++ b/kod/object/active/holder/room/ghall.kod
@@ -88,6 +88,9 @@ resources:
 
    guildhall_newsball = "news"
    guildhall_newsdesc = "This is the latest guild news."
+   
+   cannot_conveyance_msg = \
+      "The guild hall's innate defenses prevent you from casting conveyance!"
 
    guildhall_sound_down = shielddn.wav
    guildhall_sound_up = shieldup.wav
@@ -1307,6 +1310,22 @@ messages:
    CanTokenEnterRoom()
    {
       return FALSE;
+   }
+   
+   ReqSpellCast(oSpell=$,who=$)
+   {
+      % Cannot conveyance inside a hall.
+      if IsClass(oSpell,&Conveyance)
+      {
+         if who <> $
+            AND IsClass(who,&Player)
+         {
+            Send(who,@MsgSendUser,#message_rsc=cannot_conveyance_msg);
+         }
+         return FALSE;
+      }
+
+      propagate;
    }
 
 end


### PR DESCRIPTION
This prevents casting of conveyance inside the main portions of halls
except by the guild that owns it. Unowned, raided, and conquered halls
also prevent conveyance. This is to prevent any 'easy looting' shenanigans
until you actually fully own the hall.

builds, runs, tested in-game no errors or debug messages