### PR TITLE
Set destination coordinates for gallery to UW portal

### DIFF
--- a/kod/object/active/holder/room/gallery.kod
+++ b/kod/object/active/holder/room/gallery.kod
@@ -76,7 +76,7 @@ messages:
 
       Send(self,@NewHold,#what=Create(&Throne),#new_row=2,#new_col=2);
       Send(self,@NewHold,#what=Create(&Tombstone),#new_row=3,#new_col=2);
-      Send(self,@NewHold,#what=Create(&Portal),#new_row=4,#new_col=2);
+      Send(self,@NewHold,#what=Create(&Portal,#dest_row=23,#dest_col=19),#new_row=4,#new_col=2);
       Send(self,@NewHold,#what=Create(&HellPortal),#new_row=2,#new_col=13);
       Send(self,@NewHold,#what=Create(&Chest),#new_row=3,#new_col=13);
       Send(self,@NewHold,#what=Create(&Box),#new_row=4,#new_col=13);


### PR DESCRIPTION
Currently the underworld portal in the object gallery room takes you outside the underworld map.  Setting destination coordinates in the portal creation fixes this.