### PR TITLE
No Sweeping between guild hall zones

### DIFF
--- a/kod/object/passive/spell/sweep.kod
+++ b/kod/object/passive/spell/sweep.kod
@@ -103,9 +103,17 @@ messages:
          oObj = Send(oRoom,@HolderExtractObject,#data=lPassive);
 
          % Cull everything that isn't "get-able" out of the list.
+         % Also exclude items that are in guild halls and not in the same
+         % section as the caster to prevent 'sweep transfers'
          if IsClass(oObj,&Item)
             AND send(who,@ReqNewHold,#what=oObj)
             AND Send(oObj,@CanSweep)
+            AND NOT (IsClass(oRoom,&GuildHall)
+               AND Send(oRoom,@InFoyer,#who=who) <>
+                  Send(oRoom,@InFoyer,#iRow=Send(oObj,@GetRow),
+                        #iCol=Send(oObj,@GetCol),
+                        #iFineRow=Send(oObj,@GetFineRow),
+                        #iFineCol=Send(oObj,@GetFineCol)))
          {
             lGoodItems = cons(oObj,lGoodItems);
          }                 


### PR DESCRIPTION
Sweep will no longer grab items between zones under any circumstances.
If the item is inside the hall and you are in the foyer, or if the item
is in the foyer and you are inside the hall, Sweep will ignore the item.

This is similar to the Conveyance tweak. I have looted halls this way in the past;
take stuff from the chest, drop it, and have a character in the foyer cast Sweep.
Sometimes you can be far enough away that people in the hall won't even
hear the spell. Other than that, it's just strange that halls would allow this while
preventing everything else (EQ, attacks, etc).

Additionally, Sweep allows riskless stocking of chests (item transfer without
opening the door).

built, tested in and out of multiple halls, and in normal zones, dm and mortal