### PR TITLE
Optimize BSPCanMoveInRoomTree

### DIFF
--- a/blakserv/ccode.c
+++ b/blakserv/ccode.c
@@ -2674,7 +2674,8 @@ int C_CanMoveInRoomBSP(int object_id, local_var_type *local_vars,
 	e.X = GRIDCOORDTOROO(col_dest.v.data, finecol_dest.v.data);
 	e.Y = GRIDCOORDTOROO(row_dest.v.data, finerow_dest.v.data);
 
-	ret_val.v.data = BSPCanMoveInRoom(&r->data, &s, &e, objectid.v.data, (move_outside_bsp.v.data != 0));
+	Wall* blockWall;
+	ret_val.v.data = BSPCanMoveInRoom(&r->data, &s, &e, objectid.v.data, (move_outside_bsp.v.data != 0), &blockWall);
 
 #if DEBUGMOVE
 	//dprintf("MOVE:%i R:%i S:(%1.2f/%1.2f) E:(%1.2f/%1.2f)", ret_val.v.data, r->data.roomdata_id, s.X, s.Y, e.X, e.Y);

--- a/blakserv/geometry.h
+++ b/blakserv/geometry.h
@@ -44,7 +44,7 @@ typedef struct V2
 
 #define V2SUB(a,b,c) \
    (a)->X = (b)->X - (c)->X; \
-   (a)->Y = (b)->Y - (c)->Y;;
+   (a)->Y = (b)->Y - (c)->Y;
 
 #define V2SCALE(a,b) \
    (a)->X *= b; \

--- a/blakserv/roofile.c
+++ b/blakserv/roofile.c
@@ -535,46 +535,50 @@ bool BSPCanMoveInRoomTree(BspNode* Node, V2* S, V2* E)
       // q will store the too-close endpoint
       else
       {
-         // iterate finite segments (walls) in this splitter
-         Wall* wall = Node->u.internal.FirstWall;
-         while (wall)
+         // check only getting closer
+         if (fabs(distE) <= fabs(distS))
          {
-            // get min. squared distance from move endpoint to line segment
-            float dist2 = MinSquaredDistanceToLineSegment(E, &wall->P1, &wall->P2);
-
-            // skip if far enough away
-            if (dist2 > WALLMINDISTANCE2)
+            // iterate finite segments (walls) in this splitter
+            Wall* wall = Node->u.internal.FirstWall;
+            while (wall)
             {
+               // get min. squared distance from move endpoint to line segment
+               float dist2 = MinSquaredDistanceToLineSegment(E, &wall->P1, &wall->P2);
+
+               // skip if far enough away
+               if (dist2 > WALLMINDISTANCE2)
+               {
+                  wall = wall->NextWallInPlane;
+                  continue;
+               }
+
+               q.X = E->X;
+               q.Y = E->Y;
+
+               // set from and to sector / side
+               // for case 2 (too close) these are based on (S),
+               // and (E) is assumed to be on the other side.
+               if (distS >= 0.0f)
+               {
+                  sideS = wall->RightSide;
+                  sectorS = wall->RightSector;
+                  sideE = wall->LeftSide;
+                  sectorE = wall->LeftSector;
+               }
+               else
+               {
+                  sideS = wall->LeftSide;
+                  sectorS = wall->LeftSector;
+                  sideE = wall->RightSide;
+                  sectorE = wall->RightSector;
+               }
+
+               // check the transition data for this wall
+               if (!BSPCanMoveInRoomTreeInternal(sectorS, sectorE, sideS, sideE, &q))
+                  return false;
+
                wall = wall->NextWallInPlane;
-               continue;
             }
-
-            q.X = E->X;
-            q.Y = E->Y;
-
-            // set from and to sector / side
-            // for case 2 (too close) these are based on (S),
-            // and (E) is assumed to be on the other side.
-            if (distS >= 0.0f)
-            {
-               sideS = wall->RightSide;
-               sectorS = wall->RightSector;
-               sideE = wall->LeftSide;
-               sectorE = wall->LeftSector;
-            }
-            else
-            {
-               sideS = wall->LeftSide;
-               sectorS = wall->LeftSector;
-               sideE = wall->RightSide;
-               sectorE = wall->RightSector;
-            }
-
-            // check the transition data for this wall
-            if (!BSPCanMoveInRoomTreeInternal(sectorS, sectorE, sideS, sideE, &q))
-               return false;
-
-            wall = wall->NextWallInPlane;
          }
       }
 

--- a/blakserv/roofile.c
+++ b/blakserv/roofile.c
@@ -87,6 +87,43 @@ __inline float GetSectorHeightFloorWithDepth(Sector* Sector, V2* P)
    return height;
 }
 
+__inline bool BSPCanMoveInRoomTreeInternal(Sector* SectorS, Sector* SectorE, Side* SideS, Side* SideE, V2* Q)
+{
+   // block moves with end outside
+   if (!SectorE || !SideE)
+      return false;
+
+   // don't block moves with start outside and end inside
+   if (!SectorS || !SideS)
+      return true;
+
+   // sides which have no passable flag set always block
+   if (!((SideS->Flags & WF_PASSABLE) == WF_PASSABLE))
+      return false;
+
+   // get floor heights
+   float hFloorS = GetSectorHeightFloorWithDepth(SectorS, Q);
+   float hFloorE = GetSectorHeightFloorWithDepth(SectorE, Q);
+
+   // check stepheight (this also requires a lower texture set)
+   if (SideS->TextureLower > 0 && (hFloorE - hFloorS > MAXSTEPHEIGHT))
+      return false;
+
+   // get ceiling heights
+   //float hCeilingS = SECTORHEIGHTCEILING(SectorS, Q);
+   float hCeilingE = SECTORHEIGHTCEILING(SectorE, Q);
+
+   // check ceilingheight (this also requires an upper texture set)
+   if (SideS->TextureUpper > 0 && (hCeilingE - hFloorS < OBJECTHEIGHTROO))
+      return false;
+
+   // check endsector height
+   if (hCeilingE - hFloorE < OBJECTHEIGHTROO)
+      return false;
+
+   return true;
+}
+
 void BSPUpdateLeafHeights(room_type* Room, Sector* Sector, bool Floor)
 {
    for (int i = 0; i < Room->TreeNodesCount; i++)
@@ -385,232 +422,175 @@ bool BSPLineOfSightTree(BspNode* Node, V3* S, V3* E)
 
 bool BSPCanMoveInRoomTree(BspNode* Node, V2* S, V2* E)
 {
-	// reached a leaf or nullchild, movements not blocked by leafs
-	if (!Node || Node->Type != BspInternalType)
-		return true;
+   // reached a leaf or nullchild, movements not blocked by leafs
+   if (!Node || Node->Type != BspInternalType)
+      return true;
 
-	/****************************************************************/
+   /****************************************************************/
 
-	// get signed distances from splitter to both endpoints of move
-	float distS = DISTANCETOSPLITTERSIGNED(&Node->u.internal, S);
-	float distE = DISTANCETOSPLITTERSIGNED(&Node->u.internal, E);
+   // get signed distances from splitter to both endpoints of move
+   float distS = DISTANCETOSPLITTERSIGNED(&Node->u.internal, S);
+   float distE = DISTANCETOSPLITTERSIGNED(&Node->u.internal, E);
 
-	/****************************************************************/
+   /****************************************************************/
 
-	// both endpoints far away enough on positive (right) side
-	// --> climb down only right subtree
-	if (distS > WALLMINDISTANCE && distE > WALLMINDISTANCE)
-		return BSPCanMoveInRoomTree(Node->u.internal.RightChild, S, E);
+   // both endpoints far away enough on positive (right) side
+   // --> climb down only right subtree
+   if (distS > WALLMINDISTANCE && distE > WALLMINDISTANCE)
+      return BSPCanMoveInRoomTree(Node->u.internal.RightChild, S, E);
 
-	// both endpoints far away enough on negative (left) side
-	// --> climb down only left subtree
-	else if (distS < -WALLMINDISTANCE && distE < -WALLMINDISTANCE)
-		return BSPCanMoveInRoomTree(Node->u.internal.LeftChild, S, E);
+   // both endpoints far away enough on negative (left) side
+   // --> climb down only left subtree
+   else if (distS < -WALLMINDISTANCE && distE < -WALLMINDISTANCE)
+      return BSPCanMoveInRoomTree(Node->u.internal.LeftChild, S, E);
 
-	// endpoints are on different sides, one/both on infinite line or potentially too close
-	// --> check walls of splitter first and then possibly climb down both subtrees
-	else
-	{
-		// loop through walls in this splitter
-		Wall* wall = Node->u.internal.FirstWall;
-		while (wall)
-		{
-			// these will be filled by two cases below
-			V2 q;
-			Side* sideS;
-			Sector* sectorS;
-			Side* sideE;
-			Sector* sectorE;
+   // endpoints are on different sides, one/both on infinite line or potentially too close
+   // --> check walls of splitter first and then possibly climb down both subtrees
+   else
+   {
+      V2 q;
+      Side* sideS;
+      Sector* sectorS;
+      Side* sideE;
+      Sector* sectorE;
 
-			// CASE 1) The move line actually crosses this infinite splitter.
-			// This case handles long movelines where S and E can be far away from each other and
-			// just checking the distance of E to the line would fail.
-			// q contains the intersection point
-			if ((distS > 0.0f && distE < 0.0f) ||
-				(distS < 0.0f && distE > 0.0f))
-			{
-				// get 2d line equation coefficients for infinite line through S and E
-				float a1, b1, c1;
-				a1 = E->Y - S->Y;
-				b1 = S->X - E->X;
-				c1 = a1 * S->X + b1 * S->Y;
+      // CASE 1) The move line actually crosses this infinite splitter.
+      // This case handles long movelines where S and E can be far away from each other and
+      // just checking the distance of E to the line would fail.
+      // q contains the intersection point
+      if ((distS > 0.0f && distE < 0.0f) ||
+          (distS < 0.0f && distE > 0.0f))
+      {
+         // get 2d line equation coefficients for infinite line through S and E
+         float a1, b1, c1;
+         a1 = E->Y - S->Y;
+         b1 = S->X - E->X;
+         c1 = a1 * S->X + b1 * S->Y;
 
-				// get 2d line equation coefficients for infinite line through P1 and P2
-				// NOTE: This should be using BspInternal A,B,C coefficients
-				float a2, b2, c2;
-				a2 = wall->P2.Y - wall->P1.Y;
-				b2 = wall->P1.X - wall->P2.X;
-				c2 = a2 * wall->P1.X + b2 * wall->P1.Y;
+         // iterate finite segments (walls) in this splitter
+         Wall* wall = Node->u.internal.FirstWall;
+         while (wall)
+         {
+            // get 2d line equation coefficients for infinite line through P1 and P2
+            // NOTE: This should be using BspInternal A,B,C coefficients
+            float a2, b2, c2;
+            a2 = wall->P2.Y - wall->P1.Y;
+            b2 = wall->P1.X - wall->P2.X;
+            c2 = a2 * wall->P1.X + b2 * wall->P1.Y;
 
-				float det = a1*b2 - a2*b1;
+            float det = a1*b2 - a2*b1;
 
-				// parallel (or identical) lines
-				// should not happen here but is important for div by 0
-				if (ISZERO(det))
-				{
-					wall = wall->NextWallInPlane;
-					continue;
-				}
+            // parallel (or identical) lines
+            // should not happen here but is important for div by 0
+            if (ISZERO(det))
+            {
+               wall = wall->NextWallInPlane;
+               continue;
+            }
 
-				// intersection point of infinite lines				
-				q.X = (b2*c1 - b1*c2) / det;
-				q.Y = (a1*c2 - a2*c1) / det;
+            // intersection point of infinite lines				
+            q.X = (b2*c1 - b1*c2) / det;
+            q.Y = (a1*c2 - a2*c1) / det;
 
-				//dprintf("intersect: %f %f \t p1.x:%f p1.y:%f p2.x:%f p2.y:%f \n", q.X, q.Y, wall->P1.X, wall->P1.Y, wall->P2.X, wall->P2.Y);
+            // infinite intersection point must be in BOTH
+            // finite segments boundingboxes, otherwise no intersect
+            if (!ISINBOX(S, E, &q) || !ISINBOX(&wall->P1, &wall->P2, &q))
+            {
+               wall = wall->NextWallInPlane;
+               continue;
+            }
 
-				// infinite intersection point must be in BOTH
-				// finite segments boundingboxes, otherwise no intersect
-				if (!ISINBOX(S, E, &q) || !ISINBOX(&wall->P1, &wall->P2, &q))
-				{
-					wall = wall->NextWallInPlane;
-					continue;
-				}
+            // set from and to sector / side
+            if (distS > 0.0f)
+            {
+               sideS = wall->RightSide;
+               sectorS = wall->RightSector;
+            }
+            else
+            {
+               sideS = wall->LeftSide;
+               sectorS = wall->LeftSector;
+            }
 
-				// set from and to sector / side
-				if (distS > 0.0f)
-				{
-					sideS = wall->RightSide;
-					sectorS = wall->RightSector;
-				}
-				else
-				{
-					sideS = wall->LeftSide;
-					sectorS = wall->LeftSector;
-				}
+            if (distE > 0.0f)
+            {
+               sideE = wall->RightSide;
+               sectorE = wall->RightSector;
+            }
+            else
+            {
+               sideE = wall->LeftSide;
+               sectorE = wall->LeftSector;
+            }
 
-				if (distE > 0.0f)
-				{
-					sideE = wall->RightSide;
-					sectorE = wall->RightSector;
-				}
-				else
-				{
-					sideE = wall->LeftSide;
-					sectorE = wall->LeftSector;
-				}
-			}
+            // check the transition data for this wall
+            if (!BSPCanMoveInRoomTreeInternal(sectorS, sectorE, sideS, sideE, &q))
+               return false;
 
-			// CASE 2) The move line does not cross the infinite splitter, both move endpoints are on the same side.
-			// This handles short moves where walls are not intersected, but the endpoint may be too close
-			// q will store the too-close endpoint
-			else
-			{
-				// allow getting "away" from wall (distS, distE are signed)
-				// even in case both endpoints would be too close
-				if (fabs(distE) > fabs(distS))
-				{
-					wall = wall->NextWallInPlane;
-					continue;
-				}
+            wall = wall->NextWallInPlane;
+         }
+      }
 
-				// get min. squared distance from move endpoint to line segment
-				float dist2 = MinSquaredDistanceToLineSegment(E, &wall->P1, &wall->P2);
+      // CASE 2) The move line does not cross the infinite splitter, both move endpoints are on the same side.
+      // This handles short moves where walls are not intersected, but the endpoint may be too close
+      // q will store the too-close endpoint
+      else
+      {
+         // iterate finite segments (walls) in this splitter
+         Wall* wall = Node->u.internal.FirstWall;
+         while (wall)
+         {
+            // get min. squared distance from move endpoint to line segment
+            float dist2 = MinSquaredDistanceToLineSegment(E, &wall->P1, &wall->P2);
 
-				// skip if far enough away
-				if (dist2 > WALLMINDISTANCE2)
-				{
-					wall = wall->NextWallInPlane;
-					continue;
-				}
+            // skip if far enough away
+            if (dist2 > WALLMINDISTANCE2)
+            {
+               wall = wall->NextWallInPlane;
+               continue;
+            }
 
-				q.X = E->X;
-				q.Y = E->Y;
+            q.X = E->X;
+            q.Y = E->Y;
 
-				// set from and to sector / side
-				// for case 2 (too close) these are based on (S),
-				// and (E) is assumed to be on the other side.
-				if (distS >= 0.0f)
-				{
-					sideS = wall->RightSide;
-					sectorS = wall->RightSector;
-					sideE = wall->LeftSide;
-					sectorE = wall->LeftSector;
-				}
-				else
-				{
-					sideS = wall->LeftSide;
-					sectorS = wall->LeftSector;
-					sideE = wall->RightSide;
-					sectorE = wall->RightSector;
-				}
-			}
+            // set from and to sector / side
+            // for case 2 (too close) these are based on (S),
+            // and (E) is assumed to be on the other side.
+            if (distS >= 0.0f)
+            {
+               sideS = wall->RightSide;
+               sectorS = wall->RightSector;
+               sideE = wall->LeftSide;
+               sectorE = wall->LeftSector;
+            }
+            else
+            {
+               sideS = wall->LeftSide;
+               sectorS = wall->LeftSector;
+               sideE = wall->RightSide;
+               sectorE = wall->RightSector;
+            }
 
-			/****************************************/
-			/*   From here on both cases together   */
-			/****************************************/
+            // check the transition data for this wall
+            if (!BSPCanMoveInRoomTreeInternal(sectorS, sectorE, sideS, sideE, &q))
+               return false;
 
-			// block moves with end outside
-			if (!sectorE || !sideE)
-			{
-#if DEBUGMOVE
-				dprintf("MOVEBLOCK (END OUTSIDE): W:%i", wall->Num);
-#endif
-				return false;
-			}
+            wall = wall->NextWallInPlane;
+         }
+      }
 
-			// don't block moves with start outside (and end inside, see above)
-			if (!sectorS || !sideS)
-			{
-#if DEBUGMOVE
-				dprintf("MOVEALLOW (START OUT, END IN): W:%i", wall->Num);
-#endif
-				wall = wall->NextWallInPlane;
-				continue;
-			}
+      /****************************************************************/
 
-			// sides which have no passable flag set always block
-			if (!((sideS->Flags & WF_PASSABLE) == WF_PASSABLE))
-				return false;
+      // try right subtree first
+      bool retval = BSPCanMoveInRoomTree(Node->u.internal.RightChild, S, E);
 
-			// get heights
-			float hFloorS = GetSectorHeightFloorWithDepth(sectorS, &q);
-			float hFloorE = GetSectorHeightFloorWithDepth(sectorE, &q);
-			float hCeilingS = SECTORHEIGHTCEILING(sectorS, &q);
-			float hCeilingE = SECTORHEIGHTCEILING(sectorE, &q);
+      // found a collision there? return it
+      if (!retval)
+         return retval;
 
-			// check stepheight (this also requires a lower texture set)
-			if (sideS->TextureLower > 0 && (hFloorE - hFloorS > MAXSTEPHEIGHT))
-			{
-#if DEBUGMOVE
-				dprintf("MOVEBLOCK (STEPHEIGHT): W:%i HFS:%1.2f HFE:%1.2f", wall->Num, hFloorS, hFloorE);
-#endif
-				return false;
-			}
-
-			// check ceilingheight (this also requires an upper texture set)
-			if (sideS->TextureUpper > 0 && (hCeilingE - hFloorS < OBJECTHEIGHTROO))
-			{
-#if DEBUGMOVE
-				dprintf("MOVEBLOCK (UPWALL): W:%i HFS:%1.2f HCE:%1.2f", wall->Num, hFloorS, hCeilingE);
-#endif
-				return false;
-			}
-
-			// check endsector height
-			if (hCeilingE - hFloorE < OBJECTHEIGHTROO)
-			{
-#if DEBUGMOVE
-				dprintf("MOVEBLOCK (SECTHEIGHT): W:%i HFE:%1.2f HCE:%1.2f", wall->Num, hFloorE, hCeilingE);
-#endif
-				return false;
-			}
-
-			// next wall for next loop
-			wall = wall->NextWallInPlane;
-		}
-
-		/****************************************************************/
-
-		// try right subtree first
-		bool retval = BSPCanMoveInRoomTree(Node->u.internal.RightChild, S, E);
-
-		// found a collision there? return it
-		if (!retval)
-			return retval;
-
-		// otherwise try left subtree
-		return BSPCanMoveInRoomTree(Node->u.internal.LeftChild, S, E);
-	}
+      // otherwise try left subtree
+      return BSPCanMoveInRoomTree(Node->u.internal.LeftChild, S, E);
+   }
 }
 #pragma endregion
 

--- a/blakserv/roofile.c
+++ b/blakserv/roofile.c
@@ -420,7 +420,7 @@ bool BSPLineOfSightTree(BspNode* Node, V3* S, V3* E)
 	}
 }
 
-bool BSPCanMoveInRoomTree(BspNode* Node, V2* S, V2* E)
+bool BSPCanMoveInRoomTree(BspNode* Node, V2* S, V2* E, Wall** BlockWall)
 {
    // reached a leaf or nullchild, movements not blocked by leafs
    if (!Node || Node->Type != BspInternalType)
@@ -437,12 +437,12 @@ bool BSPCanMoveInRoomTree(BspNode* Node, V2* S, V2* E)
    // both endpoints far away enough on positive (right) side
    // --> climb down only right subtree
    if (distS > WALLMINDISTANCE && distE > WALLMINDISTANCE)
-      return BSPCanMoveInRoomTree(Node->u.internal.RightChild, S, E);
+      return BSPCanMoveInRoomTree(Node->u.internal.RightChild, S, E, BlockWall);
 
    // both endpoints far away enough on negative (left) side
    // --> climb down only left subtree
    else if (distS < -WALLMINDISTANCE && distE < -WALLMINDISTANCE)
-      return BSPCanMoveInRoomTree(Node->u.internal.LeftChild, S, E);
+      return BSPCanMoveInRoomTree(Node->u.internal.LeftChild, S, E, BlockWall);
 
    // endpoints are on different sides, or one/both on infinite line or potentially too close
    // --> check walls of splitter first and then possibly climb down both subtrees
@@ -522,8 +522,10 @@ bool BSPCanMoveInRoomTree(BspNode* Node, V2* S, V2* E)
 
                   // check the transition data for this wall
                   if (!BSPCanMoveInRoomTreeInternal(sectorS, sectorE, sideS, sideE, &q))
+                  {
+                     *BlockWall = wall;
                      return false;
-
+                  }
                   wall = wall->NextWallInPlane;
                }
             }		 
@@ -575,8 +577,10 @@ bool BSPCanMoveInRoomTree(BspNode* Node, V2* S, V2* E)
 
                // check the transition data for this wall
                if (!BSPCanMoveInRoomTreeInternal(sectorS, sectorE, sideS, sideE, &q))
+               {
+                  *BlockWall = wall;
                   return false;
-
+               }
                wall = wall->NextWallInPlane;
             }
          }
@@ -585,14 +589,14 @@ bool BSPCanMoveInRoomTree(BspNode* Node, V2* S, V2* E)
       /****************************************************************/
 
       // try right subtree first
-      bool retval = BSPCanMoveInRoomTree(Node->u.internal.RightChild, S, E);
+      bool retval = BSPCanMoveInRoomTree(Node->u.internal.RightChild, S, E, BlockWall);
 
       // found a collision there? return it
       if (!retval)
          return retval;
 
       // otherwise try left subtree
-      return BSPCanMoveInRoomTree(Node->u.internal.LeftChild, S, E);
+      return BSPCanMoveInRoomTree(Node->u.internal.LeftChild, S, E, BlockWall);
    }
 }
 #pragma endregion
@@ -630,7 +634,7 @@ bool BSPLineOfSight(room_type* Room, V3* S, V3* E)
 /*********************************************************************************************/
 /* BSPCanMoveInRoom:  Checks if you can walk a straight line from (S)tart to (E)nd           */
 /*********************************************************************************************/
-bool BSPCanMoveInRoom(room_type* Room, V2* S, V2* E, int ObjectID, bool moveOutsideBSP)
+bool BSPCanMoveInRoom(room_type* Room, V2* S, V2* E, int ObjectID, bool moveOutsideBSP, Wall** BlockWall)
 {
    if (!Room || Room->TreeNodesCount == 0 || !S || !E)
       return false;
@@ -645,7 +649,7 @@ bool BSPCanMoveInRoom(room_type* Room, V2* S, V2* E, int ObjectID, bool moveOuts
    }
 
    // first check against room geometry
-   bool roomok = (moveOutsideBSP || BSPCanMoveInRoomTree(&Room->TreeNodes[0], S, E));
+   bool roomok = (moveOutsideBSP || BSPCanMoveInRoomTree(&Room->TreeNodes[0], S, E, BlockWall));
 
    // already found a collision in room
    if (!roomok)
@@ -983,7 +987,8 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
    V2ADD(&stepend, S, &se);
    stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
    stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-   if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+   Wall* blockWall = NULL;
+   if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
    {
       *P = stepend;
       *Flags &= ~ESTATE_AVOIDING;
@@ -996,27 +1001,59 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
    /****************************************************/
 
    bool isAvoiding = ((*Flags & ESTATE_AVOIDING) == ESTATE_AVOIDING);
-   bool isRight = ((*Flags & ESTATE_CLOCKWISE) == ESTATE_CLOCKWISE);
+   bool isLeft = ((*Flags & ESTATE_CLOCKWISE) == ESTATE_CLOCKWISE);
 
    // not yet in clockwise or cclockwise mode
-   // randomly pick one of them
    if (!isAvoiding)
-      isRight = (rand() % 2 == 1);
+   {
+      // if not blocked by a wall, roll a dice to decide
+      // how to get around the blocking obj.
+      if (!blockWall)
+         isLeft = (rand() % 2 == 1);
+
+      // blocked by wall, go first into slide-along direction
+      // based on vector towards target
+      else
+      {		
+         V2 p1p2;
+         V2SUB(&p1p2, &blockWall->P2, &blockWall->P1);
+
+         float f1 = atan2f(se.Y, se.X);
+         float f2 = atan2f(p1p2.Y, p1p2.X);
+         float df = f1 - f2;
+
+         bool q1_pos = (df >= 0.0f && df <= (float)M_PI_2);
+         bool q2_pos = (df >= (float)M_PI_2 && df <= (float)M_PI);
+         bool q3_pos = (df >= (float)M_PI && df <= (float)(M_PI + M_PI_2));
+         bool q4_pos = (df >= (float)(M_PI + M_PI_2) && df <= (float)M_PI*2.0f);
+         bool q1_neg = (df <= 0.0f && df >= (float)-M_PI_2);
+         bool q2_neg = (df <= (float)-M_PI_2 && df >= (float)-M_PI);
+         bool q3_neg = (df <= (float)-M_PI && df >= (float)-(M_PI + M_PI_2));
+         bool q4_neg = (df <= (float)-(M_PI + M_PI_2) && df >= (float)-M_PI*2.0f);
+
+         isLeft = (q1_pos || q2_pos || q1_neg || q3_neg) ? false : true;
+
+         /*if (isLeft)
+            dprintf("trying left first  r: %f", df);
+         else
+            dprintf("trying right first   r: %f", df);*/
+      }
+   }
 
    // must run this possibly twice
    // e.g. left after right failed or right after left failed
    for (int i = 0; i < 2; i++)
    {
-      if (isRight)
+      if (isLeft)
       {
          V2 v = se;
 
-		 // try 22.5° right
+		 // try 22.5° left
 		 V2ROTATE(&v, 0.5f * (float)-M_PI_4);
 		 V2ADD(&stepend, S, &v);
          stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
          stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
 		 {
             *P = stepend;
             *Flags |= ESTATE_AVOIDING;
@@ -1024,12 +1061,12 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
             return true;
          }
 
-         // try 45° right
+         // try 45° left
          V2ROTATE(&v, 0.5f * (float)-M_PI_4);
          V2ADD(&stepend, S, &v);
          stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
          stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
          {
             *P = stepend;
             *Flags |= ESTATE_AVOIDING;
@@ -1037,12 +1074,12 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
             return true;
          }
 
-         // try 67.5° right
+         // try 67.5° left
          V2ROTATE(&v, 0.5f * (float)-M_PI_4);
          V2ADD(&stepend, S, &v);
          stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
          stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
          {
             *P = stepend;
             *Flags |= ESTATE_AVOIDING;
@@ -1050,12 +1087,12 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
             return true;
 		 }
 
-         // try 90° right
+         // try 90° left
          V2ROTATE(&v, 0.5f * (float)-M_PI_4);
          V2ADD(&stepend, S, &v);
          stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
          stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
          {
             *P = stepend;
             *Flags |= ESTATE_AVOIDING;
@@ -1063,12 +1100,12 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
             return true;
          }
 
-         // try 112.5° right
+         // try 112.5° left
          V2ROTATE(&v, 0.5f * (float)-M_PI_4);
          V2ADD(&stepend, S, &v);
          stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
          stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
          {
             *P = stepend;
             *Flags |= ESTATE_AVOIDING;
@@ -1076,12 +1113,12 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
             return true;
          }
 
-         // try 135° right
+         // try 135° left
          V2ROTATE(&v, (float)-M_PI_4);
          V2ADD(&stepend, S, &v);
          stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
          stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
          {
             *P = stepend;
             *Flags |= ESTATE_AVOIDING;
@@ -1089,21 +1126,22 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
             return true;
          }
 
-         // failed to circumvent by going right, switch to left
-         isRight = false;
+         // failed to circumvent by going left, switch to right
+         isLeft = false;
          *Flags |= ESTATE_AVOIDING;
          *Flags &= ~ESTATE_CLOCKWISE;
+		 dprintf("left failed, switching to right");
       }
       else
       {
          V2 v = se;
 
-         // try 22.5° left
+         // try 22.5° right
          V2ROTATE(&v, 0.5f * (float)M_PI_4);
          V2ADD(&stepend, S, &v);
          stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
          stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
          {
             *P = stepend;
             *Flags |= ESTATE_AVOIDING;
@@ -1111,12 +1149,12 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
             return true;
          }
 
-         // try 45° left
+         // try 45° right
          V2ROTATE(&v, 0.5f * (float)M_PI_4);
          V2ADD(&stepend, S, &v);
          stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
          stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
          {
             *P = stepend;
             *Flags |= ESTATE_AVOIDING;
@@ -1124,12 +1162,12 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
             return true;
          }
 
-         // try 67.5° left
+         // try 67.5° right
          V2ROTATE(&v, 0.5f * (float)M_PI_4);
          V2ADD(&stepend, S, &v);
          stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
          stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
          {
             *P = stepend;
             *Flags |= ESTATE_AVOIDING;
@@ -1137,12 +1175,12 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
             return true;
 		 }
 
-         // try 90° left
+         // try 90° right
          V2ROTATE(&v, 0.5f * (float)M_PI_4);
          V2ADD(&stepend, S, &v);
          stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
          stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
          {
             *P = stepend;
             *Flags |= ESTATE_AVOIDING;
@@ -1150,12 +1188,12 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
             return true;
          }
 
-         // try 112.5° left
+         // try 112.5° right
          V2ROTATE(&v, 0.5f * (float)M_PI_4);
          V2ADD(&stepend, S, &v);
          stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
          stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
          {
             *P = stepend;
             *Flags |= ESTATE_AVOIDING;
@@ -1163,12 +1201,12 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
             return true;
          }
 
-         // try 135° left
+         // try 135° right
          V2ROTATE(&v, 0.5f * (float)M_PI_4);
          V2ADD(&stepend, S, &v);
          stepend.X = ROUNDROOTOKODFINENESS(stepend.X);
          stepend.Y = ROUNDROOTOKODFINENESS(stepend.Y);
-         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP))
+         if (BSPCanMoveInRoom(Room, S, &stepend, ObjectID, moveOutsideBSP, &blockWall))
          {
             *P = stepend;
             *Flags |= ESTATE_AVOIDING;
@@ -1176,10 +1214,11 @@ bool BSPGetStepTowards(room_type* Room, V2* S, V2* E, V2* P, unsigned int* Flags
             return true;
          }
 
-         // failed to circumvent by going left, switch to right
-         isRight = true;
+         // failed to circumvent by going right, switch to left
+         isLeft = true;
          *Flags |= ESTATE_AVOIDING;
          *Flags |= ESTATE_CLOCKWISE;
+		 dprintf("right failed, switching to left");
       }
    }
 

--- a/blakserv/roofile.c
+++ b/blakserv/roofile.c
@@ -683,18 +683,6 @@ bool BSPCanMoveInRoom(room_type* Room, V2* S, V2* E, int ObjectID, bool moveOuts
          // end must be farer away than start
          if (de2 <= ds2)
             return false;
-
-         // step (se) must also point towards +-90° of the straight step-away direction (ms)
-         // if it's not starting exactly on S (if so there's no straight step-away dir and all are allowed)
-         if (ds2 > EPSILON)
-         {
-            V2 se;
-            V2SUB(&se, E, S); // from s to e
-            float angle = acosf(V2DOT(&ms, &se));
-
-            if (angle < -M_PI_2 || angle > M_PI_2)
-               return false;
-		 }
       }
 
       // CASE 2) Start is outside blockradius, verify by intersection algorithm.

--- a/blakserv/roofile.h
+++ b/blakserv/roofile.h
@@ -219,7 +219,7 @@ typedef struct room_type
 /*                                          METHODS                                                           */
 /**************************************************************************************************************/
 bool  BSPGetHeight(room_type* Room, V2* P, float* HeightF, float* HeightFWD, float* HeightC, BspLeaf** Leaf);
-bool  BSPCanMoveInRoom(room_type* Room, V2* S, V2* E, int ObjectID, bool moveOutsideBSP);
+bool  BSPCanMoveInRoom(room_type* Room, V2* S, V2* E, int ObjectID, bool moveOutsideBSP, Wall** BlockWall);
 bool  BSPLineOfSight(room_type* Room, V3* S, V3* E);
 void  BSPChangeTexture(room_type* Room, unsigned int ServerID, unsigned short NewTexture, unsigned int Flags);
 void  BSPMoveSector(room_type* Room, unsigned int ServerID, bool Floor, float Height, float Speed);


### PR DESCRIPTION
a9ddfb4, aa46922, 1a7e81e
Performance improvements in BSPCanMoveInRoomTree

b05f775 :
Mini fix

cd8161c :
This improves the movement-heuristic. The room collision check will now return the collision-wall. Using this and the vector towards the target, monsters are now able to pick a better "initial" avoid-direction to get around a blocking room-element (better than just to roll a dice). Please note that this initial decision they make now can still lead them towards a dead-end etc. However their behaviour for chasing a player around a building (especially when deciding the first direction to go) should be better.

5836077 :
Removed a part from BSPCanMoveInRoom which has a calculation mistake and turned out to be not required anyways.