### PR TITLE
Fix banker dup bug

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -4459,8 +4459,11 @@ messages:
             }
          }
       }
+      else
+      {
+         Send(oMoney,@AddNumber,#number=amount);
+      }
 
-      Send(oMoney,@AddNumber,#number=amount);
       Send(oBank,@DepositAccount,#what=who,#amount=iBankAmt-amount);
 
       % Send this message even if we gave the almost full one - players are


### PR DESCRIPTION
If a player had no shillings on them, the BankWithdraw message would both create the requested amount and then also give the player the money a second time lower in the message.