### PR TITLE
Remove /fp:fast compiler flag from nmake build.

### DIFF
--- a/common.mak
+++ b/common.mak
@@ -59,14 +59,15 @@ PALETTEFILE = $(TOPDIR)\blakston.pal
 # /GR-                    Turns off RTTI
 # /EHsc-                  Turns off exceptions
 # /MP                     Compile using multiple cpu cores
-# /fp:fast                Use fast floating-point
+# /fp:precise             Use precise floating-point calculations
+#                         /fp:fast causes issues with BSP tree calcs
 # /DBLAK_PLATFORM_WINDOWS Build blakserv for Windows
 # /DLIBARCHIVE_STATIC     For static libarchive build
 # /DHAVE_CONFIG_H         For libarchive build
 # /WX                     Treat warnings as errors
 # /W3                     Warnings level
 # /wdXXXX                 Disable specific warnings
-CCOMMONFLAGS = /nologo /GR- /EHsc- /MP /fp:fast \
+CCOMMONFLAGS = /nologo /GR- /EHsc- /MP /fp:precise \
     /DBLAK_PLATFORM_WINDOWS /DWIN32 \
     /D_CRT_SECURE_NO_WARNINGS \
     /D_CRT_NONSTDC_NO_DEPRECATE \


### PR DESCRIPTION
/fp:fast causes issues with the blakserv BSP tree calculations, causing
monsters to walk and hit through some walls. /fp:precise is the compiler
default, however I have declared it here to specify that we need this
setting (and left a comment explaining briefly why).

I haven't modified any of the VS solution settings as another pull request
is open touching those settings, and the blakserv project already has
/fp:precise set.