### PR TITLE
Fix Human/Troop constructors to set correct HP, speed up xeochicatls.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/human.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/human.kod
@@ -218,6 +218,9 @@ messages:
       % Sets random clothes for humans.
       Send(self,@SetClothes);
 
+      Send(self,@SetShield);
+      Send(self,@SetEquipment);
+
       propagate;
    }
 
@@ -227,6 +230,17 @@ messages:
       piAttackRange = Send(self,@GetAttackRange);
 
       propagate;
+   }
+
+   % Child classes override these.
+   SetShield()
+   {
+      return;
+   }
+
+   SetEquipment()
+   {
+      return;
    }
 
    SetClothes()

--- a/kod/object/active/holder/nomoveon/battler/monster/human/troop.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/human/troop.kod
@@ -68,14 +68,6 @@ properties:
 
 messages:
 
-   Constructed()
-   {
-      Send(self,@SetShield);
-      Send(self,@SetEquipment);
-
-      propagate;
-   }
-
    SetClothes()
    {
       Send(self,@SetDefaultClothes,#shirt_color=viColorTranslate1);

--- a/kod/object/active/holder/nomoveon/battler/monster/human/troop/factionmage.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/human/troop/factionmage.kod
@@ -29,7 +29,7 @@ messages:
    {
       local oEquipmentItem, iBonusModifier, oSpell;
 
-      oEquipmentItem = create(&Mace);
+      oEquipmentItem = Create(&Mace);
       iBonusModifier = 3;
 
       viDifficulty = piBaseDifficulty + iBonusModifier;
@@ -38,29 +38,31 @@ messages:
       if Random(0,1)
       {
          oEquipmentItem = Create(&LeatherArmor);
-         iBonusModifier = 30;
+         iBonusModifier = Random(30,60);
       }
       else if plSpellBook = $
       {
          oEquipmentItem = Create(&Robe,#color=Random(XLAT_TO_RED,XLAT_TO_SKY));
-         iBonusModifier = 20;
+         iBonusModifier = Random(20,40);
       }
       else
       {
          oSpell = Send(SYS,@FindSpellByNum,
                         #num=First(Nth(plSpellBook,Random(1,Length(plSpellBook)))));
          oEquipmentItem = Create(&DiscipleRobe,#school=Send(oSpell,@GetSchool));
-         iBonusModifier = 40;
+         iBonusModifier = Random(40,60);
       }
 
-      viLevel = piBaseLevel + iBonusModifier;
       Send(self,@AddEquipmentObject,#what=oEquipmentItem);
 
-      if Random(1,100) < 15
+      if Random(1,100) < 20
       {
+         iBonusModifier = iBonusModifier + 20;
          oEquipmentItem = Create(&Circlet);
          Send(self,@AddEquipmentObject,#what=oEquipmentItem);
       }
+
+      viLevel = piBaseLevel + iBonusModifier;
 
       return;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/jasprtwn/jasvaultm.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/jasprtwn/jasvaultm.kod
@@ -21,7 +21,7 @@ resources:
    jaspervaultman_name_rsc = "Rolan De'nair"
    jaspervaultman_icon_rsc = cngrocer.bgf
    jaspervaultman_desc_rsc =  \
-      "The cousin of Obert Cair'bre, Ronal has taken the family business "
+      "The cousin of Obert Cair'bre, Rolan has taken the family business "
       "south.  Though as he diligently serves the people of Jasper, his big "
       "city demeanor is often at odds with the townsfolk's more rebellious "
       "attitude."

--- a/kod/object/active/holder/nomoveon/battler/monster/xeochctl.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/xeochctl.kod
@@ -75,7 +75,7 @@ classvars:
    viVisionDistance = 60
    % Attack range of 192, or 3 row/col.
    viAttackRange = 3 * FINENESS
-   viSpeed = SPEED_AVERAGE
+   viSpeed = SPEED_FASTER
    viKarma = 0
 
    vrSound_hit = Xeochicatl_sound_attack

--- a/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeoearth.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeoearth.kod
@@ -43,7 +43,7 @@ resources:
    viAttack_type = ATCK_WEAP_MAGIC
    viLevel = 200
    viDifficulty = 9
-   viSpeed = SPEED_AVERAGE
+   viSpeed = SPEED_FASTER
    vrSound_aware = XeoEarth_sound_aware
 
    viTreasure_type = TID_XEO_EARTH

--- a/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeofire.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeofire.kod
@@ -43,7 +43,7 @@ resources:
    viAttack_type = ATCK_WEAP_MAGIC
    viLevel = 170
    viDifficulty = 7
-   viSpeed = SPEED_FAST
+   viSpeed = SPEED_FASTER
    vrSound_aware = XeoFire_sound_aware
 
    viTreasure_type = TID_XEO_FIRE

--- a/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeoholy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeoholy.kod
@@ -43,7 +43,7 @@ resources:
    viAttack_type = ATCK_WEAP_MAGIC
    viLevel = 170
    viDifficulty = 7
-   viSpeed = SPEED_FAST
+   viSpeed = SPEED_FASTER
    vrSound_aware = XeoHoly_sound_aware
 
    viTreasure_type = TID_XEO_HOLY

--- a/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeoill.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeoill.kod
@@ -43,7 +43,7 @@ resources:
    viAttack_type = ATCK_WEAP_MAGIC
    viLevel = 200
    viDifficulty = 9
-   viSpeed = SPEED_AVERAGE
+   viSpeed = SPEED_VERY_FAST
    vrSound_aware = XeoIll_sound_aware
 
    viTreasure_type = TID_XEO_ILL

--- a/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeounholy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeounholy.kod
@@ -43,7 +43,7 @@ resources:
    viAttack_type = ATCK_WEAP_MAGIC
    viLevel = 200
    viDifficulty = 9
-   viSpeed = SPEED_AVERAGE
+   viSpeed = SPEED_FASTER
    vrSound_aware = XeoUnholy_sound_aware
 
    viTreasure_type = TID_XEO_UNHOLY

--- a/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeowater.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/xeochctl/xeowater.kod
@@ -43,7 +43,7 @@ resources:
    viAttack_type = ATCK_WEAP_MAGIC
    viLevel = 190
    viDifficulty = 8
-   viSpeed = SPEED_FAST
+   viSpeed = SPEED_FASTER
    vrSound_aware = XeoWater_sound_aware
 
    viTreasure_type = TID_XEO_WATER

--- a/kod/object/passive/spell/atakspel/radproj/firestorm.kod
+++ b/kod/object/passive/spell/atakspel/radproj/firestorm.kod
@@ -33,7 +33,7 @@ resources:
 
    % These aren't in use at the moment.
    firestorm_killed_someone = \
-      "The ice shards fatally wound %s%s."
+      "The flames consume %s%s."
    firestorm_cast_rsc = \
       "You let out a cry of pain as flames sear your flesh, "
       "causing ~r~B%i~n damage."


### PR DESCRIPTION
These mobs need to set equipment before setting HP and any other level/difficulty based properties in Monster's constructor.

Raised level slightly on faction mages.

Xeos were a bit lackluster in the recent node attack, so increased speed on all to at least 18 (some are at 20).

Fix spelling in Japser vaultman description, change firestorm killed resource.