### PR TITLE
Upgrades to the escaped convict event actor class

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4195,6 +4195,18 @@ messages:
          return FALSE;
       }
 
+      % Can always attack Escaped Convict regardless of room
+      if IsClass(victim,&EscapedConvict)
+      {
+         return TRUE;
+      }
+
+      % But Escaped Convict can also fight back!
+      if IsClass(self,&EscapedConvict)
+      {
+         return TRUE;
+      }
+
       % Make sure room allows the attack. Check if room has
       % special combat affects.
       if actual

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1084,6 +1084,13 @@ messages:
    {
       local rName;
 
+      % don't inform non-DM clients of Escaped Convict
+      if (NOT IsClass(self,&DM) AND IsClass(what,&EscapedConvict)
+         AND NOT IsClass(self,&EscapedConvict) AND IsClass(what,&EscapedConvict))
+      {
+         return;
+      }
+
       rName = Send(what,@GetTrueName);
 
       if pbLogged_on
@@ -2995,15 +3002,40 @@ messages:
    "Sends client a list of all users logged on, including object id, "
    "resource id, and actual string of the resource (since it's a dynarsc)."
    {
-      local i, lUsers, rName;
+      local i, lUsers, rName, bVisible;
 
       lUsers = $;
 
       foreach i in Send(SYS,@GetUsersLoggedOn)
       {
-         if IsClass(self,&Admin)
-            OR NOT (IsClass(i,&DM)
-                    AND Send(i,@IsHidden))
+         bVisible = FALSE;
+
+         % admins see everyone
+         if (IsClass(self,&Admin))
+         {
+            bVisible = TRUE;
+         }
+         % escaped convict can see self and fellow convicts
+         else if (IsClass(self,&EscapedConvict) AND IsClass(i,&EscapedConvict))
+         {
+            bVisible = TRUE;
+         }
+         else
+         {
+            % self is a regular user, here is where to start hiding special
+            % players like escaped convict and hidden DMs
+            if (IsClass(i,&EscapedConvict)
+               OR (IsClass(i,&DM) AND Send(i,@IsHidden)))
+            {
+               bVisible = FALSE;
+            }
+            else
+            {
+               bVisible = TRUE;
+            }
+         }
+            
+         if (bVisible)
          {
             lUsers = Cons(i,lUsers);
          }

--- a/kod/object/active/holder/nomoveon/battler/player/user/escapedconvict.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/escapedconvict.kod
@@ -16,15 +16,25 @@ constants:
 
 resources:
 
+   escaped_convict_name_rsc = "Escaped Convict"
+
 classvars:
 
    % Amount of shillings to distribute to EACH ATTACKER.
    viMoneyAmount = 20000
 
+   viMax_Vigor = 50000
+   viMax_Health = 50000
+   viMax_Mana = 50000
+
+   viBulk_hold_max = 1000000
+   viWeight_hold_max = 1000000
+
 properties:
 
+   % NOT IMPLEMENTED
    % Enable Convict Pick Pocket ability.
-   pbPickPocket = FALSE
+   % pbPickPocket = FALSE
 
    % Queue of most recent attackers.
    plAttackers = $
@@ -65,7 +75,6 @@ messages:
          }
          else
          {
-            % Debug("Player not in list");
             % Player not already in list, check size and delete if needed.
             if (Length(plAttackers) < piAttackers)
             {
@@ -108,7 +117,6 @@ messages:
                {
                   Debug("treasure list",lTreasure);
                }
-               %Send(oAttacker,@NewHold,#what=lTreasure);
                foreach oTreasure in lTreasure
                {
                   if pbDebug
@@ -169,6 +177,115 @@ messages:
       plAttackers = $;
 
       propagate;
+   }
+
+   GetName()
+   {
+      % Give a generic resource Clients will not have the proper name resource.
+      % as EscapedConvict is hidden from the who list
+      return escaped_convict_name_rsc;
+   }
+
+   PlayerNewCharInfo(desc = $,charinfo = $,gender = $)
+   {
+      vrName = escaped_convict_name_rsc;
+
+      propagate;
+   }
+
+   AdminReset()
+   {
+      
+      piMight = 50;
+      piIntellect = 50;
+      piStamina = 50;
+      piAgility = 50;
+      piMysticism = 50;
+      piAim = 50;
+
+      Send(self,@FillHealth);
+      Send(self,@FillMana);
+      Send(self,@FillVigor);
+
+      Send(self,@GivePlayerAllSpells,#override=TRUE);
+      Send(self,@GivePlayerAllSKills,#override=TRUE);
+      Send(self,@EvaluatePKStatus);
+      Send(self,@PlayerIsIntriguing);
+
+      Send(self,@EquipEscapedConvict);
+
+      return;
+   }
+
+   EquipEscapedConvict()
+   {
+      if (Send(self,@FindHolding,#class=&ReagentBag) = $)
+      {
+         Send(self,@Newhold,#what=Create(&ReagentBag));
+      }
+
+      return;
+   }
+
+   AdminHarm(percent=10)
+   {
+      piHealth = piHealth - (piHealth / (100 / percent));
+      Send(self,@DrawHealth);
+
+      return piHealth;
+   }
+
+   AdminHeal(percent=10)
+   {
+      piHealth = piHealth + ((viMax_Health / (100 / percent)) * 100);
+      return;
+   }
+
+   FillHealth(percent=100)
+   {
+      local iAmount;
+
+      iAmount = viMax_Health * percent / 100;
+
+      piHealth = iAmount * 100;
+      piMax_Health = iAmount;
+      piBase_Max_Health = iAmount;
+      Send(self,@DrawHealth);
+
+      return piHealth;
+   }
+
+   FillMana(percent=100)
+   {
+      local iAmount;
+
+      iAmount = viMax_Mana * percent / 100;
+
+      piMana = iAmount;
+      piMax_Mana = iAmount;
+      Send(self,@DrawMana);
+
+      return piMana;
+   }
+
+   FillVigor(percent=100)
+   {
+      local iAmount;
+
+      iAmount = viMax_Vigor * percent / 100;
+
+      piVigor = iAmount;
+      Send(self,@DrawVigor);
+
+      return piVigor;
+   }
+
+   SendStatVigor()
+   {
+      AddPacket(1,3, 4,user_stat_vigor, 1,STAT_VALUE, 1,STAT_INTEGER,
+                4,piVigor, 4,0, 4,viMax_Vigor, 4,piVigor_rest_threshold);
+
+      return;
    }
 
    GetClientObjectType()

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -695,6 +695,7 @@ messages:
       oRoom = Send(who,@GetOwner);
       if Send(who,@PlayerIsImmortal)
          OR Send(oRoom,@NoReagents)
+         OR IsClass(who,&EscapedConvict)
       {
          return TRUE;
       }
@@ -1380,6 +1381,12 @@ messages:
 
          % Spell casting requires exertion (which is in 10^-4 units)
          Send(who,@AddExertion,#amount=10000*viSpellExertion);
+
+         % Escaped Convict loses mana and vigor, but reagents are not required
+         if (IsClass(who,&EscapedConvict))
+         {
+            return TRUE;
+         }
 
          % Use up reagents, provided reagent use is turned on
          if NOT Send(oRoom, @NoReagents)


### PR DESCRIPTION
- Made Escaped Convict invisible to mortals on the who list
- Added a ResetEscapedConvict Message to boost stats, heal, give spells,
    and equip an escaped convict before each event
- Added AdminHarm and AdminHeal messages to shorten or prolong an event
- added message to add equipment to an EC (currently only reagent bag if
    he doesn't have one already
- Removed the need for reagents for EC
- Increased Max bulk and weight held to 1 million
- Can attack EC anytime anywhere including when pvp is turned off for the
  server, but beware, EC can also fight back!