### PR TITLE
Add ternary conditional operator to kod.

### DIFF
--- a/blakcomp/actions.c
+++ b/blakcomp/actions.c
@@ -747,6 +747,21 @@ expr_type make_bin_op(expr_type expr1, int op, expr_type expr2)
    return e;
 }
 /************************************************************************/
+expr_type make_ter_op(expr_type expr1, expr_type expr2, expr_type expr3)
+{
+   expr_type e = (expr_type) SafeMalloc(sizeof(expr_struct));
+
+   e->type = E_TERNARY_OP;
+   e->value.ternary_opval.eval_exp = expr1;
+   e->value.ternary_opval.left_exp = expr2;
+   e->value.ternary_opval.right_exp = expr3;
+   e->value.ternary_opval.op = 1;
+   e->lineno = lineno;
+
+   SimplifyExpression(e);
+   return e;
+}
+/************************************************************************/
 expr_type make_un_op(int op, expr_type expr1)
 {
    expr_type e = (expr_type) SafeMalloc(sizeof(expr_struct));

--- a/blakcomp/blakcomp.h
+++ b/blakcomp/blakcomp.h
@@ -115,11 +115,16 @@ typedef struct {
    const_type resource[MAX_LANGUAGE_ID];
 } *resource_type, resource_struct;
 
-enum { E_BINARY_OP, E_UNARY_OP, E_IDENTIFIER, E_CONSTANT, E_CALL, };
+enum { E_BINARY_OP, E_UNARY_OP, E_IDENTIFIER, E_CONSTANT, E_CALL, E_TERNARY_OP };
 typedef struct _expr {
    int type;
    int lineno;   /* line number; used for putting debugging information in output */
    union {
+      struct _terexpr{
+         struct _expr *eval_exp, *left_exp, *right_exp;
+         int op;
+      } ternary_opval;
+
       struct _binexpr{
          struct _expr *left_exp, *right_exp;
          int op;
@@ -317,6 +322,7 @@ expr_type make_expr_from_call(stmt_type);
 expr_type make_expr_from_constant(const_type);
 expr_type make_expr_from_literal(id_type id);
 expr_type make_bin_op(expr_type, int, expr_type);
+expr_type make_ter_op(expr_type, expr_type, expr_type);
 expr_type make_un_op(int, expr_type);
 
 arg_type make_arg_from_expr(expr_type expr);

--- a/blakcomp/blakcomp.l
+++ b/blakcomp/blakcomp.l
@@ -117,7 +117,7 @@ default { return DEFAULT; }
 "++"	{ yylval.int_val = INC_OP; return INC_OP; }
 
 
-[-+*/,:#&@()={}\$\[\]\|~]	{ return yytext[0]; }	/* return character itself */
+[-+*/,?:#&@()={}\$\[\]\|~]	{ return yytext[0]; }	/* return character itself */
 \;                              { return SEP; }  /* Separator */
 
 	/* names */

--- a/blakcomp/blakcomp.y
+++ b/blakcomp/blakcomp.y
@@ -66,6 +66,7 @@
 %token END EOL SEP INCLUDE FOREACH DEFAULT
 
 /* precedence of operators, lowest precedence first */
+%right '?' ':'
 %left OR
 %left AND
 %left '|'
@@ -373,6 +374,8 @@ expression:
 	|	INC_OP id			{ $$ = make_un_op(PRE_INC_OP, make_expr_from_id($2)); }
 	|	id DEC_OP			{ $$ = make_un_op(POST_DEC_OP, make_expr_from_id($1)); }
 	|	DEC_OP id			{ $$ = make_un_op(PRE_DEC_OP, make_expr_from_id($2)); }
+	|	expression '?' expression ':' expression	{ $$ = make_ter_op($1, $3, $5); }
+	|	expression '?' ':' expression	{ $$ = make_ter_op($1, NULL, $4); }
 	|	constant			{ $$ = make_expr_from_constant($1); }
 	|	literal				{ $$ = make_expr_from_constant($1); }
 	|	call				{ $$ = make_expr_from_call($1); }

--- a/blakcomp/codegen.c
+++ b/blakcomp/codegen.c
@@ -299,6 +299,66 @@ int codegen_return(expr_type expr, int maxlocal)
 }
 /************************************************************************/
 /*
+* codegen_conditional_op: Generate code for a conditional operator.
+*   our_maxlocal gives highest #ed temporary needed to evaluate the
+*   entire expression.
+*/
+int codegen_conditional_op(expr_type e, id_type destvar, int maxlocal)
+{
+   opcode_type opcode;
+   int our_maxlocal = maxlocal, numtemps, sourceval;
+   long falsepos, endpos;
+
+   // First generate code for condition.
+   our_maxlocal = simplify_expr(e->value.ternary_opval.eval_exp, our_maxlocal);
+
+   // Jump over then clause if condition is false.
+   memset(&opcode, 0, sizeof(opcode));  // Set opcode to all zeros.
+   opcode.command = GOTO;
+   opcode.dest = GOTO_IF_FALSE;
+   sourceval = set_source_id(&opcode, SOURCE1, e->value.ternary_opval.eval_exp);
+   OutputOpcode(outfile, opcode);
+
+   // Leave space for destination address.
+   falsepos = FileCurPos(outfile);
+   OutputInt(outfile, 0);
+
+   OutputInt(outfile, sourceval);
+
+   // Evaluate and assign true condition. If left_exp is NULL,
+   // assign the condition instead.
+   if (!e->value.ternary_opval.left_exp)
+      numtemps = flatten_expr(e->value.ternary_opval.eval_exp, destvar, our_maxlocal);
+   else
+      numtemps = flatten_expr(e->value.ternary_opval.left_exp, destvar, our_maxlocal);
+   if (numtemps > our_maxlocal)
+      our_maxlocal = numtemps;
+
+   // Jump past false condition.
+   opcode.source1 = 0;
+   opcode.source2 = GOTO_UNCONDITIONAL;
+   opcode.dest = 0;
+   OutputOpcode(outfile, opcode);
+
+   // Leave space for destination address
+   endpos = FileCurPos(outfile);
+   OutputInt(outfile, 0);
+
+   // Go back and fill in destination address for conditional goto.
+   BackpatchGoto(outfile, falsepos, FileCurPos(outfile));
+
+   // Evaluate and assign false condition.
+   numtemps = flatten_expr(e->value.ternary_opval.right_exp, destvar, our_maxlocal);
+   if (numtemps > our_maxlocal)
+      our_maxlocal = numtemps;
+
+   // Go back and fill in destination address for end of true condition.
+   BackpatchGoto(outfile, endpos, FileCurPos(outfile));
+
+   return our_maxlocal;
+}
+/************************************************************************/
+/*
  * codegen_if: Generate code for an if-then-else statement.
  *    numlocals should be # of local variables for message excluding temps.
  *   Returns highest # local variable used in code for statement.

--- a/blakcomp/codegen.h
+++ b/blakcomp/codegen.h
@@ -65,5 +65,6 @@ void codegen_property(property_type p);
 void codegen_message(message_handler_type m);
 void codegen_class(class_type c);
 int codegen_call(call_stmt_type c, id_type destvar, int maxlocal);
+int codegen_conditional_op(expr_type e, id_type destvar, int maxlocal);
 
 #endif /* #ifndef _CODEGEN_H */

--- a/blakcomp/codeutil.c
+++ b/blakcomp/codeutil.c
@@ -394,16 +394,16 @@ int flatten_expr(expr_type e, id_type destvar, int maxlocal)
       templocals = maxlocal;  /* Holds max # used in one subexpression (left or right) */
 
       if (is_base_level(tempexpr))
-	 sourceval1 = set_source_id(&opcode, SOURCE1, tempexpr);
+         sourceval1 = set_source_id(&opcode, SOURCE1, tempexpr);
       else
       {
-	 opcode.source1 = LOCAL_VAR;
+         opcode.source1 = LOCAL_VAR;
 
-	 /* Evaluate rhs, store in temporary, and assign it to destvar */
-	 our_maxlocal++;
-	 templocals++;  /* Lhs must be stored in temp; rhs must not use this temp */
-	 sourceval1 = our_maxlocal;
-	 our_maxlocal = flatten_expr(tempexpr, make_temp_var(our_maxlocal), our_maxlocal);
+         /* Evaluate rhs, store in temporary, and assign it to destvar */
+         our_maxlocal++;
+         templocals++;  /* Lhs must be stored in temp; rhs must not use this temp */
+         sourceval1 = our_maxlocal;
+         our_maxlocal = flatten_expr(tempexpr, make_temp_var(our_maxlocal), our_maxlocal);
       }
 
       exitpos = 0;
@@ -492,6 +492,9 @@ int flatten_expr(expr_type e, id_type destvar, int maxlocal)
 				  destvar, our_maxlocal);
       break;
       
+   case E_TERNARY_OP:
+      our_maxlocal = codegen_conditional_op(e, destvar, our_maxlocal);
+      break;
    default:
       codegen_error("Unknown expression type (%d) encountered", e->type);
    }


### PR DESCRIPTION
Adds the C-style ? : ternary operator to the kod language. Works the same as the C version - doesn't evaluate the 3rd expression if the condition is true, can be nested etc. Can also be used with the syntax x = y ? : z; to assign y to x if y is true.