### PR TITLE
Check all worn items for heat damage, refactor room enchantment attack/damage code.

### DIFF
--- a/kod/object/active/holder/nomoveon.kod
+++ b/kod/object/active/holder/nomoveon.kod
@@ -263,6 +263,12 @@ messages:
       return FALSE;
    }
 
+   PossessesA(class = $)
+   "Override from Holder, optimised for NoMoveOn."
+   {
+      return GetListElemByClass(plPassive,class) <> $;
+   }
+
    SquaredDistanceTo(what = $)
    "Computes squared distance to <what>. Returns $ for any object that is "
    "not within a room."

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1556,7 +1556,7 @@ messages:
 
    SpellCast(who = $,oSpell = $,lItems = $,bItemCast = FALSE)
    {
-      local state, school, roomench;
+      local state, school, oRoomEnch;
 
       % Skip these if the spell is cast by an item.
       if bItemCast
@@ -1568,22 +1568,22 @@ messages:
 
       if school = SS_SHALILLE
       {
-         roomench = Send(SYS,@FindSpellByNum,#num=SID_SHALILLEBANE);
-         state = Send(self,@GetEnchantmentState,#what=roomench);
+         oRoomEnch = Send(SYS,@FindSpellByNum,#num=SID_SHALILLEBANE);
+         state = Send(self,@GetEnchantmentState,#what=oRoomEnch);
          if state <> $
          {
-            Post(roomench,@HurtCaster,#shalCaster=who,#iSpellPower=state,
-                 #shalSpellLevel=Send(oSpell,@GetLevel));
+            Post(oRoomEnch,@RoomEnchantmentDamage,#oTarget=who,#state=state,
+                 #iLevel=Send(oSpell,@GetLevel));
          }
       }
       else if school = SS_QOR
       {
-         roomench = Send(SYS,@FindSpellByNum,#num=SID_QORBANE);
-         state = Send(self,@GetEnchantmentState,#what=roomench);
+         oRoomEnch = Send(SYS,@FindSpellByNum,#num=SID_QORBANE);
+         state = Send(self,@GetEnchantmentState,#what=oRoomEnch);
          if state <> $
          {
-            Post(roomench,@HurtCaster,#qorCaster=who,#iSpellPower=state,
-                 #qorSpellLevel=Send(oSpell,@GetLevel));
+            Post(oRoomEnch,@RoomEnchantmentDamage,#oTarget=who,#state=state,
+                 #iLevel=Send(oSpell,@GetLevel));
          }
       }
 
@@ -3402,17 +3402,17 @@ messages:
       return;
    }
 
-   EnchantAllOccupants(what = $, iSpellPower=0)
+   EnchantAllOccupants(what = $, iSpellPower = 0, state = $)
    {
       local i, each_obj;
 
       foreach i in plActive
       {
-         each_obj = Send(self,@HolderExtractObject,#data=i);
+         each_obj = First(i);
          if IsClass(each_obj,&Player)
          {
             Send(what,@StartEnchantment,#who=each_obj,
-                 #iSpellPower=iSpellPower);
+                 #iSpellPower=iSpellPower,#state=state);
          }
       }
 

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -773,9 +773,7 @@ messages:
 
    CanPayCosts(who=$,lTargets=$,iSpellPower=0,bItemCast=FALSE)
    {
-      local i, oRoom, iRand, oSpell, oTarget;
-
-      oTarget = $;
+      local i, each_obj, oRoom, iRand, oSpell, oTarget;
 
       if lTargets <> $
          AND Length(lTargets) = 1
@@ -783,7 +781,7 @@ messages:
          % Extract first target for handling single target code.
          oTarget = First(lTargets);
 
-         if IsClass(oTarget,&Player)
+         if IsClass(oTarget,&User)
             AND Send(oTarget,@IsInCannotInteractMode)
          {
             Send(who,@MsgSendUser,#message_rsc=cannot_cast_on_phased_out,
@@ -794,7 +792,7 @@ messages:
          }
       }
 
-      if NOT IsClass(who,&Player)
+      if NOT IsClass(who,&User)
       {
          return TRUE;
       }
@@ -847,8 +845,7 @@ messages:
          }
 
          % Don't check the attack time for itemcast spells. The items
-         % themselves will allow or disallow this - for instance a
-         % potion can be used during the cooldown, but a wand cannot.
+         % themselves will allow or disallow this.
          if NOT Send(who,@IsOkayAttackTime,#seconds=viPostCast_Time)
          {
             return FALSE;
@@ -872,10 +869,10 @@ messages:
          piCast_attempts = piCast_attempts + 1;
          foreach i in lTargets
          {
-            if IsClass(i,&Player)
+            if IsClass(i,&User)
             {
                piCast_attempts_at_players = piCast_attempts_at_players + 1;
-               
+
                break;
             }
          }
@@ -924,15 +921,16 @@ messages:
       % Check for newbies/mules using attack or annoyance spells.
       if NOT Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
          AND NOT Send(oRoom,@CheckRoomFlag,#flag=ROOM_SAFE_DEATH)
-         AND NOT Send(oRoom,@CheckRoomFlag,#flag=ROOM_KILL_ZONE) 
+         AND NOT Send(oRoom,@CheckRoomFlag,#flag=ROOM_KILL_ZONE)
       {
-         if oTarget = $ 
+         if oTarget = $
          {
             if viNoNewbieOffense
             {
                foreach i in Send(oRoom,@GetHolderActive)
                {
-                  if IsClass(First(i),&Player) AND First(i) <> who
+                  each_obj = First(i);
+                  if IsClass(each_obj,&User) AND each_obj <> who
                   {
                      Send(who,@MsgSendUser,#message_rsc=spell_guardian);
 
@@ -943,7 +941,7 @@ messages:
          }
          else
          {
-            if oTarget <> who AND IsClass(oTarget,&Player)
+            if oTarget <> who AND IsClass(oTarget,&User)
             {
                if viNoNewbieOffense
                {
@@ -956,8 +954,8 @@ messages:
                   AND oTarget <> who
                {
                   Send(who,@MsgSendUser,#message_rsc=spell_cant_help,
-                       #parm1=Send(oTarget,@GetDef),
-                       #parm2=Send(oTarget,@GetName));
+                        #parm1=Send(oTarget,@GetDef),
+                        #parm2=Send(oTarget,@GetName));
 
                   return FALSE;
                }
@@ -976,7 +974,7 @@ messages:
       if Send(self,@IsHarmful)
       {
          % Can the caster attack the target(s) with the harmful spell?
-         if NOT Send(self,@CheckPlayerAttack,#who=who,#lTargets=lTargets)
+         if NOT Send(self,@CheckPlayerAttackCast,#who=who,#lTargets=lTargets)
          {
             return FALSE;
          }
@@ -999,7 +997,7 @@ messages:
          % A bit kludgish here.  We call PayCosts here to simulate casting the
          % spell with no effect.  There should be a special function for this,
          % but we're cutting corners to save money!
-         if not bItemCast
+         if NOT bItemCast
          {
             Send(self,@PayCosts,#who=who,#iSpellpower=iSpellpower,
                   #lTargets=lTargets);
@@ -1068,7 +1066,7 @@ messages:
       return lTargets;
    }
 
-   CheckPlayerAttack(who=$,lTargets=$)
+   CheckPlayerAttackCast(who=$,lTargets=$)
    "Checks to see if player can attack said targets."
    {
       local oRoom, i, lFinalTargets, oTarget;
@@ -1087,8 +1085,12 @@ messages:
                i = Send(oRoom,@HolderExtractObject,#data=i);
                if i = who
                   OR NOT IsClass(i,&Battler)
-                  OR (IsClass(i,&DM) AND Send(i,@PlayerIsImmortal))
-                  OR (IsClass(i,&Player) AND Send(i,@IsInCannotInteractMode))
+                  OR (IsClass(i,&DM)
+                     AND Send(i,@PlayerIsImmortal))
+                  OR (IsClass(i,&User)
+                     AND (Send(i,@IsInCannotInteractMode)
+                        OR (NOT Send(i,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE))
+                        OR Send(i,@CheckPlayerFlag,#flag=PFLAG_TEMPSAFE)))
                   OR (IsClass(i,&Monster)
                      AND (Send(i,@GetBehavior) & AI_NPC))
                   OR Send(oRoom,@IsArena)
@@ -1112,12 +1114,12 @@ messages:
 
             % Don't cast the spell if there's no valid targets.
             if lFinalTargets = $
-               OR length(lFinalTargets) = 0
+               OR Length(lFinalTargets) = 0
             {
                if Send(self,@GetNumSpellTargets) <> 1
                {
                   Send(who,@MsgSendUser,#message_rsc=spell_no_targets,
-                       #parm1=Send(self,@GetName));
+                        #parm1=Send(self,@GetName));
                }
 
                return FALSE;
@@ -1978,8 +1980,8 @@ messages:
       }
 
       if (Send(self,@IsHarmful)
-          AND IsClass(who,&Player)
-          AND NOT Send(self,@CheckPlayerAttack,#who=who,#lTargets=lTargets))
+            AND IsClass(who,&User)
+            AND NOT Send(self,@CheckPlayerAttackCast,#who=who,#lTargets=lTargets))
          OR NOT Send(Send(who,@GetOwner),@ReqSpellCast,#who=who,#oSpell=self,
                      #lItems=lTargets)
       {
@@ -2310,8 +2312,8 @@ messages:
          if Send(oRoom,@IsEnchanted,#what=SID_FORCES_OF_LIGHT)
          {
             % Add a function of the spellpower.
-            iAbilityGain = Send(oRoom,@GetEnchantMentState,
-                                #what=SID_FORCES_OF_LIGHT);  
+            iAbilityGain = Send(oRoom,@GetEnchantmentState,
+                                 #what=SID_FORCES_OF_LIGHT);
             iAbilityGain = iAbilityGain/10;
             iSecondaryBonus = iSecondaryBonus + iAbilityGain;
          }
@@ -2329,7 +2331,7 @@ messages:
          {
             % This reconstructs the darkness spellpower.
             iAbilityGain = Send(oRoom,@GetEnchantmentState,
-                                #what=SID_DARKNESS);
+                                 #what=SID_DARKNESS);
             iAbilityGain = -(iAbilityGain - 25);
             iAbilityGain = iAbilityGain/10;
             iSecondaryBonus = iSecondaryBonus + iAbilityGain;
@@ -2578,6 +2580,12 @@ messages:
    "Used for flavor text on player-enchanted items."
    {
       return vrEnchantment_type;
+   }
+
+   % This is for the attack message infrastructure.
+   GetAttackName()
+   {
+      return vrName;
    }
 
    GetRingCharges()

--- a/kod/object/passive/spell/atakspel.kod
+++ b/kod/object/passive/spell/atakspel.kod
@@ -34,7 +34,6 @@ classvars:
    vrCast = attack_spell_cast_rsc
    vrHit = attack_spell_hit_rsc
 
-
    viAttack_type = 0
    viAttack_spell = ATCK_SPELL_ALL
 
@@ -362,12 +361,6 @@ messages:
    ComputeDamage(who=$,target=$,iDamage=$)
    {
       return;
-   }
-
-   % This is for the attack message infrastructure.
-   GetAttackName()
-   {
-      return vrName;
    }
 
 end

--- a/kod/object/passive/spell/roomench.kod
+++ b/kod/object/passive/spell/roomench.kod
@@ -22,7 +22,9 @@ resources:
    RoomEnchantment_icon_rsc = iheat.bgf
    RoomEnchantment_desc_rsc = \
       "An enchantment which is attached to a room."
-
+   RoomEnchantment_kill_rsc = "The room enchantment kills you."
+   RoomEnchantment_killer_rsc = "You killed %s%s with your room enchantment."
+   RoomEnchantment_hit_rsc = "The room enchantment damages you."
    room_blank_template = "%q"
 
 classvars:
@@ -31,33 +33,69 @@ classvars:
    vrIcon = RoomEnchantment_icon_rsc
    vrDesc = RoomEnchantment_desc_rsc
 
+   vrAlreadyEnchanted = spell_already_in_effect % From spell.kod
+   vrRoomEnchKilled = RoomEnchantment_kill_rsc
+   vrRoomEnchKiller = RoomEnchantment_killer_rsc
+   vrRoomEnchHit = RoomEnchantment_hit_rsc
+
+   vbRoomEnchHitCaster = TRUE
+
+   viAttack_type = 0
+   viAttack_spell = ATCK_SPELL_ALL
+
 properties:
 
 messages:
-	 
+
+   GetNumSpellTargets()
+   {
+      return 0;
+   }
+
+   CanPayCosts(who = $, lTargets = $)
+   {
+      local oRoom;
+
+      oRoom = Send(who,@GetOwner);
+
+      if (oRoom = $)
+      {
+         return FALSE;
+      }
+
+      % Check for enchantment already applied.
+      if Send(oRoom,@IsEnchanted,#what=self)
+      {
+         Send(who,@MsgSendUser,#message_rsc=vrAlreadyEnchanted);
+
+         return FALSE;
+      }
+
+      propagate;
+   }
+
    DoubleCheckAfterTrance(who = $, lTargets = $)
    {
       local oRoom;
 
       oRoom = Send(who,@GetOwner);
-    
-      if (Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT) 
-           OR Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_MAGIC)) 
+
+      if (Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
+           OR Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_MAGIC))
          AND (viOutlaw OR viHarmful)
       {
          Send(who,@MsgSendUser,#message_rsc=spell_bad_location,#parm1=vrName);
 
          return FALSE;
       }
-      
-      if send(oRoom,@IsEnchanted,#what=self)
+
+      if Send(oRoom,@IsEnchanted,#what=self)
       {
-         Send(who,@MsgSendUser,#message_rsc=spell_already_in_effect,
-              #parm1=vrName);
+         Send(who,@MsgSendUser,#message_rsc=vrAlreadyEnchanted,#parm1=vrName);
 
          return FALSE;
       }
-      
+
       propagate;
    }
 
@@ -73,6 +111,95 @@ messages:
       }
 
       propagate;
+   }
+
+   RoomEnchantmentDamage(oTarget=$, state=$, iLevel=1)
+   "Takes a target (oTarget), an enchantment state (state) and optional "
+   "iLevel parameter (used for Qor/Shalbane) and deals the damage to oTarget."
+   {
+      local iDamage, iSpellPower, oCaster, oCasterRoom, oRoom;
+
+      if (state = $
+         OR oTarget = $)
+      {
+         return;
+      }
+
+      iSpellPower = First(state);
+
+      % oCaster is original caster of the spell.
+      oCaster = Nth(state,2);
+      if (oCaster = $)
+      {
+         return;
+      }
+
+      if (IsClass(oCaster,&User)
+         AND ((oTarget = self AND NOT vbRoomEnchHitCaster)
+            OR NOT Send(oCaster,@AllowPlayerAttack,#victim=oTarget,
+                        #stroke_obj=self)))
+      {
+         return;
+      }
+
+      iDamage = Send(self,@ComputeDamage,#who=oCaster,#oTarget=oTarget,
+                     #iDamage=iDamage,#iLevel=iLevel,#iSpellpower=iSpellPower);
+
+      if (iDamage = 0)
+      {
+         return;
+      }
+
+      iDamage = Send(oTarget,@AssessDamage,#report=TRUE,#what=self,
+                        #damage=iDamage,#aspell=viAttack_spell,
+                        #atype=viAttack_type);
+
+      if (IsClass(oCaster,&Battler))
+      {
+         Send(oCaster,@AssessHit,#what=oTarget,#damage=iDamage,
+               #use_weapon=self);
+      }
+
+      if (iDamage = $)
+      {
+         if IsClass(oTarget,&User)
+         {
+            Send(oTarget,@MsgSendUser,#message_rsc=vrRoomEnchKilled);
+         }
+
+         if IsClass(oCaster,&User)
+         {
+            Send(oCaster,@MsgSendUser,#message_rsc=vrRoomEnchKiller,
+                  #parm1=Send(oTarget,@GetCapDef),
+                  #parm2=Send(oTarget,@GetTrueName));
+         }
+
+         oRoom = Send(oTarget,@GetOwner);
+         oCasterRoom = Send(oCaster,@GetOwner);
+         
+         Send(oCaster,@KilledSomething,#what=oTarget,#use_weapon=self);
+
+         if (oRoom <> oCasterRoom)
+         {
+            Send(oRoom,@SomethingKilled,#what=oCaster,#victim=oTarget);
+         }
+      }
+      else if IsClass(oTarget,&User)
+      {
+         Send(oTarget,@MsgSendUser,#message_rsc=vrRoomEnchHit);
+      }
+
+      return;
+   }
+
+   GetAttackSpell()
+   {
+      return viAttack_spell;
+   }
+
+   GetAttackType()
+   {
+      return viAttack_type;
    }
 
 end

--- a/kod/object/passive/spell/roomench/darkness.kod
+++ b/kod/object/passive/spell/roomench/darkness.kod
@@ -48,6 +48,8 @@ classvars:
    vrSucceed_wav = darkness_sound
    vrSpell_intro = darkness_spell_intro
 
+   vrAlreadyEnchanted = darkness_unnecessary
+
    viSpell_num = SID_DARKNESS
    viSchool = SS_QOR
    viMana = 8
@@ -67,27 +69,6 @@ messages:
       plReagents = Cons([&EntrootBerry,1],plReagents);
 
       return;
-   }
-
-   GetNumSpellTargets()
-   {
-      return 0;
-   }
-
-   CanPayCosts(who = $, lTargets = $)
-   {
-      local oRoom;
-
-      oRoom = Send(who,@GetOwner);
-
-      if Send(oRoom,@IsEnchanted,#what=self)
-      {
-         Send(who,@MsgSendUser,#message_rsc=darkness_unnecessary);
-
-         return FALSE;
-      }
-
-      propagate;
    }
 
    CastSpell(who = $, iSpellPower = 0)

--- a/kod/object/passive/spell/roomench/forceslt.kod
+++ b/kod/object/passive/spell/roomench/forceslt.kod
@@ -43,6 +43,8 @@ classvars:
    vrIcon = forcesoflight_icon_rsc
    vrDesc = forcesoflight_desc_rsc
 
+   vrAlreadyEnchanted = forcesoflight_already_enchanted
+
    viSpell_num = SID_FORCES_OF_LIGHT
    viSchool = SS_SHALILLE
    viSpell_level = 4
@@ -64,28 +66,6 @@ messages:
       plReagents = Cons([&Emerald,1],plReagents);
 
       return;
-   }
-
-   GetNumSpellTargets()
-   {
-      return 0;
-   }
-
-   CanPayCosts(who = $, lTargets = $)
-   {
-      local oRoom;
-
-      oRoom = Send(who,@GetOwner);
-
-      % check for enchantment already applied
-      if Send(oRoom,@IsEnchanted,#what=self)
-      {
-	      Send(who,@MsgSendUser,#message_rsc=forcesoflight_already_enchanted);
-	      
-	      return FALSE;
-      }
-
-      propagate;
    }
 
    CastSpell(who = $, iSpellpower = $)

--- a/kod/object/passive/spell/roomench/heat.kod
+++ b/kod/object/passive/spell/roomench/heat.kod
@@ -180,7 +180,7 @@ messages:
    StartEnchantment(who = $, iSpellpower = 0)
    "Does enchantment effect on one player"
    {
-      local oRoom, bDoDamage, iDamage, oArmor;
+      local i, oRoom, bDoDamage, iDamage, lUsing;
 
       if who = $
       {
@@ -196,10 +196,10 @@ messages:
 
       bDoDamage = FALSE;
 
-      oArmor = Send(who,@GetArmor);
+      lUsing = Send(who,@GetPlayerUsing);
       oRoom = Send(who,@GetOwner);
 
-      if oArmor <> $
+      if lUsing <> $
       {
          if Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
          {
@@ -226,20 +226,24 @@ messages:
       
       if bDoDamage
       {
-         iDamage = Send(oArmor,@GetHeatDamage);
+         iDamage = 0;
 
-         % robes = no heat damage
+         foreach i in lUsing
+         {
+            iDamage = iDamage + Send(i,@GetHeatDamage);
+         }
+
          if iDamage = 0
          {
             return;
-         }    
+         }
 
          Send(who,@MsgSendUser,#message_rsc=heat_hurts_you);
          
          if Send(who,@AssessDamage,#report=FALSE,#what=self,#damage=iDamage,
-            #aspell=ATCK_SPELL_FIRE) = $
+                  #aspell=ATCK_SPELL_FIRE) = $
          {
-            if IsClass(who,&Player)
+            if IsClass(who,&User)
             {
                Send(who,@MsgSendUser,#message_rsc=heat_kills_you);
             }

--- a/kod/object/passive/spell/roomench/heat.kod
+++ b/kod/object/passive/spell/roomench/heat.kod
@@ -17,7 +17,7 @@ constants:
    % Damage every 5 secs.
    HEAT_PERIOD = 5000
    % Total duration: 10 realtime minutes
-   HEAT_TIME = 300000       
+   HEAT_TIME = 300000
 
 resources:
 
@@ -40,7 +40,7 @@ resources:
    heat_new_entrant = \
       "Faren earth magic fills the room heating all armor to a molten state."
    heat_kills_you = "You expire from burns caused by your armor."
-   heat_kills_him = "%s expires from armor-induced burns."
+   heat_kills_him = "%s%s expires from armor-induced burns."
 
    heat_hurts_you = \
       "You offer a yelp of pain as your red-hot armor presses against your skin."
@@ -49,17 +49,21 @@ resources:
 
 classvars:
 
-   viSpell_num = SID_HEAT
-
    vrName = heat_name_rsc
    vrIcon = heat_icon_rsc
    vrDesc = heat_desc_rsc
 
+   vrAlreadyEnchanted = heat_already_enchanted
+   vrRoomEnchKilled = heat_kills_you
+   vrRoomEnchKiller = heat_kills_him
+   vrRoomEnchHit = heat_hurts_you
+
+   viAttack_spell = ATCK_SPELL_FIRE
+   viSpell_num = SID_HEAT
    viSchool = SS_FAREN
    viSpell_level = 3
    viMana = 8
 
-   viOutlaw = TRUE
    viHarmful = TRUE
    viNoNewbieOffense = TRUE
 
@@ -82,38 +86,6 @@ messages:
       return;
    }
 
-   GetNumSpellTargets()
-   {
-      return 0;
-   }
-
-   CanPayCosts(who = $, lTargets = $)
-   {
-      local oRoom;
-      
-      oRoom = Send(who,@GetOwner);
-      
-      % Check for enchantment already applied.
-      if Send(oRoom,@IsEnchanted,#what=self)
-      {
-         Send(who,@MsgSendUser,#message_rsc=heat_already_enchanted);
-         
-         return FALSE;
-      }
-      
-      % Disallow in non-combat areas.  Towns, for example
-      if Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
-         OR Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_PK)
-         OR Send(oRoom,@CheckRoomFlag,#flag=ROOM_GUILD_PK_ONLY)
-      {
-         Send(who,@MsgSendUser,#message_rsc=spell_bad_location,#parm1=vrName);
-         
-         return FALSE;
-      }
-      
-      propagate;
-   }
-
    CastSpell( who = $, iSpellPower = 0 )
    "Initiation point for the spell."
    {
@@ -129,20 +101,21 @@ messages:
       iPeriod = iPeriod * 1000;
 
       Send(oRoom,@RoomStartEnchantment,#what=self,#time=iPeriod,
-           #state=iPeriod+iSpellPower,#addicon=TRUE,#lastcall=FALSE);
+            #state=[iPeriod + iSpellPower, who],#addicon=TRUE,#lastcall=FALSE);
 
       propagate;
    }
 
-   StartPeriodicEnchantment( who = $, where = $, state = 0 )
+   StartPeriodicEnchantment(who = $, where = $, state = $)
    "Sends enchantment message to room like CastSpell for most room enchantments, "
    "but silent, and done as often as necessary"
    {
-      local iNext_time, iPower, iPeriod;
-      
+      local iNext_time, iCombined, iPower, iPeriod;
+
       % First, extract the spellpower from the state
-      iPower = state mod 100;
-      state = state - iPower;
+      iCombined = First(state);
+      iPower = iCombined MOD 100;
+      iCombined = iCombined - iPower;
 
       % Ranges from 7 to 17 seconds
       iPeriod = (170-iPower)/10;
@@ -151,118 +124,69 @@ messages:
       
       % Global effects of the enchantment
       % State is elapsed time in ms
-      iNext_time = state + iPeriod;
+      iNext_time = iCombined + iPeriod;
       if iNext_time >= HEAT_TIME
       {
-         Send(where,@RoomStartEnchantment,#what=self,#time=HEAT_TIME-state,
-              #state=HEAT_TIME+iPower,#addicon=False,#lastcall=TRUE);
-         return ;
+         Send(where,@RoomStartEnchantment,#what=self,#time=HEAT_TIME-iCombined,
+               #state=[HEAT_TIME + iPower, Nth(state,2)],#addicon=False,
+               #lastcall=TRUE);
+
+         return;
       }
-      
+
       Send(where,@RoomStartEnchantment,#what=self,#time=iPeriod,
-           #state=iNext_time+iPower,#addicon=FALSE,#lastcall=FALSE);
-           
-      Send(where,@EnchantAllOccupants,#what=self,#iSpellPower=iPower);
-      
+            #state=[iNext_time+iPower, Nth(state,2)],#addicon=FALSE,
+            #lastcall=FALSE);
+
+      Send(where,@EnchantAllOccupants,#what=self,#iSpellPower=iPower,
+            #state=state);
+
       return;
    }
-   
 
-   StartEnchantmentNewOccupant( who = $ )
+   StartEnchantmentNewOccupant(who = $,state = $)
    "Called on new occupants of the enchanted room."
    {
       Send(who,@MsgSendUser,#message_rsc=heat_new_entrant);
-      Send(self,@StartEnchantment,#who=who);
-      
+      Send(self,@StartEnchantment,#who=who,#state=state);
+
       return;
    }
 
-   StartEnchantment(who = $, iSpellpower = 0)
+   StartEnchantment(who = $, state = $)
    "Does enchantment effect on one player"
    {
-      local i, oRoom, bDoDamage, iDamage, lUsing;
-
-      if who = $
+      if (who = $)
       {
          return;
       }
 
-      if ((IsClass(who,&DM)
-            AND Send(who,@PlayerIsImmortal))
-         OR Send(who,@IsInCannotInteractMode))
-      {
-         return;
-      }
-
-      bDoDamage = FALSE;
-
-      lUsing = Send(who,@GetPlayerUsing);
-      oRoom = Send(who,@GetOwner);
-
-      if lUsing <> $
-      {
-         if Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
-         {
-            bDoDamage = TRUE;
-         }
-         
-         if Send(oRoom,@CheckRoomFlag,#flag=ROOM_KILL_ZONE)
-         {
-            bDoDamage = TRUE;
-         }
-         
-         if Send(oRoom,@CheckRoomFlag,#flag=ROOM_SAFE_DEATH)
-         {
-            if Send(oRoom,@IsValidTarget,#who=who)
-            {
-               bDoDamage = TRUE;
-            }
-            else
-            {
-               bDoDamage = FALSE;
-            }
-         }
-      }
-      
-      if bDoDamage
-      {
-         iDamage = 0;
-
-         foreach i in lUsing
-         {
-            iDamage = iDamage + Send(i,@GetHeatDamage);
-         }
-
-         if iDamage = 0
-         {
-            return;
-         }
-
-         Send(who,@MsgSendUser,#message_rsc=heat_hurts_you);
-         
-         if Send(who,@AssessDamage,#report=FALSE,#what=self,#damage=iDamage,
-                  #aspell=ATCK_SPELL_FIRE) = $
-         {
-            if IsClass(who,&User)
-            {
-               Send(who,@MsgSendUser,#message_rsc=heat_kills_you);
-            }
-            
-            Send(who,@Killed,#what=self);
-            
-            % Currently no one is charged with the death
-            Send(oRoom,@SomethingKilled,#what=self,#victim=who);
-         }
-      }
+      Send(self,@RoomEnchantmentDamage,#oTarget=who,#state=state);
 
       return;
+   }
+
+   ComputeDamage(who=$,oTarget=$,iDamage=$)
+   {
+      local i, lUsing;
+
+      lUsing = Send(oTarget,@GetPlayerUsing);
+
+      iDamage = 0;
+
+      foreach i in lUsing
+      {
+         iDamage = iDamage + Send(i,@GetHeatDamage);
+      }
+
+      return iDamage;
    }
 
    EndSpell(where = $, state = $)
    "Called when spell expires."
    {
       Send(where,@SomeoneSaid,#type=SAY_MESSAGE,#string=heat_off,#what=self);
-      
+
       return;
    }
 
@@ -270,7 +194,7 @@ messages:
    "Ends enchantment effect on one player"
    {
       Send(who,@RemoveEnchantment,#what=self);
-      
+
       return;
    }
 

--- a/kod/object/passive/spell/roomench/heat.lkod
+++ b/kod/object/passive/spell/roomench/heat.lkod
@@ -13,6 +13,6 @@ heat_new_entrant = de \
    "Farens ;Agoe erfüllt den Raum mit Hitze, die alle Rüstungen schmelzen "
    "lässt."
 heat_kills_you = de "Du erfährst Verbrennungen durch deine Rüstung."
-heat_kills_him = de "%s erfährt Verbrennungen durch die getragene Rüstung."
+heat_kills_him = de "%s%s erfährt Verbrennungen durch die getragene Rüstung."
 heat_hurts_you = de \
    "Du schreist vor Schmerzen, als deine glühende Rüstung deine Haut berührt."

--- a/kod/object/passive/spell/roomench/killing.kod
+++ b/kod/object/passive/spell/roomench/killing.kod
@@ -45,6 +45,8 @@ classvars:
    vrIcon = killingfields_icon_rsc
    vrDesc = killingfields_desc_rsc
 
+   vrAlreadyEnchanted = killingfields_already_enchanted
+
    viSpell_num = SID_KILLING_FIELDS
    viMana = 9
    viSchool = SS_KRAANAN
@@ -64,28 +66,6 @@ messages:
       plReagents = Cons([&OrcTooth,1],plReagents);
 
       return;
-   }
-
-   GetNumSpellTargets()
-   {
-      return 0;
-   }
-
-   CanPayCosts(who = $, lTargets = $)
-   {
-      local oRoom;
-
-      oRoom = Send(who,@GetOwner);
-
-      % check for enchantment already applied
-      if Send(oRoom,@IsEnchanted,#what=self)
-      {
-         Send(who,@MsgSendUser,#message_rsc=killingfields_already_enchanted);
-         
-         return FALSE;
-      }
-
-      propagate;
    }
 
    CastSpell(who = $,iSpellPower = 0)

--- a/kod/object/passive/spell/roomench/light.kod
+++ b/kod/object/passive/spell/roomench/light.kod
@@ -44,6 +44,8 @@ classvars:
    vrDesc = light_desc_rsc
    vrSucceed_wav = light_sound
 
+   vrAlreadyEnchanted = light_unnecessary
+
    vrSpell_intro = light_spell_intro
 
    viSpell_num = SID_LIGHT
@@ -65,27 +67,6 @@ messages:
 
       return;
    }
-
-   GetNumSpellTargets()
-   {
-      return 0;
-   }
-
-   CanPayCosts(who = $, lTargets = $)
-   {
-      local oRoom;
-
-      oRoom = Send(who,@GetOwner);
-      % check if room already has light
-      if Send(oRoom,@IsEnchanted,#what=self)
-      {
-	 Send(who,@MsgSendUser,#message_rsc=light_unnecessary);
-	 return False;
-      }
-
-      propagate;
-   }
-
 
    CastSpell( who = $, iSpellPower = 0 )
    "Initiation point for the spell."

--- a/kod/object/passive/spell/roomench/martyrs.kod
+++ b/kod/object/passive/spell/roomench/martyrs.kod
@@ -46,6 +46,7 @@ classvars:
    vrName = martyrsbg_name_rsc
    vrIcon = martyrsbg_icon_rsc
    vrDesc = martyrsbg_desc_rsc
+   vrAlreadyEnchanted = martyrsbg_unnecessary
 
    viSpell_num = SID_MARTYRS_BATTLEGROUND
    viSchool = SS_KRAANAN
@@ -70,28 +71,6 @@ messages:
 
       return;
    }
-
-   GetNumSpellTargets()
-   {
-      return 0;
-   }
-
-   CanPayCosts(who = $, lTargets = $)
-   {
-      local oRoom;
-
-      oRoom = Send(who,@GetOwner);
-      % check if room already has martyrsbg
-      if Send(oRoom,@IsEnchanted,#what=self)
-      {
-         Send(who,@MsgSendUser,#message_rsc=martyrsbg_unnecessary);
-
-         return FALSE;
-      }
-
-      propagate;
-   }
-
 
    CastSpell(who = $, iSpellPower = 0)
    "Initiation point for the spell."

--- a/kod/object/passive/spell/roomench/qorbane.kod
+++ b/kod/object/passive/spell/roomench/qorbane.kod
@@ -21,22 +21,31 @@ resources:
    QorBane_name_rsc = "Qorbane"
    QorBane_icon_rsc = iqorbane.bgf
    QorBane_desc_rsc = \
-      "Permeates an area with the holy essence of Shal'ille, harming any who attempt to call on the evil energy of Qor.  "
-      "Requires yrxl sap and fairy wings to cast."
+      "Permeates an area with the holy essence of Shal'ille, harming any who "
+      "attempt to call on the evil energy of Qor.  Requires one vial of yrxl "
+      "sap and one fairy wing to cast."
    
    QorBane_unnecessary = "This area is already polarized against Qor."
 
-   QorBane_on = "A magical force enters the area, filling the air with a sweet odor.  Everything around "
-      "you seems to glow almost imperceptibly, radiating holy energy."
+   QorBane_on = \
+      "A magical force enters the area, filling the air with a sweet odor.  "
+      "Everything around you seems to glow almost imperceptibly, radiating "
+      "holy energy."
    QorBane_off = "The holy force dissipates."
-   QorBane_new_entrant = "This place is permeated by a holy presence;  you can feel the eyes of Shal'ille "
-      "watching you, warning you against calling upon the magical forces of Qor."
+   QorBane_new_entrant = \
+      "This place is permeated by a holy presence;  you can feel the eyes "
+      "of Shal'ille watching you, warning you against calling upon the "
+      "magical forces of Qor."
 
-   QorBane_HurtCaster = "As you utter the final syllables of your spell, a wash of holy "
+   QorBane_hit_rsc = \
+      "As you utter the final syllables of your spell, a wash of holy "
       "power passes through your body, scalding you with purity."
-   QorBane_kills_you = "As you utter the final syllables of your spell, a wash of holy "
-      "power passes through your body.  The wave of purity is too much for you to stand, "
-      "and you expire."
+   QorBane_kill_rsc = \
+      "As you utter the final syllables of your spell, a wash of holy power "
+      "passes through your body.  The wave of purity is too much for you to "
+      "stand, and you expire."
+   QorBane_killer_rsc = \
+      "%s%s expires from the holy power of your Qorbane enchantment."
 
    QorBane_sound = sqrbane.wav
 
@@ -46,6 +55,13 @@ classvars:
    vrIcon = QorBane_icon_rsc
    vrDesc = QorBane_desc_rsc
 
+   vrAlreadyEnchanted = QorBane_unnecessary
+   vrRoomEnchKilled = QorBane_kill_rsc
+   vrRoomEnchKiller = QorBane_killer_rsc
+   vrRoomEnchHit = QorBane_hit_rsc
+
+   viAttack_spell = ATCK_SPELL_HOLY
+
    viSpell_num = SID_QORBANE
    viSchool = SS_SHALILLE
    viMana = 15
@@ -54,17 +70,15 @@ classvars:
    viCast_time = 5000
    viChance_To_Increase = 40
    viMeditate_ratio = 30
-   
+
    vrSucceed_wav = QorBane_sound
-   viOutlaw = False
-   viHarmful = True
+   viHarmful = TRUE
    vbCastable_in_HappyLand = FALSE
 
 properties:
 
 messages:
 
-   
    ResetReagents()
    {
       plReagents = $;
@@ -74,28 +88,7 @@ messages:
       return;
    }
 
-   GetNumSpellTargets()
-   {
-      return 0;
-   }
-
-   CanPayCosts(who = $, lTargets = $)
-   {
-      local oRoom;
-
-      oRoom = Send(who,@GetOwner);
-      % check if room already has this
-      if Send(oRoom,@IsEnchanted,#what=self)
-      {
-         Send(who,@MsgSendUser,#message_rsc=QorBane_unnecessary);
-         return FALSE;
-      }
-
-      propagate;
-   }
-
-
-   CastSpell( who = $, iSpellPower = 0 )
+   CastSpell(who = $, iSpellPower = 0)
    "Initiation point for the spell."
    {
       local oRoom;
@@ -103,15 +96,16 @@ messages:
       oRoom = Send(who,@GetOwner);
       if Send(oRoom,@IsEnchanted,#what=self)
       {
-        Send(who,@MsgSendUser,#message_rsc=QorBane_unnecessary);
-        return;
+         Send(who,@MsgSendUser,#message_rsc=vrAlreadyEnchanted);
+
+         return;
       }
 
       % global effects of the enchantment
       Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#string=QorBane_on,#what=self);
-      Send(oRoom,@RoomStartEnchantment,#what=self,#state=iSpellPower,
-            #time=send(self,@GetDuration,#iSpellPower = iSpellPower));
-      
+      Send(oRoom,@RoomStartEnchantment,#what=self,#state=[iSpellPower,who],
+            #time=Send(self,@GetDuration,#iSpellPower=iSpellPower));
+
       propagate;
    }
 
@@ -119,80 +113,33 @@ messages:
    {
       local iDuration;
 
-      iDuration = 45 + (iSpellPower*3);  %% 30 - 228 seconds
-      iDuration = iDuration * 1000;      %% convert to seconds            
+      iDuration = 45 + (iSpellPower * 3);  %% 30 - 228 seconds
+      iDuration = iDuration * 1000;      %% convert to seconds
 
-      return random(iDuration/2,iDuration);
+      return Random(iDuration/2,iDuration);
    }
 
-   StartEnchantmentNewOccupant( who = $ )
+   StartEnchantmentNewOccupant(who = $)
    "Called on new occupants of the enchanted room."
    {
       Send(who,@MsgSendUser,#message_rsc=QorBane_new_entrant);
+
       return;
    }
 
-   EndSpell( where = $, state = $ )
+   EndSpell(where = $, state = $)
    "Called when spell expires."
    {
       Send(where,@SomeoneSaid,#type=SAY_MESSAGE,#string=QorBane_off,#what=self);
+
       return;
    }
 
-   HurtCaster(qorCaster=$, iSpellPower=0, qorSpellLevel=1)
+   ComputeDamage(iSpellPower=$,iLevel=1)
    {
-      local bDoDamage,oRoom,iDamageAmt;
-
-      bDoDamage = FALSE;
-      
-      if IsClass(qorCaster,&Monster)
-         OR send(qorCaster,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
-         OR send(send(qorCaster,@GetOwner),@CheckRoomFlag,#flag=ROOM_KILL_ZONE)
-      {
-         bDoDamage = TRUE;
-      }
-      
-      if send(send(qorCaster,@GetOwner),@CheckRoomFlag,#flag=ROOM_SAFE_DEATH)
-      {
-         if send(send(qorCaster,@GetOwner),@IsValidTarget,#who=qorCaster)
-         {
-            bDoDamage = TRUE;
-         }
-         else
-         {
-            bDoDamage = FALSE;
-         }
-      }
-      
-      if bDoDamage
-      {
-         if IsClass(qorCaster,&Player)
-         {
-            Send(qorCaster,@MsgSendUser,#message_rsc=QorBane_HurtCaster);
-         }
-
-         %Conceptually: ((iSpellPower/15) * (qorSpellLevel/2) * random(8,12))/10
-         iDamageAmt = (iSpellPower * qorSpellLevel * random(8,12))/300;
-
-         if Send(qorCaster,@AssessDamage,#report=FALSE,#what=self,
-                 #damage=iDamageAmt,#aspell=ATCK_SPELL_HOLY) = $
-         {
-            if IsClass(qorCaster,&Player)
-            {
-               Send(qorCaster,@MsgSendUser,#message_rsc=QorBane_kills_you);
-            }
-            
-            oRoom = Send(qorCaster,@GetOwner);
-            Send(qorCaster,@Killed,#what=self);
-            
-            % currently no one is charged with the death
-            Send(oRoom,@SomethingKilled,#what=self,#victim=qorCaster);
-         }
-      }
-
-      return;
+      % Conceptually: ((iSpellPower/15) * (iLevel/2) * Random(8,12))/10
+      return (iSpellPower * iLevel * Random(8,12))/300;
    }
 
 end
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/roomench/qorbane.lkod
+++ b/kod/object/passive/spell/roomench/qorbane.lkod
@@ -13,10 +13,10 @@ QorBane_new_entrant = de \
    "Dieser Ort ist von einer heiligen Gegenwart umgeben. Du kannst fühlen, "
    "das Shal'ill dich beobachtet und dich davor warnt die dunklen Zauber "
    "Qors auszuüben."
-QorBane_HurtCaster = de \
+QorBane_hit_rsc = de \
    "Als Du den dunklen Zauber ausführst, spürst Du einen Stich und erleidest "
    "Verbrühungen durch die heilie Kraft"
-QorBane_kills_you = de \
+QorBane_kill_rsc = de \
    "Als Du den dunklen Zauber ausführst, spürst Du einen Stich und erleidest "
    "Verbrühungen durch die heilie Kraft.Du schreist noch ein einiziges Mal "
    "auf bevor die Heiligkeit dich tötet."

--- a/kod/object/passive/spell/roomench/shalbane.kod
+++ b/kod/object/passive/spell/roomench/shalbane.kod
@@ -21,21 +21,32 @@ resources:
    ShalilleBane_name_rsc = "Shal'illebane"
    ShalilleBane_icon_rsc = ishabane.bgf
    ShalilleBane_desc_rsc = \
-      "Permeates an area with the unholy essence of Qor, harming any who attempt to call on the holy energy of Shal'ille.  "
-      "Requires yrxl sap and fairy wings to cast."
+      "Permeates an area with the unholy essence of Qor, harming any who "
+      "attempt to call on the holy energy of Shal'ille.  Requires one vial of "
+      "yrxl sap and one fairy wing to cast."
    
-   ShalilleBane_unnecessary = "This area is already polarized against Shal'ille."
+   ShalilleBane_unnecessary = \
+      "This area is already polarized against Shal'ille."
 
-   ShalilleBane_on = "A magical force enters the area, filling the air with an acrid odor.  The shadows seem "
-      "to deepen almost imperceptibly, and a chill creeps up your spine, making the hairs on your arms stand up."
+   ShalilleBane_on = \
+      "A magical force enters the area, filling the air with an acrid odor.  "
+      "The shadows seem to deepen almost imperceptibly, and a chill creeps "
+      "up your spine, making the hairs on your arms stand up."
    ShalilleBane_off = "The evil force dissipates."
-   ShalilleBane_new_entrant = "This place is permeated by an evil presence;  you can feel the eyes of Qor "
-      "watching you, warning you against calling upon the magical forces of Shal'ille."
+   ShalilleBane_new_entrant = \
+      "This place is permeated by an evil presence;  you can feel the eyes "
+      "of Qor watching you, warning you against calling upon the magical "
+      "forces of Shal'ille."
 
-   ShalilleBane_HurtCaster = "As you utter the final syllables of your spell, a bolt of unholy "
+   ShalilleBane_hit_rsc = \
+      "As you utter the final syllables of your spell, a bolt of unholy "
       "energy slams into your body."
-   ShalilleBane_kills_you = "As you utter the final syllables of your spell a bolt of unholy "
+   ShalilleBane_kill_rsc = \
+      "As you utter the final syllables of your spell a bolt of unholy "
       "energy slams into your body, killing you instantly."
+   ShalilleBane_killer_rsc = \
+      "%s%s is destroyed by a bolt of unholy energy from your Shal'illebane "
+      "enchantment."
 
    ShalilleBane_sound = qshalban.wav
 
@@ -45,6 +56,12 @@ classvars:
    vrIcon = ShalilleBane_icon_rsc
    vrDesc = ShalilleBane_desc_rsc
 
+   vrAlreadyEnchanted = ShalilleBane_unnecessary
+   vrRoomEnchKilled = ShalilleBane_kill_rsc
+   vrRoomEnchKiller = ShalilleBane_killer_rsc
+   vrRoomEnchHit = ShalilleBane_hit_rsc
+
+   viAttack_spell = ATCK_SPELL_UNHOLY
    viSpell_num = SID_SHALILLEBANE
    viSchool = SS_QOR
    viMana = 15
@@ -55,8 +72,7 @@ classvars:
    viMeditate_ratio = 30
 
    vrSucceed_wav =  ShalilleBane_sound
-   viOutlaw = True
-   viHarmful = True
+   viHarmful = TRUE
    vbCastable_in_HappyLand = FALSE
 
 properties:
@@ -72,27 +88,6 @@ messages:
       return;
    }
 
-   GetNumSpellTargets()
-   {
-      return 0;
-   }
-
-   CanPayCosts(who = $, lTargets = $)
-   {
-      local oRoom;
-
-      oRoom = Send(who,@GetOwner);
-      % check if room already has this
-      if Send(oRoom,@IsEnchanted,#what=self)
-      {
-         Send(who,@MsgSendUser,#message_rsc=ShalilleBane_unnecessary);
-         return FALSE;
-      }
-
-      propagate;
-   }
-
-
    CastSpell( who = $, iSpellPower = 0 )
    "Initiation point for the spell."
    {
@@ -107,7 +102,7 @@ messages:
 
       % global effects of the enchantment
       Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#string=ShalilleBane_on,#what=self);
-      Send(oRoom,@RoomStartEnchantment,#what=self,#state=iSpellPower,
+      Send(oRoom,@RoomStartEnchantment,#what=self,#state=[iSpellPower,who],
             #time=send(self,@GetDuration,#iSpellPower=iSpellPower));
       
       propagate;
@@ -118,79 +113,33 @@ messages:
       local iDuration;
 
       iDuration = 45 + (iSpellPower*3);  %% 30 - 228 seconds
-      iDuration = iDuration * 1000;      %% convert to seconds            
+      iDuration = iDuration * 1000;      %% convert to seconds
 
-      return random(iDuration/2,iDuration);
+      return Random(iDuration/2,iDuration);
    }
 
    StartEnchantmentNewOccupant( who = $ )
    "Called on new occupants of the enchanted room."
    {
       Send(who,@MsgSendUser,#message_rsc=ShalilleBane_new_entrant);
+
       return;
    }
 
    EndSpell( where = $, state = $ )
    "Called when spell expires."
    {
-      Send(where,@SomeoneSaid,#type=SAY_MESSAGE,#string=ShalilleBane_off,#what=self);
+      Send(where,@SomeoneSaid,#type=SAY_MESSAGE,#string=ShalilleBane_off,
+            #what=self);
+
       return;
    }
 
-   HurtCaster(shalCaster=$, iSpellPower=0, shalSpellLevel=1)
+   ComputeDamage(iSpellPower=$,iLevel=1)
    {
-      local bDoDamage,oRoom,iDamageAmt;
-      
-      bDoDamage = FALSE;
-
-      if IsClass(shalCaster,&Monster)
-         OR send(shalCaster,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
-         OR send(send(shalCaster,@GetOwner),@checkroomflag,#flag=ROOM_KILL_ZONE)
-      {
-         bDoDamage = TRUE;
-      }
-      
-      if send(send(shalCaster,@getowner),@CheckRoomFlag,#flag=ROOM_SAFE_DEATH)
-      {
-         if send(send(shalCaster,@GetOwner),@IsValidTarget,#who=shalCaster)
-         {
-            bDoDamage = TRUE;
-         }
-         else
-         {
-            bDoDamage = FALSE;
-         }
-      }
-      
-      if bDoDamage
-      {
-         if IsClass(shalCaster,&Player)
-         {
-            Send(shalCaster,@MsgSendUser,#message_rsc=ShalilleBane_HurtCaster);
-         }
-         
-         % Conceptually: ((iSpellPower/15) * (shalSpellLevel/2) * random(8,12))/10
-         iDamageAmt = (iSpellPower * shalSpellLevel * random(8,12))/300;
-         
-         if Send(shalCaster,@AssessDamage,#report=FALSE,#what=self,
-                 #damage=iDamageAmt,#aspell=ATCK_SPELL_UNHOLY) = $
-         {
-            if IsClass(shalCaster,&Player)
-            {
-               Send(shalCaster,@MsgSendUser,#message_rsc=ShalilleBane_kills_you);
-            }
-            
-            oRoom = Send(shalCaster,@GetOwner);
-            Send(shalCaster,@Killed,#what=self);
-            
-            % currently no one is charged with the murder
-            Send(oRoom,@SomethingKilled,#what=self,#victim=shalCaster);
-         }
-      }
-
-      return;
+      % Conceptually: ((iSpellPower/15) * (iLevel/2) * Random(8,12))/10
+      return (iSpellPower * iLevel * Random(8,12))/300;
    }
 
 end
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/roomench/shalbane.lkod
+++ b/kod/object/passive/spell/roomench/shalbane.lkod
@@ -11,8 +11,8 @@ ShalilleBane_on = de \
 ShalilleBane_off = de "Die dunkle Kraft verschwindet."
 ShalilleBane_new_entrant = de \
    "Du weißt, dass Du hier lieber nicht Shal'ill zaubern solltest."
-ShalilleBane_HurtCaster = de \
+ShalilleBane_hit_rsc = de \
    "Du zauberst Shal'ill und wirst dadurch verletzt durch die Macht Qors."
-ShalilleBane_kills_you = de \
+ShalilleBane_kill_rsc = de \
    "Durch die dunkle Macht Qors wirst Du getötet, da du Shal'ill in einer "
    "dunklen Gegend gezaubert hast."

--- a/kod/object/passive/spell/roomench/silence.kod
+++ b/kod/object/passive/spell/roomench/silence.kod
@@ -43,6 +43,8 @@ classvars:
    vrDesc = Silence_desc_rsc
    vrSpell_intro = Silence_spell_intro
 
+   vrAlreadyEnchanted = Silence_unnecessary
+
    viSpell_num = SID_SILENCE
    viSchool = SS_QOR
    viMana = 10
@@ -69,27 +71,6 @@ messages:
       plReagents = Cons([&PurpleMushroom,1],plReagents);
 
       return;
-   }
-
-   GetNumSpellTargets()
-   {
-      return 0;
-   }
-
-   CanPayCosts(who = $, lTargets = $)
-   {
-      local oRoom;
-
-      oRoom = Send(who,@GetOwner);
-
-      if Send(oRoom,@IsEnchanted,#what=self)
-      {
-   	   Send(who,@MsgSendUser,#message_rsc=Silence_unnecessary);
-   	   
-	      return FALSE;
-      }
-
-      propagate;
    }
 
    CastSpell(who = $, iSpellPower = 0)


### PR DESCRIPTION
##### Room enchantment code
* Renamed Spell's CheckPlayerAttack() to CheckPlayerAttackCast() to better reflect its purpose (checking attack status on cast rather than on effect).
* Added PKILL_ENABLE and temp safe checks to CheckPlayerAttackCast().
* Added RoomEnchantmentDamage() message in RoomEnchantment, handles all damaging room effects. Heat, Qorbane and ShalilleBane use this to apply damage. Uses AllowPlayerAttack() to determine whether any target will be damaged, also damages caster (can be toggled with vbRoomEnchHitCaster).
* Room enchantments that do damage now have similar code to attack spells - viAttack_spell to determine the damage type (e.g. fire, holy) and a ComputeDamage() message to calculate the damage.
* Damaging or killing players with room enchantments will now incur outlaw/murderer penalties.
* Fixed a bug causing players to go outlaw for casting Shalillebane but not for casting Qorbane. Casting either spell won't give outlaw status (nor will heat) but damaging players will.
* Heat now checks all items worn by the player instead of just the armor. Nothing else currently does any damage, but this may change in the future (i.e. #1262).
* Can now cast Heat in towns.

##### Misc
* Added a PossessesA() override in NoMoveOn, optimised for NoMoveOn's plPassive.