### PR TITLE
Fix client audio issues, fix mobs walking through walls, misc. kod fixes.

### DIFF
--- a/blakserv/geometry.h
+++ b/blakserv/geometry.h
@@ -56,8 +56,8 @@ typedef struct V2
 
 // true if point (c) lies inside boundingbox defined by min/max of (a) and (b)
 #define ISINBOX(a, b, c) \
-   (fmin((a)->X, (b)->X) - EPSILON <= (c)->X && (c)->X <= fmax((a)->X, (b)->X) + EPSILON && \
-    fmin((a)->Y, (b)->Y) - EPSILON <= (c)->Y && (c)->Y <= fmax((a)->Y, (b)->Y) + EPSILON)
+   (fmin((a)->X, (b)->X) - 0.1f <= (c)->X && (c)->X <= fmax((a)->X, (b)->X) + 0.1f && \
+    fmin((a)->Y, (b)->Y) - 0.1f <= (c)->Y && (c)->Y <= fmax((a)->Y, (b)->Y) + 0.1f)
 
 // Rotates V2 instance by radian
 __inline void V2ROTATE(V2* V, float Radian)

--- a/blakserv/geometry.h
+++ b/blakserv/geometry.h
@@ -1,4 +1,5 @@
 #define EPSILON     0.0001f
+#define EPSILONBIG  0.1f
 #define ISZERO(a)   ((a) > -EPSILON && (a) < EPSILON)
 
 typedef struct V3
@@ -56,8 +57,8 @@ typedef struct V2
 
 // true if point (c) lies inside boundingbox defined by min/max of (a) and (b)
 #define ISINBOX(a, b, c) \
-   (fmin((a)->X, (b)->X) - 0.1f <= (c)->X && (c)->X <= fmax((a)->X, (b)->X) + 0.1f && \
-    fmin((a)->Y, (b)->Y) - 0.1f <= (c)->Y && (c)->Y <= fmax((a)->Y, (b)->Y) + 0.1f)
+   (fmin((a)->X, (b)->X) - EPSILONBIG <= (c)->X && (c)->X <= fmax((a)->X, (b)->X) + EPSILONBIG && \
+    fmin((a)->Y, (b)->Y) - EPSILONBIG <= (c)->Y && (c)->Y <= fmax((a)->Y, (b)->Y) + EPSILONBIG)
 
 // Rotates V2 instance by radian
 __inline void V2ROTATE(V2* V, float Radian)

--- a/blakserv/roofile.c
+++ b/blakserv/roofile.c
@@ -462,25 +462,25 @@ bool BSPCanMoveInRoomTree(BspNode* Node, V2* S, V2* E, Wall** BlockWall)
           (distS < 0.0f && distE > 0.0f))
       {
          // get 2d line equation coefficients for infinite line through S and E
-         float a1, b1, c1;
+         double a1, b1, c1;
          a1 = E->Y - S->Y;
          b1 = S->X - E->X;
          c1 = a1 * S->X + b1 * S->Y;
 
          // get 2d line equation coefficients of splitter
-         float a2, b2, c2;
+         double a2, b2, c2;
          a2 = -Node->u.internal.A;
          b2 = -Node->u.internal.B;
          c2 = Node->u.internal.C;
 
-         float det = a1*b2 - a2*b1;
+         double det = a1*b2 - a2*b1;
 
          // shouldn't be zero at all, because distS and distE have different sign
          if (!ISZERO(det))
          {
-            // intersection point of infinite lines				
-            q.X = (b2*c1 - b1*c2) / det;
-            q.Y = (a1*c2 - a2*c1) / det;
+            // intersection point of infinite lines
+            q.X = (float)((b2*c1 - b1*c2) / det);
+            q.Y = (float)((a1*c2 - a2*c1) / det);
 
             // must be in boundingbox of SE
             if (ISINBOX(S, E, &q))

--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -48,7 +48,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 50   /* Major version of client program */
-#define MINOR_REV 33  /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 34  /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 512 /* Max length of a string loaded from string table */

--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -1589,7 +1589,7 @@ messages:
       {
          if IsClass(i,&Monster)
          {
-            Send(i,&Delete);
+            Send(i,@Delete);
          }
       }
 

--- a/kod/object/passive/spell/multicst/hunt.kod
+++ b/kod/object/passive/spell/multicst/hunt.kod
@@ -169,6 +169,11 @@ messages:
 
       oPrey = Send(SYS,@FindUserByString,#string=string);
 
+      if (oPrey = $)
+      {
+         return;
+      }
+
       if IsClass(oPrey,&DM) AND NOT Send(oPrey,@IsHuntable)
       {
          Send(who,@MsgSendUser,#message_rsc=hunt_target_is_dm);


### PR DESCRIPTION
##### Mob movement
When a monster's move will cross a wall, the point on the wall for the lines move_start->move_end and the wall line itself is calculated. Currently the X,Y values for this point are often incorrect by < 0.1, and if the end point is across a wall from the start point and the end point is very close to the wall, this will allow the monster to incorrectly move through it.

To fix this, the calculation is now done using doubles instead of floats (fixing cases where c1 is large). Some cases remained after this and to handle those, the ISINBOX macro now subtracts 0.1f from the min box value and adds 0.1f to the max box value to ensure the point is contained within.

##### Misc
* Fixed client crashes caused by having no sound devices connected to the computer.
* Fixed typo in minion removal code.
* Added sanity check in dealing with player name string in hunt.
