### PR TITLE
Small LOS refactoring

### DIFF
--- a/blakserv/roofile.c
+++ b/blakserv/roofile.c
@@ -627,7 +627,41 @@ bool BSPLineOfSight(room_type* Room, V3* S, V3* E)
    if (!Room || Room->TreeNodesCount == 0 || !S || !E)
       return false;
 
-   return BSPLineOfSightTree(&Room->TreeNodes[0], S, E);
+   // test center
+   if (BSPLineOfSightTree(&Room->TreeNodes[0], S, E))
+      return true;
+
+   V3 e;
+
+   // test p
+   e.X = E->X + LOSEXTEND;
+   e.Y = E->Y + LOSEXTEND;
+   e.Z = E->Z;
+   if (BSPLineOfSightTree(&Room->TreeNodes[0], S, &e))
+      return true;
+
+   // test p
+   e.X = E->X - LOSEXTEND;
+   e.Y = E->Y - LOSEXTEND;
+   e.Z = E->Z;
+   if (BSPLineOfSightTree(&Room->TreeNodes[0], S, &e))
+      return true;
+
+   // test p
+   e.X = E->X + LOSEXTEND;
+   e.Y = E->Y - LOSEXTEND;
+   e.Z = E->Z;
+   if (BSPLineOfSightTree(&Room->TreeNodes[0], S, &e))
+      return true;
+
+   // test p
+   e.X = E->X - LOSEXTEND;
+   e.Y = E->Y + LOSEXTEND;
+   e.Z = E->Z;
+   if (BSPLineOfSightTree(&Room->TreeNodes[0], S, &e))
+      return true;
+
+   return false;
 }
 
 /*********************************************************************************************/

--- a/blakserv/roofile.h
+++ b/blakserv/roofile.h
@@ -34,7 +34,7 @@
 #define WALLMINDISTANCE2    (WALLMINDISTANCE * WALLMINDISTANCE)    // (from clientd3d/game.c)
 #define OBJMINDISTANCE      768.0f                                 // 3 highres rows/cols, old value from kod
 #define OBJMINDISTANCE2     (OBJMINDISTANCE * OBJMINDISTANCE)
-#define LOSEXTEND           128.0f
+#define LOSEXTEND           64.0f
 
 // converts grid coordinates
 // input: 1-based value of big row (or col), 0-based value of fine-row (or col)

--- a/blakserv/roofile.h
+++ b/blakserv/roofile.h
@@ -34,6 +34,7 @@
 #define WALLMINDISTANCE2    (WALLMINDISTANCE * WALLMINDISTANCE)    // (from clientd3d/game.c)
 #define OBJMINDISTANCE      768.0f                                 // 3 highres rows/cols, old value from kod
 #define OBJMINDISTANCE2     (OBJMINDISTANCE * OBJMINDISTANCE)
+#define LOSEXTEND           128.0f
 
 // converts grid coordinates
 // input: 1-based value of big row (or col), 0-based value of fine-row (or col)


### PR DESCRIPTION
Changes to BSPLineOfSight:

1) Reformatted from tabs to whitespaces
2) Use BSP splitter's A,B,C as a2,b2,c2 (faster, like in BSPCanMoveInRoom)
3) Move some code out of the wall loop (faster, like done in BSPCanMoveInRoom)
4) Use 'double' precision for calculating the intersection point.
5) Add 4 additional LoS checks for points slightly off in x, y directions if center check fails