### PR TITLE
Remove cast timer from CC defenses

### DIFF
--- a/kod/object/passive/spell/persench/detinvis.kod
+++ b/kod/object/passive/spell/persench/detinvis.kod
@@ -46,7 +46,6 @@ classvars:
    viMana = 15
    viSpellExertion = 3
 
-   viCast_time = 3000
    viChance_To_Increase = 15
    viMeditate_ratio = 20
 

--- a/kod/object/passive/spell/persench/eagleyes.kod
+++ b/kod/object/passive/spell/persench/eagleyes.kod
@@ -63,7 +63,6 @@ classvars:
    viMana = 5
    viSpellExertion = 3
 
-   viCast_time = 2000
    viChance_To_Increase = 20
    viMeditate_ratio = 30
 

--- a/kod/object/passive/spell/persench/freeact.kod
+++ b/kod/object/passive/spell/persench/freeact.kod
@@ -61,7 +61,6 @@ classvars:
    viMana = 10
    viSpellExertion = 3
 
-   viCast_time = 2000
    viChance_To_Increase = 15
    viMeditate_ratio = 30
 


### PR DESCRIPTION
As posted on the globe if you are caught unbuffed it is basically game over.
With no cast time u can quickly buff yourself and have a chance at safety or even defeating your attacker. 