### PR TITLE
thrasher upgrades

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/thrasher.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/thrasher.kod
@@ -60,7 +60,7 @@ classvars:
    vrDead_name = thrasher_dead_name_rsc
 
    viTreasure_type = TID_THRASHER
-   viCashmin = -12000
+   viCashmin = -9000
    viCashmax = 6000
    viNormalSpeed = SPEED_FAST
    viAttack_type = ATCK_WEAP_BLUDGEON
@@ -68,7 +68,7 @@ classvars:
    % Attack range of 192, or 3 row/col.
    viAttackRange = 192
    viAttributes = 0
-   viKarma = -75
+   viKarma = 0
    vbIsUndead = TRUE
    viDefault_behavior = AI_FIGHT_AGGRESSIVE | AI_FIGHT_HYPERAGGRESSIVE \
                         | AI_FIGHT_LASHOUT | AI_MOVE_FLEE_FRIGHTENERS
@@ -156,27 +156,6 @@ messages:
             oObject = Create(&Scimitar);
             Send(self,@NewHold,#what=oObject);
             prShieldOverlay = thrasher_scimitar_overlay;
-         }
-      }
-
-      return;
-   }
-
-   HitSideEffect(what = $, who = $)
-   {
-      local oSpell;
-
-      oSpell = Send(SYS,@FindSpellByNum,#num=SID_ENFEEBLE);
-      if NOT Send(what,@IsEnchanted,#what=oSpell)
-         AND Random(1,PALSY_CHANCE) = 1
-      {
-         if who <> $
-         {
-            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=90);
-         }
-         else
-         {
-            Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=90);
          }
       }
 


### PR DESCRIPTION
Remove enfeeble, it is nothing but aggervating. it serves no purpose.

Raised cashmin from -12000 to -9000. such tuff mobs shouldn't have such
a negative cash drop.

Made karma neutral so that qors may have a place to reach 150 without
destroing karma.