### PR TITLE
Use object's num_props value for bounds checking when assigning data to a property in StoreValue.

### DIFF
--- a/blakserv/sendmsg.c
+++ b/blakserv/sendmsg.c
@@ -748,7 +748,6 @@ in sendmsg.h now */
 __inline void StoreValue(int object_id,local_var_type *local_vars,int data_type,int data,
 						 val_type new_data)
 {
-	class_node *class_data;
 	object_node *o;
 	
 	switch (data_type)
@@ -771,18 +770,11 @@ __inline void StoreValue(int object_id,local_var_type *local_vars,int data_type,
 				BlakodDebugInfo(),object_id);
 			return;
 		}
-		class_data = GetClassByID(o->class_id);
-		if (class_data == NULL)
-		{
-			eprintf("[%s] StoreValue can't find class id %i\n",
-				BlakodDebugInfo(),o->class_id);
-			return;
-		}
-		/* equal to num_properties is ok, because self = prop 0 */
-		if (data < 0 || data > class_data->num_properties) 
+		// num_props includes self, so the max property is stored at [num_props - 1]
+		if (data < 0 || data >= o->num_props)
 		{
 			eprintf("[%s] StoreValue can't write to illegal property %i (max %i)\n",
-				BlakodDebugInfo(),data,class_data->num_properties);
+				BlakodDebugInfo(), data, o->num_props - 1);
 			return;
 		}
 		o->p[data].val.int_val = new_data.int_val; 


### PR DESCRIPTION
To ensure that data isn't written outside an object's property array, StoreValue must check lower (0) and upper (number of obj props) bounds when assigning data to a property.

Currently this is done using the number of properties taken from the object's class data structure, requiring the class to be obtained and checked to assign to the property. However, since objects already keep track of how many properties they have (o->num_props), this value can be used directly from the object itself, allowing the removal of the class-related code from StoreValue.

This provides a 10-15% performance increase when assigning data to a property (11% in the following benchmark).

#### Test code
https://gist.github.com/skittles1/cd5906a3de2ac0ef4508
All builds from clean, tried with several variations (number of assignments in loop, number of iterations) with similar results. Local var assignment shown for comparison. Times in milliseconds.

#### Results
##### Property assignment
Prop val, 103 master, release build:
Completed in ,198
Completed in ,197
Completed in ,196
Completed in ,197
Completed in ,198
AVG 197.2 ms for 1 mil iterations (10 mil assignments)

Prop val, StoreValue upgraded, release build:
Completed in ,173
Completed in ,175
Completed in ,172
Completed in ,175
Completed in ,175
AVG: 174 ms for 1 mil iterations (10 mil assignments)
11.8% performance increase

##### Local var assignment
Local val, 103 master, release build:
Completed in ,148
Completed in ,153
Completed in ,147
Completed in ,148
Completed in ,147
AVG: 148.6 ms for 1 mil iterations (10 mil assignments)

Local val, StoreValue upgraded, release build:
Completed in ,149
Completed in ,149
Completed in ,148
Completed in ,149
Completed in ,149
AVG: 148.8 ms for 1 mil iterations (10 mil assignments)