### PR TITLE
Fix LoS issue with raised objects in small spaces.

### DIFF
--- a/blakserv/roofile.c
+++ b/blakserv/roofile.c
@@ -226,7 +226,7 @@ bool BSPLineOfSightTree(BspNode* Node, V3* S, V3* E)
             if (blocked)
             {
 #if DEBUGLOS
-               dprintf("BLOCK - CEILING");
+               dprintf("BLOCK - CEILING sector %i", Node->u.leaf.SectorNum);
 #endif
                return false;
             }
@@ -632,6 +632,13 @@ bool BSPLineOfSight(room_type* Room, V3* S, V3* E)
       return true;
 
    V3 e;
+
+   // test lower
+   e.X = E->X;
+   e.Y = E->Y;
+   e.Z = E->Z - OBJECTHEIGHTROO + 1;
+   if (BSPLineOfSightTree(&Room->TreeNodes[0], S, &e))
+      return true;
 
    // test p
    e.X = E->X + LOSEXTEND;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -4838,7 +4838,7 @@ messages:
       }
 
       if IsClass(what,&StorageBox)
-         AND NOT Send(poOwner,@LineOfSight,#obj1=what,#obj2=self)
+         AND NOT Send(poOwner,@LineOfSight,#obj1=self,#obj2=what)
       {
          Debug("User ", self, vrName, "tried to look at storebox item they could not see!");
          return;

--- a/kod/object/active/holder/room/ghall/guildh6.kod
+++ b/kod/object/active/holder/room/ghall/guildh6.kod
@@ -16,6 +16,7 @@ constants:
    GH6SECRET = 1
    
    LIFT_DELAY = 10000
+   CHEST_DELAY = 60000
        
    include blakston.khd
 
@@ -149,7 +150,7 @@ messages:
          Send(self,@SetSector,#sector=GH6SECRET,#animation=ANIMATE_CEILING_LIFT,
               #height=204,#speed=30);
          Send(self,@OpenSecretDoorSound);
-         ptSecret = CreateTimer(self,@CloseSecretDoor,LIFT_DELAY);
+         ptSecret = CreateTimer(self,@CloseSecretDoor,CHEST_DELAY);
       }
 
       return; 


### PR DESCRIPTION
Ivory Chapel guild hall chest is in a small raised alcove, and currently
BSPLineOfSightTree returns false when a player tries to add or remove
items from this chest (DEBUGLOS reports a ceiling block). This appears
to happen because of the height adjustment to the end point's Z axis,
which adjusts for the object's (which is presumed to be a player or
monster) viewing height.

BSPLineOfSight will now call BSPLineOfSightTree an extra time with end
point coordinates and height adjustment +1 (floor height returns a
block) instead of 768 (player eye height), which fixes this issue.

Also changed the chest LoS check in user.kod to check from player->chest
rather than chest->player.

Raised the time the Ivory Chapel chest stays open from 10 seconds to 60.