### PR TITLE
Soldier shield settings & fixes

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4562,7 +4562,8 @@ messages:
             AND oEnemyGuild <> $
             AND Send(poGuild,@IsMutualEnemy,#otherguild=oEnemyGuild))
          OR (oSoldierShield <> $
-            AND Send(oSoldierShield,@IsEnemyAttack,#what=victim))
+            AND Send(oSoldierShield,@IsEnemyAttack,#who=victim,#what=self,
+                      #damage=FALSE))
       {
          % Okay, attack is against a player, so record the time
          if actual = TRUE
@@ -5576,9 +5577,10 @@ messages:
       % Faction enemies an extra 15% damage to each other, above caps.
       if what <> $ AND IsClass(what,&Player)
       {
-         oSoldierShield = Send(what,@FindUsing,#class=&SoldierShield,#damage=TRUE);
+         oSoldierShield = Send(what,@FindUsing,#class=&SoldierShield);
          if oSoldierShield <> $
-            AND Send(oSoldierShield,@IsEnemyAttack,#what=self,#damage=TRUE)
+            AND Send(oSoldierShield,@IsEnemyAttack,#who=self,#what=what,
+                      #damage=TRUE)
          {
             damage = (damage * 115)/100;
          }
@@ -5953,8 +5955,8 @@ messages:
                    OR oEnemyGuild = $
                    OR NOT Send(poGuild,@IsMutualEnemy,#otherguild=oEnemyGuild))
                   AND (oSoldierShield = $
-                       OR NOT Send(oSoldierShield,@IsEnemyAttack,
-                                    #what=what,#damage=TRUE))
+                       OR NOT Send(oSoldierShield,@IsEnemyAttack,#who=what,
+                                    #what=self,#damage=TRUE))
                {
                   % SUBTLE BUG: Somehow, the faction check is missed when you
                   % kill something. We check it here, but only for players.

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -6128,7 +6128,8 @@ messages:
       }
 
       % Get the spell power
-      iSpellPower = Send(oSpell,@GetSpellPower,#who=self);
+      iSpellPower = Send(oSpell,@GetSpellPower,#who=self,
+                          #lTargets=lFinalTargets);
 
       % First make sure user has enough magic points, reagents, etc.
       if NOT Send(oSpell,@CanPayCosts,#who=self,#lTargets=lFinalTargets,

--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -2063,11 +2063,12 @@ messages:
       return viSpell_modifier;
    }
 
-   GetSpellModifier(oSpell=$)
+   GetSpellModifier(oSpell=$,lTargets=$)
    {
       local oItemAtt, iModifier, i, iNum, oObjectAttribute;
 
-      iModifier = Send(self,@GetBaseSpellModifier,#oSpell=oSpell);
+      iModifier = Send(self,@GetBaseSpellModifier,#oSpell=oSpell,
+                        #lTargets=lTargets);
       foreach i in plItem_Attributes
       {
          iNum = Send(self,@GetNumFromCompound,#compound=First(i));

--- a/kod/object/item/passitem/defmod/shield/soldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld.kod
@@ -217,7 +217,7 @@ messages:
       {
          % No bonus if it wasn't an enemy or if for some reason we didn't
          %  attack any one "recently" (IE, our owner can be helped by mules).
-         if NOT Send(self,@IsEnemyAttack,#what=what)
+         if NOT Send(self,@IsEnemyAttack,#who=what,#what=poOwner)
             OR Send(poOwner,@CanHelpPlayer)
          {
             return;
@@ -289,10 +289,18 @@ messages:
    {
       local oSoldierShield;
 
+      oSoldierShield = $;
+      if poLastEnemyToAttack <> $
+      {
+         oSoldierShield = Send(poLastEnemyToAttack,@FindUsing,
+                               #class=&SoldierShield);
+      }
+
       % logoff is used for logoff ghosts to thump us a good one for being
       %  cowardly.
       if logoff
-         OR Send(self,@IsEnemyAttack,#what=what)
+         OR (oSoldierShield <> $
+            AND Send(oSoldierShield,@IsEnemyAttack,#who=poOwner,#what=what))
       {
          % If we're rank 3 or below, then we lose our item for slacking.
          if piFactionRank <= 3
@@ -308,10 +316,8 @@ messages:
          % Give the last person to attack us a bonus for forcing owner off if
          %  logged
          if logoff
-            AND poLastEnemyToAttack <> $
+            AND oSoldierShield <> $
          {
-            oSoldierShield = Send(poLastEnemyToAttack,@FindUsing,
-                                  #class=&SoldierShield);
             Send(oSoldierShield,@KilledSomething,#what=poOwner);
          }
       }
@@ -319,22 +325,31 @@ messages:
       return;
    }
 
-   IsEnemyAttack(what=$,damage=FALSE)
+   IsEnemyAttack(who=$,what=$,damage=FALSE)
    "Returns TRUE if what is an enemy (opposing faction soldier)."
    {
       local oSoldierShield;
 
-      if what <> $
-         AND IsClass(what,&Player)
-         AND what <> poOwner
+      % Who is the defender.
+      % What is the attacker.
+      % This obj is the attacker's shield.
+      % oSoldierShield is the defender's shield.
+
+      if who <> $
+         AND IsClass(who,&Player)
+         AND who <> poOwner
       {
-         oSoldierShield = Send(what,@FindUsing,#class=&SoldierShield);
+         oSoldierShield = Send(who,@FindUsing,#class=&SoldierShield);
 
          % Gotta have a shield, and it can't be the same faction as us.
          if oSoldierShield <> $
             AND Send(oSoldierShield,@GetFaction) <> viFaction
          {
-            Send(oSoldierShield,@AttackedByEnemy,#who=what);
+            if damage = TRUE
+            {
+               % Tell defender's shield it was attacked by our owner.
+               Send(oSoldierShield,@AttackedByEnemy,#what=what);
+            }
 
             return TRUE;
          }
@@ -343,9 +358,9 @@ messages:
       return FALSE;
    }
 
-   AttackedByEnemy(who=$)
+   AttackedByEnemy(what=$)
    {
-      poLastEnemyToAttack = who;
+      poLastEnemyToAttack = what;
 
       return;
    }

--- a/kod/object/item/passitem/defmod/shield/soldshld/dukeshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld/dukeshld.kod
@@ -152,13 +152,34 @@ messages:
       return;
    }
 
-   GetBaseSpellModifier(oSpell=$)
+   GetBaseSpellModifier(oSpell=$,lTargets=$)
    {
-      local iModifier;
+      local oTarget, oSoldierShield;
 
-      iModifier = ((15 * piFactionRank) / 10);
+      % Duke shield gives a spellpower bonus against monsters & enemy soldiers
 
-      return iModifier;
+      if Send(SETTINGS_OBJECT,@GetAlwaysApplySoldierBonus)
+      {
+         return ((15 * piFactionRank) / 10);
+      }
+
+      if lTargets <> $
+         AND Length(lTargets) = 1
+      {
+         oTarget = First(lTargets);
+
+         oSoldierShield = Send(poOwner,@FindUsing,#class=&SoldierShield);
+         if (IsClass(oTarget,&Player)
+               AND oSoldierShield <> $
+               AND Send(oSoldierShield,@IsEnemyAttack,#who=oTarget,
+                         #what=poOwner,#damage=FALSE))
+            OR IsClass(oTarget,&Monster)
+         {
+            return ((15 * piFactionRank) / 10);
+         }
+      }
+
+      return 0;
    }
 
 

--- a/kod/object/item/passitem/defmod/shield/soldshld/prinshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld/prinshld.kod
@@ -151,13 +151,34 @@ messages:
       return;
    }
 
-   GetSpellManaReduction()
+   GetSpellManaReduction(lTargets=$)
    {
-      local iReduction;
+      local oTarget, oSoldierShield;
 
-      iReduction = ((piFactionRank/3) - 1);
+      % Cess shield gives mana cost reduction against monsters & enemy soldiers
 
-      return iReduction;
+      if Send(SETTINGS_OBJECT,@GetAlwaysApplySoldierBonus)
+      {
+         return ((piFactionRank/3) - 1);
+      }
+
+      if lTargets <> $
+         AND Length(lTargets) = 1
+      {
+         oTarget = First(lTargets);
+
+         oSoldierShield = Send(poOwner,@FindUsing,#class=&SoldierShield);
+         if (IsClass(oTarget,&Player)
+               AND oSoldierShield <> $
+               AND Send(oSoldierShield,@IsEnemyAttack,#who=oTarget,
+                         #what=poOwner,#damage=FALSE))
+            OR IsClass(oTarget,&Monster)
+         {
+            return ((piFactionRank/3) - 1);
+         }
+      }
+
+      return 0;
    }
 
 

--- a/kod/object/item/passitem/defmod/shield/soldshld/reblshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld/reblshld.kod
@@ -155,8 +155,25 @@ messages:
    ModifyDefenseDamage(who = $,what = $,damage = $,atype = 0,aspell = 0)
    "Sets piDamage_reduce for damage reduction in the superclass."
    {
-      % This ranges from 2-4.  At low end, we absorb 0-2 damage.  At high end, 1-4.
-      piDamage_reduce = viDamage_base + ((piFactionRank/3) - 1);
+      local oSoldierShield;
+
+      oSoldierShield = $;
+      if IsClass(what,&Player)
+      {
+         oSoldierShield = Send(what,@FindUsing,#class=&SoldierShield);
+      }
+
+      piDamage_reduce = 0;
+      if (oSoldierShield <> $
+            AND Send(oSoldierShield,@IsEnemyAttack,#who=who,#what=what,
+                      #damage=FALSE))
+         OR IsClass(what,&Monster)
+         OR Send(SETTINGS_OBJECT,@GetAlwaysApplySoldierBonus)
+      {
+         % This ranges from 2-4.  At low end, we absorb 0-2 damage.
+         % At high end, 1-4. This bonus only works against mobs and soldiers.
+         piDamage_reduce = viDamage_base + ((piFactionRank/3) - 1);
+      }
 
       propagate;
    }

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -660,7 +660,8 @@ messages:
 
       % Make sure caster has enough magic
       if Send(who,@GetMana)
-            < Send(self,@GetManaCost,#who=who,#iSpellpower=iSpellpower)
+            < Send(self,@GetManaCost,#who=who,#iSpellpower=iSpellpower,
+                    #lTargets=lTargets)
       {
          iCrystalizeManaAbility = Send(who,@GetSpellAbility,
                                        #spell_num=SID_CRYSTALIZE_MANA);
@@ -671,7 +672,8 @@ messages:
             oCrystalizeMana = Send(SYS,@FindSpellByNum,#num=SID_CRYSTALIZE_MANA);
             Send(oCrystalizeMana,@DoManaSurge,#who=who,#triggered=TRUE);
             if Send(who,@GetMana)
-                  > Send(self,@GetManaCost,#who=who,#iSpellpower=iSpellpower)
+                  > Send(self,@GetManaCost,#who=who,#iSpellpower=iSpellpower,
+                          #lTargets=lTargets)
             {
                return TRUE;
             }
@@ -1713,7 +1715,7 @@ messages:
       return $;
    }
 
-   GetManaCost(who=$,iSpellPower=0)
+   GetManaCost(who=$,iSpellPower=0,lTargets=$)
    "Returns number of magic points needed to cast spell"
    {
       local iCost, oPrincessShield;
@@ -1747,7 +1749,8 @@ messages:
       oPrincessShield = Send(who,@FindUsing,#class=&PrincessShield);
       if oPrincessShield <> $
       {
-         iCost = iCost - Send(oPrincessShield,@GetSpellManaReduction);
+         iCost = iCost - Send(oPrincessShield,@GetSpellManaReduction,
+                               #lTargets=lTargets);
       }
       
       return bound(iCost,1,$);
@@ -2254,7 +2257,7 @@ messages:
       return;
    }
 
-   GetSpellPower(who=$)
+   GetSpellPower(who=$,lTargets=$)
    {
       local iSpellPower, i, iTerrain, oRoom, oModifierSpell, iAbilityLoss,
             iAbilityGain, iItemModifier, iBase, iPrimaryBonus, iSecondaryBonus,
@@ -2291,7 +2294,8 @@ messages:
       foreach i in Send(who,@GetPlayerUsing)
       {
          iItemModifier = iItemModifier + Send(i,@GetSpellModifier,
-                                              #oSpell=self);
+                                              #oSpell=self,
+                                              #lTargets=lTargets);
       }
    
       % Each school has a bonus for different things.

--- a/kod/object/passive/spell/utility/phase.kod
+++ b/kod/object/passive/spell/utility/phase.kod
@@ -418,7 +418,8 @@ messages:
       local i, bLooped, LossCounter, BaseLossAmount, iHealth,
             LossAmount, iNumItemsInventory, numItemsLost, iLoops,
             iStart, lSpells, iSpellAbility, iAbilityNum, numSpellPointsLost,
-            lSkills, iSkillAbility, numSkillPointsLost, poGhostedPlayer;
+            lSkills, iSkillAbility, numSkillPointsLost, poGhostedPlayer,
+            oSoldierShield;
 
       if who = $
       {
@@ -627,6 +628,15 @@ messages:
          Send(poGhostedPlayer,@MsgSendUser,#message_rsc=penalties_inflicted_plural,
                #parm1=numItemsLost,#parm2=numSpellPointsLost,
                #parm3=numSkillPointsLost);
+      }
+
+      % Let the faction shield know of this person's naughtiness if we took a
+      %  penalty.
+      oSoldierShield = Send(poGhostedPlayer,@FindUsing,#class=&SoldierShield);
+      if oSoldierShield <> $
+      {
+         % Treat it like a death.
+         Send(oSoldierShield,@OwnerDied,#logoff=TRUE);
       }
 
       % Reset the time to avoid any funny business like potential double

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -250,6 +250,11 @@ properties:
    % chance for stormy weather
    piStormChance = 25
 
+   % If this is set to true, soldier shields will give their specialized bonuses
+   % under all conditions. If it is false, they will only apply when attacking or being
+   % attacked by another soldier to prevent scenario overlap.
+   pbAlwaysApplySoldierBonus = FALSE
+
 messages:
 
    Constructor()
@@ -653,6 +658,11 @@ messages:
    GetStormChance()
    {
       return piStormChance;
+   }
+   
+   GetAlwaysApplySoldierBonus()
+   {
+      return pbAlwaysApplySoldierBonus;
    }
 
 end


### PR DESCRIPTION
* New setting to restrict soldier shield specialized bonuses purely to
direct attacks and spells on other soldiers and mobs. This should prevent
scenario overlap that has proven to be a problem. Specifically,
this applies Cess shield's mana cost reduction only to spells with 1 
target that target a mob or enemy soldier; Duke shield's spellpower
bonus only adds to spells with 1 target that target a mob or enemy
soldier; Jonas shield only gives armor against mobs and enemy soldier
attacks. Why? Because this fixes a variety of scenario overlap problems.
Players have been complaining about 'stacking shields', and also that
murderers get soldier shields 'free' while hunters cannot use them for
character train reasons. This fixes both of those issues. If a murderer
has a soldier shield and you don't, it doesn't matter: his shield won't
help him against you. Likewise, a hunter 'stacking shields' like
Duke shield + Orc Shield won't help him against you if you don't
have a shield. No more guild war / hunter-pk scenario overlap.
It is no longer automatically the correct choice to have a soldier
shield in all situations. If you go without one, your enemy will have
a few stat points on you, but his specialized bonuses won't
function against you. Meanwhile, all those involved in the soldier game
will still have explicit specialized bonuses (and they remain functioning
against mobs because a player using a shield to build is taking added
risk, and we should reward that).

* Fixed soldier shield bug that probably always prevented tracking who
logged another player in soldier fights. Previously, it always set
poLastEnemyToAttack equal to you, as if you attacked yourself, instead
of the enemy having attacked you. Also made it depend on damage actually
being done (like it was supposed to based on passed parameters).
Phasing/penning a soldier will give you a rank boost. I suggest we change
this to something like the items that a player might pen being directly given
to the soldier that penned them, or perhaps some additional money or
item pen with the same convention. This nearly invisible bug was why
penning soldiers has never given a rank boost since soldier shields' introduction
in the early 2000's.

* Fixed up IsEnemyAttack calls, which were frankly a mess. Now it is
(and must be) always called on the attacker's soldier shield. Who is the
defender, What is the attacker. IsEnemyAttack's garbled state was
the main issue in quite a few little invisible bugs.

* Added lTargets passed down to a variety of places where it may be
useful in the future (and required for this change). It will let us
discriminate on bonuses based on what is being attacked or cast on.

* Removed extraneous #damage=TRUE in FindUsing a soldier shield in
assessdamage. FindUsing doesn't do anything with that parameter.

---

Tested:

* Fighting normal mobs works correctly

* Killing NPC soldier for rank works correctly

* Killing player soldier works correctly

* Penning/phase penning soldier works correctly

* Fighting non soldiers works correctly (bonuses do not apply when new setting is FALSE)