### PR TITLE
Prevent tokens from entering protected rooms

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -4062,6 +4062,11 @@ messages:
       {
          return FALSE;
       }
+      
+      if NOT Send(self,@CanHavePlayerPortal)
+      {
+         return FALSE;
+      }
 
       return TRUE;
    }


### PR DESCRIPTION
Tokens will no longer enter rooms that NOT CanHavePlayerPortal. These
typically indicate special or complex rooms that tokens don't really
have a business being in.

This will prevent tokens from entering survival, underworld, etc. as well
as any complex future content.