### PR TITLE
Add Delete Post button to newsglobes. Move deleted posts to god globe. Misc bug fix/improvement PR.

### DIFF
--- a/blakserv/sprocket.c
+++ b/blakserv/sprocket.c
@@ -41,6 +41,7 @@ client_def_table_type client_def_table[] =
 	{ BP_SEND_MAIL,            { {2, LIST_OBJ_PARM}, {0, TAG_STRING}, {0, DONE_PARM} } },
 	{ BP_REQ_GET_MAIL,         { {0, DONE_PARM} } },
 	{ BP_DELETE_MAIL,          { {4, TAG_INT}, {0, DONE_PARM} } },
+	{ BP_DELETE_NEWS,          { {2, TAG_INT}, {4, TAG_INT}, {0, DONE_PARM} } },
 	{ BP_SEND_STATS,           { {1, TAG_INT}, {0, DONE_PARM} } },
 	{ BP_SEND_STAT_GROUPS,     { {0, DONE_PARM} } },
 	{ BP_REQ_HIDE,             { {4, TAG_OBJECT}, {0, DONE_PARM} } },

--- a/include/proto.h
+++ b/include/proto.h
@@ -98,7 +98,7 @@ enum {
    BP_REQ_GET_MAIL          = 81,
    BP_SEND_MAIL             = 82,
    BP_DELETE_MAIL           = 83,
-
+   BP_DELETE_NEWS           = 84,
    BP_REQ_ARTICLES          = 85,
    BP_REQ_ARTICLE           = 86,
    BP_POST_ARTICLE          = 87,

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -3634,7 +3634,7 @@
    MAX_GUILD_NAME_LEN = 30
    MAX_GUILD_RANK_LEN = 20
    MAX_URL_LEN = 200
-   MAX_CHAT_LEN = 500
+   MAX_CHAT_LEN = 550
    
    %Statistics Constants, must match enum sql_recordtype in database.h
    STAT_TOTALMONEY = 1

--- a/kod/include/protocol.khd
+++ b/kod/include/protocol.khd
@@ -43,7 +43,7 @@
    BP_REQ_GET_MAIL          = 81
    BP_SEND_MAIL             = 82
    BP_DELETE_MAIL           = 83
-
+   BP_DELETE_NEWS           = 84
    BP_REQ_ARTICLES          = 85
    BP_REQ_ARTICLE           = 86
    BP_POST_ARTICLE          = 87

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -13417,7 +13417,7 @@ messages:
 
       foreach i in Send(SYS,@GetSpells)
       {
-         if not IsClass(i,&Spell)
+         if NOT IsClass(i,&Spell)
          {
             continue;
          }
@@ -13427,7 +13427,7 @@ messages:
             if iMaxLevel >= Send(i,@Getlevel)
             {
                Send(self,@AddSpell,#num=Send(i,@GetSpellNum),
-                     #iability=iAbility);
+                     #iability=iAbility,#dontSend=TRUE);
             }
          }
       }
@@ -13444,6 +13444,8 @@ messages:
          % Need -10 Karma per spell level (-10 for fudge).
          piKarma = level * -1000;
       }
+      Send(self,@ToCliSpells);
+      Send(self,@DrawKarma);
 
       return TRUE;
    }
@@ -13498,7 +13500,7 @@ messages:
 
       foreach i in Send(SYS,@GetSkills)
       {
-         if not IsClass(i,&Skill)
+         if NOT IsClass(i,&Skill)
          {
             continue;
          }
@@ -13507,10 +13509,13 @@ messages:
          {
             if iMaxLevel >= Send(i,@Getlevel)
             {
-               Send(self,@AddSkill,#num=Send(i,@GetSkillNum),#iability=iAbility);
+               Send(self,@AddSkill,#num=Send(i,@GetSkillNum),
+                     #iability=iAbility,#dontSend=TRUE);
             }
          }
       }
+
+      Send(self,@ToCliSkills);
 
       return TRUE;
    }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3505,39 +3505,45 @@ messages:
 
    ToCliSpells()
    {
-      local i,oSpell;
+      local i, oSpell;
 
-      AddPacket(1,BP_SPELLS, 2,Length(plSpells));
-
-      foreach i in plSpells
+      if pbLogged_on
       {
-         oSpell = Send(SYS,@FindSpellByNum,#num=Send(self,@DecodeSpellNum,
-                                                     #compound=i));
-         Send(self,@ToCliObject,#what=oSpell);
-         AddPacket(1,Send(oSpell,@GetNumSpellTargets));
-         AddPacket(1,Send(oSpell,@GetSchool));
-      }
+         AddPacket(1,BP_SPELLS, 2,Length(plSpells));
 
-      SendPacket(poSession);
-      Send(self,@ToCliStats,#group=3);
+         foreach i in plSpells
+         {
+            oSpell = Send(SYS,@FindSpellByNum,#num=Send(self,@DecodeSpellNum,
+                                                        #compound=i));
+            Send(self,@ToCliObject,#what=oSpell);
+            AddPacket(1,Send(oSpell,@GetNumSpellTargets));
+            AddPacket(1,Send(oSpell,@GetSchool));
+         }
+
+         SendPacket(poSession);
+         Send(self,@ToCliStats,#group=3);
+      }
 
       return;
    }
 
    ToCliSkills()
    {
-      local i,oSkill;
+      local i, oSkill;
 
-      AddPacket(1, BP_SKILLS,2,Length(plSkills));
-      foreach i in plSkills
+      if pbLogged_on
       {
-         oSkill = Send(SYS,@FindSkillByNum,#num=Send(self,@DecodeSkillNum,
-                                                     #compound=i));
-         Send(self,@ToCliObject,#what=oSkill);
-      }
+         AddPacket(1, BP_SKILLS,2,Length(plSkills));
+         foreach i in plSkills
+         {
+            oSkill = Send(SYS,@FindSkillByNum,#num=Send(self,@DecodeSkillNum,
+                                                        #compound=i));
+            Send(self,@ToCliObject,#what=oSkill);
+         }
 
-      SendPacket(poSession);
-      Send(self,@ToCliStats,#group=4);
+         SendPacket(poSession);
+         Send(self,@ToCliStats,#group=4);
+      }
 
       return;
    }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -5976,7 +5976,7 @@ messages:
          return;
       }
 
-      if (Send(oNews,@MovePostToGodGlobe,#who=self,#index=index))
+      if (Send(oNews,@RemovePost,#who=self,#index=index))
       {
          GodLog(Send(self,@GetTrueName)," deleted post ",index,
                " from newsglobe ",Send(oNews,@GetName));

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1213,6 +1213,13 @@ messages:
          {
             piFloodCount++;
 
+            % Have to let this message through in case they're logging off.
+            if (type = 0
+               AND First(client_msg) = BP_REQ_QUIT)
+            {
+               Send(self,@UserLogoff);
+            }
+
             % Don't go on if marked as spammer
             return;
          }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1194,10 +1194,8 @@ messages:
    "parameters for any of the client_msg things that are number objects.  "
    "It is dynamically allocated each time (wasting list nodes)."
    {
-      local liClient_cmd, oWhat, oWhere, oRoom, iRow, iCol, iSay_type,
-            sStr_said, sStr_mailed, lDest_mail, iAttack_type, iGroup, lItems,
-            lUsers, oApply_on, iNid, sTitle, iAngle, sBody, iNum, iSpeed,
-            lTargets, i;
+      local liClient_cmd, oWhat, oRoom, iRow, iCol, lUsers, iAngle, sBody,
+            iSpeed, i, sStr_said;
 
       % This checks to see if the user is trying to Send too many packets
       %  per second.  If they are, then we mark them as a spammer and
@@ -1242,7 +1240,7 @@ messages:
 
          % Check if it's an outdated message, from a person going off side of
          %  room multiple times before they got their new room.
-         if oRoom <> poOwner 
+         if oRoom <> poOwner
          {
             return;
          }
@@ -1316,41 +1314,36 @@ messages:
 
       if liClient_cmd = BP_REQ_DROP
       {
-         oWhat = Nth(client_msg,2);
-         Send(self,@UserDrop,#what=oWhat,#number=number_stuff);
+         Send(self,@UserDrop,#what=Nth(client_msg,2),#number=number_stuff);
 
          return;
       }
 
       if liClient_cmd = BP_REQ_INVENTORY_MOVE
       {
-         oWhat = Nth(client_msg,2);
-         oWhere = Nth(client_msg,3);
-         Send(self,@UserMoveInventoryItem,#what=oWhat,#where=oWhere);
+         Send(self,@UserMoveInventoryItem,#what=Nth(client_msg,2),
+               #where=Nth(client_msg,3));
 
          return;
       }
 
       if liClient_cmd = BP_REQ_PUT
       {
-         oWhat = Nth(client_msg,2);
-         oWhere = Nth(client_msg,3);
-         Send(self,@UserPut,#what=oWhat,#where=oWhere,#number=number_stuff);
+         Send(self,@UserPut,#what=Nth(client_msg,2),#where=Nth(client_msg,3),
+               #number=number_stuff);
 
          return;
       }
 
       if liClient_cmd = BP_SEND_OBJECT_CONTENTS
       {
-         oWhat = Nth(client_msg,2);
-         Send(self,@UserObjectContents,#what=oWhat);
+         Send(self,@UserObjectContents,#what=Nth(client_msg,2));
 
          return;
       }
 
       if liClient_cmd = BP_SAY_TO
       {
-         iSay_type = Nth(client_msg,2);
          sStr_said = Nth(client_msg,3);
 
          % don't send oversized chat strings
@@ -1361,14 +1354,13 @@ messages:
             return;
          }
 
-         Send(self,@UserSay,#type=iSay_type,#string=sStr_said);
+         Send(self,@UserSay,#type=Nth(client_msg,2),#string=sStr_said);
 
          return;
       }
 
       if liClient_cmd = BP_SAY_GROUP
       {
-         lUsers  = Nth(client_msg,2);
          sStr_said = Nth(client_msg,3);
 
          % don't send oversized chat strings
@@ -1379,24 +1371,22 @@ messages:
             return;
          }
 
-         Send(self,@UserSayGroup,#users=lUsers,#string=sStr_said);
+         Send(self,@UserSayGroup,#users=Nth(client_msg,2),#string=sStr_said);
 
          return;
       }
 
       if liClient_cmd = BP_REQ_LOOK
       {
-         oWhat = Nth(client_msg,2);
-         Send(self,@UserLook,#what=oWhat);
+         Send(self,@UserLook,#what=Nth(client_msg,2));
 
          return;
       }
 
       if liClient_cmd = BP_SEND_MAIL
       {
-         lDest_mail = Nth(client_msg,2);
-         sStr_mailed = Nth(client_msg,3);
-         Send(self,@UserMail,#dest_list=lDest_mail,#string=sStr_mailed);
+         Send(self,@UserMail,#dest_list=Nth(client_msg,2),
+               #string=Nth(client_msg,3));
 
          return;
       }
@@ -1415,45 +1405,46 @@ messages:
          return;
       }
 
+      if liClient_cmd = BP_DELETE_NEWS
+      {
+         Send(self,@UserDeleteNews,#nid=Nth(client_msg,2),
+               #index=Nth(client_msg,3));
+
+         return;
+      }
+
       if liClient_cmd = BP_REQ_USE
       {
-         oWhat = Nth(client_msg,2);
-         Send(self,@UserUseItem,#what=oWhat);
+         Send(self,@UserUseItem,#what=Nth(client_msg,2));
 
          return;
       }
 
       if liClient_cmd = BP_REQ_UNUSE
       {
-         oWhat = Nth(client_msg,2);
-         Send(self,@UserUnuseItem,#what=oWhat);
+         Send(self,@UserUnuseItem,#what=Nth(client_msg,2));
 
          return;
       }
 
       if liClient_cmd = BP_REQ_ATTACK
       {
-         iAttack_type = Nth(client_msg,2);
-         oWhat = Nth(client_msg,3);
-         Send(self,@UserAttack,#type=iAttack_type,#what=oWhat);
+         Send(self,@UserAttack,#type=Nth(client_msg,2),#what=Nth(client_msg,3));
 
          return;
       }
 
       if liClient_cmd = BP_SEND_STATS
       {
-         iGroup = Nth(client_msg,2);
-         Send(self,@ToCliStats,#group=iGroup);
+         Send(self,@ToCliStats,#group=Nth(client_msg,2));
 
          return;
       }
 
       if liClient_cmd = BP_REQ_OFFER
       {
-         oWhat = Nth(client_msg,2);
-         lItems = Nth(client_msg,3);
-         Send(self,@UserOffer,#what=oWhat,#item_list=lItems,
-              #number_list=number_stuff);
+         Send(self,@UserOffer,#what=Nth(client_msg,2),
+               #item_list=Nth(client_msg,3),#number_list=number_stuff);
 
          return;
       }
@@ -1467,8 +1458,7 @@ messages:
 
       if liClient_cmd = BP_REQ_COUNTEROFFER
       {
-         lItems = Nth(client_msg,2);
-         Send(self,@UserCounterOffer,#item_list=lItems,
+         Send(self,@UserCounterOffer,#item_list=Nth(client_msg,2),
               #number_list=number_stuff);
 
          return;
@@ -1504,9 +1494,8 @@ messages:
          oWhat = Nth(client_msg,2);
          if IsClass(oWhat,&Monster)
          {
-            lItems = Nth(client_msg,3);
-            Send(self,@UserBuyItems,#what=oWhat,#item_list=lItems,
-               #number_list=number_stuff);
+            Send(self,@UserBuyItems,#what=oWhat,#item_list=Nth(client_msg,3),
+                  #number_list=number_stuff);
          }
 
          return;
@@ -1528,9 +1517,8 @@ messages:
          oWhat = Nth(client_msg,2);
          if IsClass(oWhat,&Monster)
          {
-            lItems = Nth(client_msg,3);
-            Send(self,@UserWithdrawalItems,#what=oWhat,#item_list=lItems,
-               #number_list=number_stuff);
+            Send(self,@UserWithdrawalItems,#what=oWhat,
+                  #item_list=Nth(client_msg,3),#number_list=number_stuff);
          }
 
          return;
@@ -1541,8 +1529,7 @@ messages:
          oWhat = Nth(client_msg,2);
          if IsClass(oWhat,&Monster)
          {
-            lItems = Nth(client_msg,3);
-            Send(self,@UserDeposit,#what=oWhat,#item_list=lItems,
+            Send(self,@UserDeposit,#what=oWhat,#item_list=Nth(client_msg,3),
                #number_list=number_stuff);
          }
 
@@ -1551,9 +1538,8 @@ messages:
 
       if liClient_cmd = BP_REQ_APPLY
       {
-         oWhat = Nth(client_msg,2);
-         oApply_on = Nth(client_msg,3);
-         Send(self,@UserApply,#what=oWhat,#apply_on=oApply_on);
+         Send(self,@UserApply,#what=Nth(client_msg,2),
+               #apply_on=Nth(client_msg,3));
 
          return;
       }
@@ -1574,44 +1560,38 @@ messages:
 
       if liClient_cmd = BP_REQ_CAST
       {
-         oWhat = Nth(client_msg,2);  % Spell type
-         lTargets = Nth(client_msg,3); % Targets of spell (if any)
-         Send(self,@UserCast,#oSpell=oWhat,#lTargets=lTargets);
+         Send(self,@UserCast,#oSpell=Nth(client_msg,2),
+               #lTargets=Nth(client_msg,3));
 
          return;
       }
 
       if liClient_cmd = BP_POST_ARTICLE
       {
-         iNid = Nth(client_msg,2);
-         sTitle = Nth(client_msg,3);
-         sBody = Nth(client_msg,4);
-         Send(self,@UserPost,#nid=iNid,#title=sTitle,#body=sBody);
+         Send(self,@UserPost,#nid=Nth(client_msg,2),#title=Nth(client_msg,3),
+               #body=Nth(client_msg,4));
 
          return;
       }
 
       if liClient_cmd = BP_REQ_ARTICLES
       {
-         iNid = Nth(client_msg,2);
-         Send(self,@UserGetNewsTitles,#nid=iNid);
+         Send(self,@UserGetNewsTitles,#nid=Nth(client_msg,2));
 
          return;
       }
 
       if liClient_cmd = BP_REQ_ARTICLE
       {
-         iNid = Nth(client_msg,2);
-         iNum = Nth(client_msg,3);
-         Send(self,@UserGetNewsArticle,#nid=iNid,#num=iNum);
+         Send(self,@UserGetNewsArticle,#nid=Nth(client_msg,2),
+               #num=Nth(client_msg,3));
 
          return;
       }
 
       if liClient_cmd = BP_ACTION
       {
-         iNum = Nth(client_msg, 2);
-         Send(self,@UserAction,#action=iNum);
+         Send(self,@UserAction,#action=Nth(client_msg,2));
 
          return;
       }
@@ -1625,8 +1605,7 @@ messages:
 
       if liClient_cmd = BP_SAY_BLOCKED
       {
-         oWhat = Nth(client_msg,2);
-         Send(self,@UserBlockedSend,#what=oWhat);
+         Send(self,@UserBlockedSend,#what=Nth(client_msg,2));
 
          return;
       }
@@ -1663,9 +1642,9 @@ messages:
             return;
          }
 
-         oWhere = Send(oWhat,@GetOwner);
+         oRoom = Send(oWhat,@GetOwner);
          if Send(oWhat,@CanEditInscription)
-            AND ((oWhere = self) or (oWhere = poOwner))
+            AND ((oRoom = self) or (oRoom = poOwner))
          {
             sBody = Send(SYS,@CleanseString,#string=sBody);
             Send(oWhat,@SetInscription,#string=sBody);
@@ -5964,6 +5943,41 @@ messages:
 
          lNew_mail = Nth(plNew_mail, index);
          plNew_mail = DelListElem(plNew_mail, lNew_mail);
+      }
+
+      return;
+   }
+
+   UserDeleteNews(nid = $, index = $)
+   {
+      local oNews;
+
+      if (index = $
+         OR nid = $)
+      {
+         Debug("UserDeleteNews got $ parameter! Index is ",index,
+               " NID is ",nid);
+
+         return;
+      }
+
+      oNews = Send(SYS,@FindNewsByNum,#num=nid);
+      if (oNews = $)
+      {
+         Debug("UserDeleteNews couldn't find news globe ",nid);
+
+         return;
+      }
+
+      if (Send(oNews,@MovePostToGodGlobe,#who=self,#index=index))
+      {
+         GodLog(Send(self,@GetTrueName)," deleted post ",index,
+               " from newsglobe ",Send(oNews,@GetName));
+      }
+      else if (IsClass(self,&DM))
+      {
+         Debug("Failed to remove post index ",index," from newsglobe ",
+               Send(oNews,@GetName));
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -54,7 +54,7 @@ constants:
    USER_RUNNING_SPEED = 50
 
    % How many packets incoming per second do we allow?
-   INCOMING_PACKET_THROTTLE = 20
+   INCOMING_PACKET_THROTTLE = 25
 
    % What's the lower threshold for being able to run?  Below this, we can't
    %  run.
@@ -1183,6 +1183,13 @@ messages:
    DisconnectSession()
    {
       Send(self,@UserLogoff);
+
+      return;
+   }
+
+   SetFloodCount(iNum=0)
+   {
+      piFloodCount = iNum;
 
       return;
    }

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -57,6 +57,8 @@ resources:
    dm_turn_off_pk = "turn off pk"
    dm_help_lights_command = "help lights"
    dm_help_scenery_command = "help scenery"
+   dm_pk_off = "PvP is now OFF for this screen."
+   dm_pk_already_off = "PvP is already OFF for this screen."
    dm_appeal_off_command = "appeal off"
    dm_appeal_on_command = "appeal on"
    dm_guest_appeal_off_command = "guest appeal off"
@@ -154,12 +156,22 @@ resources:
       "Use `rgo #`n to teleport to a room number or room RID.\n"
       "Cast Squelch for information on how to Squelch players."
 
-   dm_help = \
-      "DM APPEAL ON/OFF, DM STEALTH ON/OFF, "
-      "DM CLEAR ABILITIES, DM CLEAR INVENTORY, DM PK ENABLE, DM PK DISABLE, DM PK LOCK, DM PK UNLOCK, "
+   dm_admin_help = \
+      "DM APPEAL ON/OFF, DM STEALTH ON/OFF, DM CLEAR ABILITIES, "
+      "DM CLEAR INVENTORY, DM PK ENABLE, DM PK DISABLE, DM PK LOCK, DM PK UNLOCK, "
       "DM GET SPELLS, DM GET SKILLS, DM GET MONEY, DM BOOST STATS, DM GOOD, DM NEUTRAL, DM EVIL, "
       "DM TOTEM, DM RELIC <number/name>, DM MONSTER <monster name>, DM ITEM <item name>, "
       "DM GET <reagents/ food/ armor/ gems/ rings/ weapons/ necklaces/ potions/ sundries>"
+
+   dm_help_all = \
+      "Sending messages to users:\n"
+      "Use 'dm systemmessage' to send a message to all users with the [###] "
+      "prefix.\nUse 'dm gemote' to send a message to all users without the "
+      "prefix.\nUse 'dm gqemote' to send to all without a 'ding' sound.\n"
+      "Use 'dm lemote' to send a message to users in the same room.\n"
+      "Use 'dm lqemote' to send to users in the same room without the 'ding' "
+      "sound.\nUse the command 'dm turn off pk' to deactivate PvP on the "
+      "current screen for 1 hour.\n"
 
    dm_help_items = \
       "You can place scenery and lights using the \"dm place \" command.\n"
@@ -172,6 +184,7 @@ resources:
       "orc torch, skull brazier, table lamp, lantern, jasper lantern, "
       "jasper lantern1 and smoke (nice for firepits).  You can also place a dynamic light "
       "(with no visible object) using \" dm place dynamic light\"."
+
    dm_help_scenery = \
       "Available scenery items for placing are:  tree, raza tree, dead tree, "
       "pine tree, elm tree, spider tree, fey tree, bush (low res), shrub, "
@@ -356,7 +369,8 @@ messages:
 
          if NOT IsClass(self,&Admin)
          {
-            Send(self,@MsgSendUser,#message_rsc=dm_login,#parm1=Send(self,@GetName));
+            Send(self,@MsgSendUser,#message_rsc=dm_login,
+                  #parm1=Send(self,@GetName));
          }
       }
 
@@ -700,30 +714,35 @@ messages:
          if prRank = dm_moderator
          {
             Send(self,@MsgSendUser,#message_rsc=dm_moderator_help);
-            Send(self,@MsgSendUser,#message_rsc=dm_help_items);
-         
-            return;
          }
-         
-         if prRank = dm_guide
+         else if prRank = dm_guide
          {
             Send(self,@MsgSendUser,#message_rsc=dm_guide_help);
-            Send(self,@MsgSendUser,#message_rsc=dm_help_items);
-
-            return;
+         }
+         else
+         {
+            % If they're a higher rank, give them the admin help guide.
+            Send(self,@MsgSendUser,#message_rsc=dm_admin_help);
          }
 
-         % If they're a higher rank, give them the whole help guide.
-         Send(self,@MsgSendUser,#message_rsc=dm_help);
+         % Generic help guides.
          Send(self,@MsgSendUser,#message_rsc=dm_help_items);
+         Send(self,@MsgSendUser,#message_rsc=dm_help_all);
 
          return;
       }
-      
+
       if StringEqual(string,dm_turn_off_pk)
       {
-         Send(Send(self,@GetOwner),@StartTemporaryNoPK);
-         
+         if (Send(poOwner,@StartTemporaryNoPK))
+         {
+            Send(self,@MsgSendUser,#message_rsc=dm_pk_off);
+         }
+         else
+         {
+            Send(self,@MsgSendUser,#message_rsc=dm_pk_already_off);
+         }
+
          return;
       }
 
@@ -748,6 +767,7 @@ messages:
       {
          StringSubstitute(string,"systemmessage ","");
          Send(SYS,@AdminSystemMessage,#string=string,#bSound=TRUE,#bPrefix=TRUE);
+
          return;
       }
 
@@ -755,6 +775,7 @@ messages:
       {
          StringSubstitute(string,"gemote ","");
          Send(SYS,@AdminSystemMessage,#string=string,#bSound=TRUE,#bPrefix=FALSE);
+
          return;
       }
 
@@ -762,16 +783,17 @@ messages:
       {
          StringSubstitute(string,"gqemote ","");
          Send(SYS,@AdminSystemMessage,#string=string,#bSound=FALSE,#bPrefix=FALSE);
+
          return;
       }
 
       if StringContain(string,"lemote")
       {
          StringSubstitute(string,"lemote ","");
-         foreach i in send(poOwner,@GetHolderActive)
+         foreach i in Send(poOwner,@GetHolderActive)
          {
-            Send(Nth(i,1),@MsgSendUser,#message_rsc=dm_system_message,#parm1=string);
-            Send(Nth(i,1),@WaveSendUser,#wave_rsc=system_message_sound);
+            Send(First(i),@MsgSendUser,#message_rsc=dm_system_message,#parm1=string);
+            Send(First(i),@WaveSendUser,#wave_rsc=system_message_sound);
          }
          return;
       }
@@ -779,10 +801,11 @@ messages:
       if StringContain(string,"lqemote")
       {
          StringSubstitute(string,"lqemote ","");
-         foreach i in send(poOwner,@GetHolderActive)
+         foreach i in Send(poOwner,@GetHolderActive)
          {
-            Send(Nth(i,1),@MsgSendUser,#message_rsc=dm_system_message,#parm1=string);
+            Send(First(i),@MsgSendUser,#message_rsc=dm_system_message,#parm1=string);
          }
+
          return;
       }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.lkod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.lkod
@@ -135,7 +135,7 @@ dm_guide_help = de \
    "~w[Decke die komplette Karte auf]~n\nHIDEMAP  ~w[Vergisst die Karte]~n\nRESET "
    "~w[Aktualisiert Deinen Client]~n\nGETPLAYER <name> ~w[Holt einen Spieler "
    "zu Dir]~n\nGOPLAYER <name> ~w[Bringt Dich zu einem Spieler]~n\n"
-dm_help = de \
+dm_admin_help = de \
    "\n~B~UDM Befehle~n\nDM APPEAL ON/OFF ~w[Schaltet den Götter-Kanal an/aus]~n\nDM "
    "STEALTH ON/OFF ~w[Schaltet Aktionsmeldungen aus/an]~n\nDM CLEAR ABILITIES "
    "~w[Löscht alle Deine Fertigkeiten]~n\nDM CLEAR INVENTORY ~w[Löscht Dein "

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1347,7 +1347,7 @@ messages:
          }
 
          % if the caster is not a combatant, attack fails.
-         if IsClass(what,&Player)
+         if IsClass(what,&User)
             AND NOT Send(oWatcher,@IsCombatant,#who=what)
          {
             return FALSE;
@@ -1361,7 +1361,7 @@ messages:
          AND (IsClass(what,&Monster)
          OR IsClass(victim,&Monster))
       {
-         if IsClass(what,&Player)
+         if IsClass(what,&User)
          {
             if report
             {
@@ -1388,8 +1388,8 @@ messages:
          return FALSE;
       }
 
-      if (piRoom_flags & ROOM_NO_PK) AND IsClass(what,&Player)
-         AND (victim = $ OR IsClass(victim,&Player))
+      if (piRoom_flags & ROOM_NO_PK) AND IsClass(what,&User)
+         AND (victim = $ OR IsClass(victim,&User))
       {
          if report
          {
@@ -1399,8 +1399,8 @@ messages:
          return FALSE;
       }
 
-      if (piRoom_flags & ROOM_GUILD_PK_ONLY) AND IsClass(what,&Player)
-         AND (victim = $ OR IsClass(victim,&Player))
+      if (piRoom_flags & ROOM_GUILD_PK_ONLY) AND IsClass(what,&User)
+         AND (victim = $ OR IsClass(victim,&User))
       {
          if (NOT Send(self,@AllowGuildAttack,#what=what,#victim=victim,#report=report))
             AND Send(SYS,@IsPKAllowed)
@@ -2175,7 +2175,7 @@ messages:
       {
          foreach i in Send(what,@GetRadiusEnchantments)
          {
-            each_obj = Nth(i,1);
+            each_obj = First(i);
             Send(what,@ShowAddEnchantment,#what=each_obj,#type=ENCHANTMENT_ROOM);
          }
       }
@@ -5136,17 +5136,26 @@ messages:
    {
       return $;
    }
-   
+
    StartTemporaryNoPK()
+   "Returns TRUE if we turned PvP off, FALSE if it was already off."
    {
       if NOT (piRoom_flags & ROOM_NO_PK)
       {
          piRoom_flags = piRoom_flags | ROOM_NO_PK;
+         if (ptNoPkTimer <> $)
+         {
+            DeleteTimer(ptNoPkTimer);
+         }
+
          ptNoPKTimer = CreateTimer(self,@EndTemporaryNoPK,60000*60);
+
+         return TRUE;
       }
-      return;
+
+      return FALSE;
    }
-   
+
    EndTemporaryNoPK(timer=$)
    {
       if timer = $
@@ -5155,7 +5164,9 @@ messages:
          DeleteTimer(ptNoPKTimer);
       }
       ptNoPKTimer = $;
+
       Send(self,@SetRoomFlagToDefault,#flag=ROOM_NO_PK);
+
       return;
    }
 

--- a/kod/object/passive/news.kod
+++ b/kod/object/passive/news.kod
@@ -26,10 +26,15 @@ resources:
       "Only DMs, Admins and Moderators may delete posts from this newsglobe."
    news_not_own_post = \
       "You can only delete your own posts."
+   news_del_time_expired_header = \
+      "You may only delete your post within %r%r%r%r%r%r%r of posting."
 
 classvars:
 
    vrIcon = news_icon_rsc
+
+   % The number of minutes a user has to delete their post after posting it.
+   viPostDeleteMinutes = 60
 
 properties:
 
@@ -140,13 +145,15 @@ messages:
       return;
    }
 
-   MovePostToGodGlobe(who=$, index=$)
+   RemovePost(who=$, index=$)
+   "Removes a post from a newsglobe, triggered by 'who'. Addresses the post "
+   "by index."
    {
       local lArticle, oNews;
 
       if (index = $)
       {
-         Debug("MovePostToGodGlobe passed $ index! Not moving post.");
+         Debug("RemovePost passed $ index! Not moving post.");
 
          return FALSE;
       }
@@ -154,7 +161,7 @@ messages:
       oNews = Send(SYS,@FindNewsByNum,#num=NID_GODROOM);
       if (oNews = $)
       {
-         Debug("MovePostToGodGlobe couldn't find GodGlobe! Not moving post.");
+         Debug("RemovePost couldn't find GodGlobe! Not moving post.");
 
          return FALSE;
       }
@@ -164,8 +171,8 @@ messages:
 
       if (lArticle = $)
       {
-         Debug("MovePostToGodGlobe unable to find article with index ",
-               index," not moving post.");
+         Debug("RemovePost unable to find article with index ",index,
+               " not moving post.");
 
          return FALSE;
       }
@@ -186,6 +193,17 @@ messages:
 
             return FALSE;
          }
+
+         if (GetTime() - Nth(lArticle,3) > viPostDeleteMinutes * 60)
+         {
+            % Resource to be sent to user is a time string which may change,
+            % so we use a callback to add a BP_MESSAGE protocol and build
+            % the packet from PostDeleteTimeExpired().
+            Send(who,@MsgSendUserCallback,#what=self,
+                  #sCallBack=SetString($,@PostDeleteTimeExpired));
+
+            return FALSE;
+         }
       }
 
       % Article is [index, player obj_id, time, title, body]
@@ -200,6 +218,26 @@ messages:
       Send(self,@DeleteMail,#number=index);
 
       return TRUE;
+   }
+
+   PostDeleteTimeExpired()
+   "Called from user.kod's MsgSendUserCallback. Adds the required packets "
+   "for a time string depending on how long users have to delete their own "
+   "posts. Has to return TRUE so MsgSendUserCallback knows the packet was "
+   "built. Don't call this directly."
+   {
+      Send(self,@SendTimeRemaining,#iTime=viPostDeleteMinutes * 60);
+
+      return TRUE;
+   }
+
+   SendTimeRemainingHeader()
+   "Adds the header resource for sending a time-related collection of "
+   "resources to a client. Only SendTimeRemaining() should call this."
+   {
+      AddPacket(4, news_del_time_expired_header);
+
+      return;
    }
 
    GetNumArticles()

--- a/kod/object/passive/news.kod
+++ b/kod/object/passive/news.kod
@@ -22,6 +22,11 @@ resources:
    news_icon_rsc = news.bgf
    news_desc_rsc = "You are looking at a public posting device."
 
+   news_users_cant_delete = \
+      "Only DMs, Admins and Moderators may delete posts from this newsglobe."
+   news_not_own_post = \
+      "You can only delete your own posts."
+
 classvars:
 
    vrIcon = news_icon_rsc
@@ -135,6 +140,68 @@ messages:
       return;
    }
 
+   MovePostToGodGlobe(who=$, index=$)
+   {
+      local lArticle, oNews;
+
+      if (index = $)
+      {
+         Debug("MovePostToGodGlobe passed $ index! Not moving post.");
+
+         return FALSE;
+      }
+
+      oNews = Send(SYS,@FindNewsByNum,#num=NID_GODROOM);
+      if (oNews = $)
+      {
+         Debug("MovePostToGodGlobe couldn't find GodGlobe! Not moving post.");
+
+         return FALSE;
+      }
+
+      % Get the article we want to move.
+      lArticle = Send(self,@GetArticle,#index=index);
+
+      if (lArticle = $)
+      {
+         Debug("MovePostToGodGlobe unable to find article with index ",
+               index," not moving post.");
+
+         return FALSE;
+      }
+
+      if (who <> $
+         AND NOT IsClass(who,&DM))
+      {
+         if (NOT Send(SETTINGS_OBJECT,@CanUsersRemoveOwnPosts))
+         {
+            Send(who,@MsgSendUser,#message_rsc=news_users_cant_delete);
+
+            return FALSE;
+         }
+
+         if (Nth(lArticle,2) <> who)
+         {
+            Send(who,@MsgSendUser,#message_rsc=news_not_own_post);
+
+            return FALSE;
+         }
+      }
+
+      % Article is [index, player obj_id, time, title, body]
+      % index and time are not preserved when copying. If deleting
+      % from god globe, don't try to move the post.
+      if (oNews <> self)
+      {
+         Send(oNews,@PostNews,#what=Nth(lArticle,2),#title=Nth(lArticle,4),
+               #body=Nth(lArticle,5));
+      }
+
+      Send(self,@DeleteMail,#number=index);
+
+      return TRUE;
+   }
+
    GetNumArticles()
    {
       return Length(plMessages);
@@ -143,6 +210,12 @@ messages:
    GetArticleList()
    {
       return plMessages;
+   }
+
+   GetArticle(index=$)
+   "Returns an article by post index."
+   {
+      return GetListNode(plMessages, 1, index);
    }
 
    GetNewsBody(num = $)
@@ -293,7 +366,7 @@ messages:
    {
       plMessages = $;
       piNext_num = 1;
-      
+
       return;
    }
 
@@ -308,7 +381,6 @@ messages:
 
       return;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/atakspel/earthqua.kod
+++ b/kod/object/passive/spell/atakspel/earthqua.kod
@@ -86,7 +86,7 @@ properties:
    piDamageMin = 17
    piDamageMax = 25
 
-   piCasterDmgPct = 100
+   piCasterDmgPct = 75
    piManaFocusBonus = 0
 
 messages:

--- a/kod/object/passive/spell/teleportspell/deathrift.lkod
+++ b/kod/object/passive/spell/teleportspell/deathrift.lkod
@@ -15,7 +15,7 @@ DeathRift_travel = de \
    "A vast passage of flames opens, and you find yourself pulled to the Underworld!"
 DeathRift_travel_notify = de \
    "A fiery portal flares open briefly, dragging %s to the Underworld!"
-DeathRift_travel_notify_with_dest = de \
+DeathRift_travel_notify_dest = de \
    "A fiery portal flares open briefly, dragging %s through the Underworld "
    "and toward %s!"
 DeathRift_generic_fail = de \

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -238,7 +238,8 @@ properties:
    % A battler's chance to hit when offense equals defense in per MILLE
    piEqualChanceToHit = 500
 
-   % This amount is added to a battler's offense and defense and serves as a baseline for calculation.
+   % This amount is added to a battler's offense and defense and
+   % serves as a baseline for calculation.
    piBaseRating = 0
 
    % Percent of mana required/used for broadcasting. Default 0 (no cost).
@@ -250,10 +251,14 @@ properties:
    % chance for stormy weather
    piStormChance = 25
 
-   % If this is set to true, soldier shields will give their specialized bonuses
-   % under all conditions. If it is false, they will only apply when attacking or being
-   % attacked by another soldier to prevent scenario overlap.
+   % If this is set to true, soldier shields will give their specialized
+   % bonuses under all conditions. If it is false, they will only apply
+   % when attacking or being attacked by another soldier to prevent
+   % scenario overlap.
    pbAlwaysApplySoldierBonus = FALSE
+
+   % Setting to allow users to remove their own posts.
+   pbCanUserRemoveOwnPosts = FALSE
 
 messages:
 
@@ -663,6 +668,11 @@ messages:
    GetAlwaysApplySoldierBonus()
    {
       return pbAlwaysApplySoldierBonus;
+   }
+
+   CanUsersRemoveOwnPosts()
+   {
+      return pbCanUserRemoveOwnPosts;
    }
 
 end

--- a/module/mailnews/mailnews.c
+++ b/module/mailnews/mailnews.c
@@ -48,6 +48,7 @@ client_message msg_table[] = {
 { BP_REQ_ARTICLES,         { PARAM_NEWSID, PARAM_END}, },
 { BP_REQ_ARTICLE,          { PARAM_NEWSID, PARAM_INDEX, PARAM_END}, },
 { BP_POST_ARTICLE,         { PARAM_NEWSID, PARAM_STRING, PARAM_STRING, PARAM_END}, },
+{ BP_DELETE_NEWS,          { PARAM_NEWSID, PARAM_INDEX, PARAM_END }, },
 { 0,                       { PARAM_END }, },
 };
 

--- a/module/mailnews/mailnews.h
+++ b/module/mailnews/mailnews.h
@@ -25,13 +25,14 @@
 #define BK_ARTICLES       (WM_USER + 122)
 
 // Sending messages to server
-#define RequestReadMail()            ToServer(BP_REQ_GET_MAIL, msg_table)
-#define SendMail(num, r, msg)        ToServer(BP_SEND_MAIL, msg_table, num, r, msg)
-#define RequestDeleteMail(index)     ToServer(BP_DELETE_MAIL, msg_table, index)
-#define RequestLookupNames(num, str) ToServer(BP_REQ_LOOKUP_NAMES, msg_table, num, str)
-#define RequestArticles(group)       ToServer(BP_REQ_ARTICLES, msg_table, group)
-#define RequestArticle(group, index) ToServer(BP_REQ_ARTICLE, msg_table, group, index)
-#define SendArticle(group, s1, s2)   ToServer(BP_POST_ARTICLE, msg_table, group, s1, s2)
+#define RequestReadMail()               ToServer(BP_REQ_GET_MAIL, msg_table)
+#define SendMail(num, r, msg)           ToServer(BP_SEND_MAIL, msg_table, num, r, msg)
+#define RequestDeleteMail(index)        ToServer(BP_DELETE_MAIL, msg_table, index)
+#define RequestDeleteNews(group, index) ToServer(BP_DELETE_NEWS, msg_table, group, index)
+#define RequestLookupNames(num, str)    ToServer(BP_REQ_LOOKUP_NAMES, msg_table, num, str)
+#define RequestArticles(group)          ToServer(BP_REQ_ARTICLES, msg_table, group)
+#define RequestArticle(group, index)    ToServer(BP_REQ_ARTICLE, msg_table, group, index)
+#define SendArticle(group, s1, s2)      ToServer(BP_POST_ARTICLE, msg_table, group, s1, s2)
 extern client_message msg_table[];
 
 extern ClientInfo *cinfo;         // Holds data passed from main client

--- a/module/mailnews/mailnews.rc
+++ b/module/mailnews/mailnews.rc
@@ -16,20 +16,18 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// German (Neutral) resources
+// German resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_DEU)
-#ifdef _WIN32
 LANGUAGE LANG_GERMAN, SUBLANG_NEUTRAL
 #pragma code_page(1252)
-#endif //_WIN32
 
 /////////////////////////////////////////////////////////////////////////////
 //
 // Dialog
 //
 
-145 DIALOG  0, 0, 282, 255
+145 DIALOG 0, 0, 282, 255
 STYLE DS_SETFONT | WS_MAXIMIZEBOX | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME
 CAPTION "Artikel veröffentlichen"
 FONT 8, "MS Sans Serif"
@@ -50,12 +48,13 @@ FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
     LTEXT           "",1001,4,4,297,8
     CONTROL         "",1115,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,4,15,297,125,WS_EX_CLIENTEDGE
-    PUSHBUTTON      "Antworten",1116,5,143,42,12
-    PUSHBUTTON      "A&utor antworten",1125,51,143,58,12,WS_DISABLED
-    PUSHBUTTON      "&Nachricht verfassen",12,113,143,68,12
-    PUSHBUTTON      "A&ktualisieren",1017,185,143,46,12
-    PUSHBUTTON      "Schließen",1,236,143,41,12
+    PUSHBUTTON      "Antworten",1116,3,143,42,12
+    PUSHBUTTON      "A&utor antworten",1125,47,143,58,12,WS_DISABLED
+    PUSHBUTTON      "&Nachricht verfassen",12,107,143,68,12
+    PUSHBUTTON      "A&ktualisieren",1017,177,143,46,12
+    PUSHBUTTON      "Schließen",1,261,143,41,12
     EDITTEXT        1118,4,161,297,157,ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | WS_VSCROLL
+    PUSHBUTTON      "Löschen",1018,225,143,35,12,NOT WS_TABSTOP
 END
 
 1013 DIALOGEX 0, 0, 283, 338
@@ -74,7 +73,7 @@ BEGIN
     EDITTEXT        1013,4,171,275,163,ES_MULTILINE | ES_READONLY | WS_VSCROLL
 END
 
-111 DIALOG  0, 0, 282, 263
+111 DIALOG 0, 0, 282, 263
 STYLE DS_SETFONT | WS_MAXIMIZEBOX | WS_VISIBLE | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME
 CAPTION "Nachricht versenden"
 FONT 8, "MS Sans Serif"
@@ -92,10 +91,37 @@ END
 
 /////////////////////////////////////////////////////////////////////////////
 //
+// DESIGNINFO
+//
+
+#ifdef APSTUDIO_INVOKED
+GUIDELINES DESIGNINFO
+BEGIN
+    145, DIALOG
+    BEGIN
+    END
+
+    144, DIALOG
+    BEGIN
+    END
+
+    1013, DIALOG
+    BEGIN
+    END
+
+    111, DIALOG
+    BEGIN
+    END
+END
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
 // String Table
 //
 
-STRINGTABLE 
+STRINGTABLE
 BEGIN
     1                       "Die Empfänger werden überprüft ..."
     2                       "Betreff: "
@@ -114,7 +140,7 @@ BEGIN
     15                      "Nachricht versendet."
 END
 
-STRINGTABLE 
+STRINGTABLE
 BEGIN
     16                      "Du mußt zumindest einen Empfänger festlegen."
     17                      "Die Nachricht %s kann nicht gelöscht werden."
@@ -125,7 +151,7 @@ BEGIN
     22                      "Du kannst auf diese Nachricht nicht antworten."
 END
 
-STRINGTABLE 
+STRINGTABLE
 BEGIN
     32                      "Jan"
     33                      "Feb"
@@ -145,7 +171,7 @@ BEGIN
     47                      "Don"
 END
 
-STRINGTABLE 
+STRINGTABLE
 BEGIN
     48                      "Fre"
     49                      "Sam"
@@ -157,18 +183,16 @@ BEGIN
     IDS_SUBJECT_GERMAN      "Betreff: "
 END
 
-#endif    // German (Neutral) resources
+#endif    // German resources
 /////////////////////////////////////////////////////////////////////////////
 
 
 /////////////////////////////////////////////////////////////////////////////
-// English (U.S.) resources
+// English (United States) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #pragma code_page(1252)
-#endif //_WIN32
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -192,7 +216,7 @@ BEGIN
     EDITTEXT        IDC_MAILEDIT,4,171,275,163,ES_MULTILINE | ES_READONLY | WS_VSCROLL
 END
 
-IDD_MAILSEND DIALOG  0, 0, 282, 263
+IDD_MAILSEND DIALOG 0, 0, 282, 263
 STYLE DS_SETFONT | DS_3DLOOK | WS_MAXIMIZEBOX | WS_VISIBLE | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME
 CAPTION "Send Mail"
 CLASS "Mail"
@@ -208,7 +232,7 @@ BEGIN
     LTEXT           "",IDC_SENDMAILMSG,9,63,249,10
 END
 
-IDD_NEWSPOST DIALOG  0, 0, 282, 255
+IDD_NEWSPOST DIALOG 0, 0, 282, 255
 STYLE DS_SETFONT | DS_3DLOOK | WS_MAXIMIZEBOX | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME
 CAPTION "Post Article"
 FONT 8, "MS Sans Serif"
@@ -232,9 +256,10 @@ BEGIN
     PUSHBUTTON      "&Reply",IDC_REPLY,5,143,42,12
     PUSHBUTTON      "&Mail author",IDC_REPLYMAIL,51,143,42,12,WS_DISABLED
     PUSHBUTTON      "&Post",IDC_NEWSPOST,97,143,41,12
-    PUSHBUTTON      "Re&scan",IDC_RESCAN,142,143,41,12
-    PUSHBUTTON      "&Close",IDOK,187,143,41,12
+    PUSHBUTTON      "Re&scan",IDC_RESCAN,141,143,41,12
+    PUSHBUTTON      "&Close",IDOK,228,143,41,12
     EDITTEXT        IDC_NEWSEDIT,4,161,297,157,ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | WS_VSCROLL
+    PUSHBUTTON      "&Delete",IDC_DELETEMSG,187,143,35,12
 END
 
 
@@ -289,7 +314,7 @@ IDB_MAILBOX             BITMAP                  "bitmap\\mailbox.bmp"
 //
 
 #ifdef APSTUDIO_INVOKED
-GUIDELINES DESIGNINFO 
+GUIDELINES DESIGNINFO
 BEGIN
     IDD_MAILREAD, DIALOG
     BEGIN
@@ -331,7 +356,7 @@ END
 // String Table
 //
 
-STRINGTABLE 
+STRINGTABLE
 BEGIN
     IDS_NORECIPIENTS        "You must specify at least one recipient"
     IDS_CANTDELETEMAIL      "Can't delete mail message %s."
@@ -342,7 +367,7 @@ BEGIN
     IDS_CANTREPLY           "You cannot reply to this message."
 END
 
-STRINGTABLE 
+STRINGTABLE
 BEGIN
     IDS_CHECKNAMES          "Checking recipient names..."
     IDS_SUBJECT             "Subject: "
@@ -361,7 +386,7 @@ BEGIN
     IDS_MESSAGESENT         "Message sent."
 END
 
-STRINGTABLE 
+STRINGTABLE
 BEGIN
     IDS_JANUARY             "Jan"
     IDS_FEBRUARY            "Feb"
@@ -381,7 +406,7 @@ BEGIN
     IDS_THURSDAY            "Thu"
 END
 
-STRINGTABLE 
+STRINGTABLE
 BEGIN
     IDS_FRIDAY              "Fri"
     IDS_SATURDAY            "Sat"
@@ -393,7 +418,7 @@ BEGIN
     IDS_SUBJECT_GERMAN      "Betreff: "
 END
 
-#endif    // English (U.S.) resources
+#endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/module/mailnews/mailnews.vcxproj
+++ b/module/mailnews/mailnews.vcxproj
@@ -27,6 +27,10 @@
   <ItemGroup>
     <ResourceCompile Include="mailnews.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <Image Include="bitmap\letter.ico" />
+    <Image Include="bitmap\mailbox.bmp" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BFFAB19A-0D34-4BF6-8BC6-A81D22274899}</ProjectGuid>
   </PropertyGroup>

--- a/module/mailnews/mailnews.vcxproj.filters
+++ b/module/mailnews/mailnews.vcxproj.filters
@@ -53,4 +53,12 @@
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
+  <ItemGroup>
+    <Image Include="bitmap\letter.ico">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="bitmap\mailbox.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+  </ItemGroup>
 </Project>

--- a/module/mailnews/mailnwrc.h
+++ b/module/mailnews/mailnwrc.h
@@ -6,7 +6,7 @@
 //
 // Meridian is a registered trademark.
 //{{NO_DEPENDENCIES}}
-// Microsoft Developer Studio generated include file.
+// Microsoft Visual C++ generated include file.
 // Used by mailnews.rc
 //
 #define IDS_GETUSERS                    1

--- a/module/mailnews/newsread.c
+++ b/module/mailnews/newsread.c
@@ -163,9 +163,11 @@ BOOL CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lPar
 
       // Ask for articles if we have read permission
       if (info->permissions & NEWS_READ)
-	 RequestArticles(info->newsgroup);
+         RequestArticles(info->newsgroup);
       else
-	 EnableWindow(GetDlgItem(hDlg, IDC_RESCAN), FALSE);
+         EnableWindow(GetDlgItem(hDlg, IDC_RESCAN), FALSE);
+
+      EnableWindow(GetDlgItem(hDlg, IDC_DELETEMSG), TRUE);
 
       // Disable post button if we don't have permission
       if (!(info->permissions & NEWS_POST))
@@ -351,10 +353,17 @@ BOOL CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lPar
 
       case IDOK:
       case IDCANCEL:
-	 info->articles = list_destroy(info->articles);
+         info->articles = list_destroy(info->articles);
          new_articles   = NULL;
-	 EndDialog(hDlg, 0);
-	 return TRUE;
+         EndDialog(hDlg, 0);
+         return TRUE;
+
+      case IDC_DELETEMSG:
+         if (!ListViewGetCurrentData(hList, &index, (int *) &article))
+            return TRUE;
+         RequestDeleteNews(info->newsgroup, article_index);
+         RequestArticles(info->newsgroup);
+         return TRUE;
       }
    }
    return FALSE;

--- a/module/mailnews/newsread.c
+++ b/module/mailnews/newsread.c
@@ -167,11 +167,12 @@ BOOL CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lPar
       else
          EnableWindow(GetDlgItem(hDlg, IDC_RESCAN), FALSE);
 
-      EnableWindow(GetDlgItem(hDlg, IDC_DELETEMSG), TRUE);
-
-      // Disable post button if we don't have permission
+      // Disable post and delete buttons if we don't have permission
       if (!(info->permissions & NEWS_POST))
-	 EnableWindow(GetDlgItem(hDlg, IDC_NEWSPOST), FALSE);
+      {
+         EnableWindow(GetDlgItem(hDlg, IDC_NEWSPOST), FALSE);
+         EnableWindow(GetDlgItem(hDlg, IDC_DELETEMSG), FALSE);
+      }
 
       SetTimer(hDlg, 1, 100, NULL);
 
@@ -244,7 +245,7 @@ BOOL CALLBACK ReadNewsDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lPar
       /* Display article's text */
       SetWindowText(hEdit, (char *) lParam);
       if (info->permissions & NEWS_POST)
-	 EnableWindow(GetDlgItem(hDlg, IDC_REPLY), TRUE);
+         EnableWindow(GetDlgItem(hDlg, IDC_REPLY), TRUE);
       EnableWindow(GetDlgItem(hDlg, IDC_REPLYMAIL), TRUE);
       SetTimer(hDlg, 1, 1000, NULL);
       return TRUE;


### PR DESCRIPTION
#### Commit 1
* Added a Delete button to all newsglobes. Anyone can click on it, but only DMs and above will be able to remove posts by default. A setting has been added to allow users to remove their own posts. Button is present in German and English versions of the classic client.
* Posts removed from newsglobes will be moved to the God Globe in room 901 instead of deleting them. Posts deleted from there will be properly deleted.
* Removed unnecessary variables from user.kod's ReceiveClient.

#### Commit 2
* Allow BP_REQ_QUIT protocol messages to bypass the packet throttle in ReceiveClient.

#### Commit 3
* Users must delete their posts within 1hr of posting, otherwise they will be unable to do so. Default time can be adjusted.

#### Commit 4
* Increased server chat (broadcast/say/tell etc.) string length limit from 500 to 550. Classic client can send slightly over 500 characters in a say/broadcast string, so the chat limit should be high enough to prevent valid length text being discarded.
* Increased packet throttle from 20 to 25 (many players are hitting thislimit) and added a message to (re)set piFloodCount.

#### Commit 5
* Stop clients getting flooded with protocol messages when using GivePlayerAllSpells/Skills. Use the dontSend parameter to prevent sending each spell/skill individually and send data once at the end of each message.

#### Commit 6
* Improved the DM menu handling a little and added a menu for the new system messages/no pk timer. DMs now get a message when they use the no PK timer.
* Fixed a German rsc name in deathrift.lkod.
* Changed a couple of Nth calls to First, and IsClass calls to use User instead of Player.

#### Commit 7
* Updated the Earthquake caster damage % value to the current live 103 value (75%).

#### Commit 8
* Disable delete post button if user doesn't have posting permissions on newsglobe.