### PR TITLE
Fix necro troop soldier shield issue, allow DMs to offer items to mobs to set up events easier. Misc bug fixes.

### DIFF
--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -99,6 +99,8 @@ void AdminShowCalled(int session_id,admin_parm_type parms[],
                      int num_blak_parm,parm_node blak_parm[]);
 void AdminShowCalledClass(class_node *c);
 
+void AdminShowBlockers(int session_id,admin_parm_type parms[],
+                       int num_blak_parm,parm_node blak_parm[]);
 void AdminShowObject(int session_id,admin_parm_type parms[],
                      int num_blak_parm,parm_node blak_parm[]);
 void AdminShowObjects(int session_id,admin_parm_type parms[],
@@ -313,44 +315,39 @@ void AdminMark(int session_id,admin_parm_type parms[],
 
 admin_table_type admin_show_table[] =
 {
-	{ AdminShowAccount,       {R,N}, F, A|M, NULL, 0, "account", 
-	"Show one account by account id or name" },
+	{ AdminShowAccount,       {R,N}, F, A|M, NULL, 0, "account",       "Show one account by account id or name" },
 	{ AdminShowAccounts,      {N},   F, A|M, NULL, 0, "accounts",      "Show all accounts" },
-	{ AdminShowObjects,       {I,N}, F, A|M, NULL, 0, "belong",       "Show objects belonging to id" },
-	{ AdminShowCalled,        {I,N}, F, A|M, NULL, 0, "called",
-     "Show top (int) called messages" },
+	{ AdminShowObjects,       {I,N}, F, A|M, NULL, 0, "belong",        "Show objects belonging to id" },
+	{ AdminShowBlockers,      {I,N}, F, A|M, NULL, 0, "blockers",      "Show all blockers in a room (TAG_ROOM_DATA parameter)" },
+	{ AdminShowCalled,        {I,N}, F, A|M, NULL, 0, "called",        "Show top (int) called messages" },
 	{ AdminShowCalls,         {I,N}, F, A|M, NULL, 0, "calls",         "Show top (int) C call counts" },
 	{ AdminShowClass,         {S,N}, F,A|M, NULL, 0, "class",          "Show info about class" },
-	{ AdminShowTime,          {N},   F, A|M, NULL, 0, "clock",        "Show current server time" },
-	{ AdminShowConfiguration, {N},   F, A|M, NULL, 0, "configuration", "Show configuration values" },
+	{ AdminShowTime,          {N},   F, A|M, NULL, 0, "clock",         "Show current server time" },
+	{ AdminShowConfiguration, {N},   F, A|M, NULL, 0, "config",        "Show configuration values" },
 	{ AdminShowConstant,      {S,N}, F,A|M, NULL, 0, "constant",       "Show value of admin constant" },
 	{ AdminShowDynamicResources,{N}, F, A|M, NULL, 0, "dynamic",       "Show all dynamic resources" },
 	{ AdminShowInstances,     {S,N}, F, A|M, NULL, 0, "instances",     "Show all instances of class" },
 	{ AdminShowList,          {I,N}, F, A|M, NULL, 0, "list",          "Traverse & show a list" },
 	{ AdminShowListNode,      {I,N}, F, A|M, NULL, 0, "listnode",      "Show one list node by id" },
-	{ AdminShowMatches,       {S,S,S,S,S,N}, F, A|M, NULL, 0, "matches",     "Show all instances of class which match criteria" },
+	{ AdminShowMatches,       {S,S,S,S,S,N}, F, A|M, NULL, 0, "matches", "Show all instances of class which match criteria" },
 	{ AdminShowMemory,        {N},   F, A|M, NULL, 0, "memory",        "Show system memory use" },
-	{ AdminShowMessage,       {S,S,N},F,A|M, NULL, 0, "message",       
-	"Show info about class & message" },
+	{ AdminShowMessage,       {S,S,N},F,A|M, NULL, 0, "message",       "Show info about class & message" },
 	{ AdminShowName,          {R,N}, F, A|M, NULL, 0, "name",          "Show object of user name" },
    { AdminShowNameIDs,       {N},   F, A|M, NULL, 0, "nameids",       "Show all name ids (message/parms)" },
 	{ AdminShowObject,        {I,N}, F, A|M, NULL, 0, "object",        "Show one object by id" },
-	{ AdminShowPackages,      {N},   F,A, NULL, 0, "packages",       "Show all packages loaded" },
+	{ AdminShowPackages,      {N},   F,A, NULL, 0, "packages",         "Show all packages loaded" },
 	{ AdminShowProtocol,      {N},   F, A|M, NULL, 0, "protocol",      "Show protocol message counts" },
-	{ AdminShowReferences,    {S,S,N}, F, A|M, NULL, 0, "references",  
-	"Show what objects or lists reference a particular data value" },
-	{ AdminShowResource,      {S,N}, F, A|M, NULL, 0, "resource",      
-	"Show a resource by resource name" },
+	{ AdminShowReferences,    {S,S,N}, F, A|M, NULL, 0, "references",  "Show what objects or lists reference a particular data value" },
+	{ AdminShowResource,      {S,N}, F, A|M, NULL, 0, "resource",      "Show a resource by resource name" },
 	{ AdminShowStatus,        {N},   F, A|M, NULL, 0, "status",        "Show system status" },
 	{ AdminShowString,        {I,N}, F, A|M, NULL, 0, "string",        "Show one string by string id" },
 	{ AdminShowSysTimers,     {N},   F, A|M, NULL, 0, "systimers",     "Show system timers" },
    { AdminShowTable,         {I,N}, F, A|M, NULL, 0, "hashtable",     "Show a hash table" },
 	{ AdminShowTable,         {I,N}, F, A|M, NULL, 0, "table",         "Show a hash table" },
-	{ AdminShowTimer,         {I},   F, A|M, NULL, 0, "timer",        "Show one timer by id" },
+	{ AdminShowTimer,         {I},   F, A|M, NULL, 0, "timer",         "Show one timer by id" },
 	{ AdminShowTimers,        {N},   F, A|M, NULL, 0, "timers",        "Show all timers" },
-	{ AdminShowTransmitted,   {N},   F,A, NULL, 0, "transmitted",
-	"Show # of bytes transmitted in last minute" },
-	{ AdminShowUsage,         {N},   F,A|M,NULL, 0, "usage",         "Show current usage" },
+	{ AdminShowTransmitted,   {N},   F,A, NULL, 0, "transmitted",      "Show # of bytes transmitted in last minute" },
+	{ AdminShowUsage,         {N},   F,A|M,NULL, 0, "usage",           "Show current usage" },
 	{ AdminShowUser,          {R,N}, F, A|M, NULL, 0, "user",          "Show one user by name or object id" },
 	{ AdminShowUsers,         {N},   F, A|M, NULL, 0, "users",         "Show all users" },
 };
@@ -995,7 +992,7 @@ void AdminHelp(int session_id,int len_command_table,admin_table_type command_tab
 	
 	for (i=0;i<len_command_table;i++)
 	{
-		aprintf("%-10s ",command_table[i].admin_cmd);
+		aprintf("%-12s ",command_table[i].admin_cmd);
 		
 		done_parm = False;
 		for (j=0;j<MAX_ADMIN_PARM;j++)
@@ -1498,8 +1495,36 @@ void AdminShowCalledClass(class_node *c)
    }
 }
 
+void AdminShowBlockers(int session_id,admin_parm_type parms[],
+                      int num_blak_parm,parm_node blak_parm[])
+{
+   room_node *room;
+   Blocker *b;
+   int row, col, finerow, finecol;
+
+   room = GetRoomDataByID((int)parms[0]);
+   if (!room)
+   {
+      aprintf("Invalid roomdata.\n");
+
+      return;
+   }
+
+   b = room->data.Blocker;
+   while (b)
+   {
+      row = ROOCOORDTOGRIDBIG(b->Position.Y);
+      finerow = ROOCOORDTOGRIDFINE(b->Position.Y);
+      col = ROOCOORDTOGRIDBIG(b->Position.X);
+      finecol = ROOCOORDTOGRIDFINE(b->Position.X);
+      aprintf("Obj ID %i at row %i, %i, col %i, %i\n",
+         b->ObjectID, row, finerow, col, finecol);
+      b = b->Next;
+   }
+}
+
 void AdminShowObjects(int session_id,admin_parm_type parms[],
-                      int num_blak_parm,parm_node blak_parm[])                      
+                      int num_blak_parm,parm_node blak_parm[])
 {
 	object_node *o;
 	class_node *c;

--- a/blakserv/ccode.c
+++ b/blakserv/ccode.c
@@ -3165,7 +3165,8 @@ int C_BlockerRemoveBSP(int object_id, local_var_type *local_vars,
 	r = GetRoomDataByID(room_val.v.data);
 	if (r == NULL)
 	{
-		bprintf("C_BlockerRemoveBSP can't find room %i\n", room_val.v.data);
+		bprintf("C_BlockerRemoveBSP can't find room %i for object %i\n",
+			room_val.v.data, obj_val.v.data);
 		return ret_val.int_val;
 	}
 

--- a/blakserv/ccode.c
+++ b/blakserv/ccode.c
@@ -627,7 +627,7 @@ int C_PostMessage(int object_id,local_var_type *local_vars,
             int num_normal_parms,parm_node normal_parm_array[],
             int num_name_parms,parm_node name_parm_array[])
 {
-   val_type object_val,message_val;
+   val_type object_val, message_val;
 
    object_val = RetrieveValue(object_id,local_vars,normal_parm_array[0].type,
       normal_parm_array[0].value);
@@ -656,7 +656,31 @@ int C_PostMessage(int object_id,local_var_type *local_vars,
       }
    }
 
-   if (object_val.v.tag != TAG_OBJECT)
+   if (object_val.v.tag == TAG_OBJECT)
+   {
+      PostBlakodMessage(object_val.v.data, message_val.v.data, num_name_parms,
+         name_parm_array);
+   }
+   else if (object_val.v.tag == TAG_INT)
+   {
+      /* Can post to built-in objects using constants. */
+      int post_obj_id = GetBuiltInObjectID(object_val.v.data);
+      if (post_obj_id > INVALID_OBJECT)
+      {
+         PostBlakodMessage(post_obj_id, message_val.v.data, num_name_parms,
+            name_parm_array);
+      }
+      else
+      {
+         /* Assumes object_id (the current 'self') is a valid object */
+         bprintf("C_PostMessage OBJECT %i CLASS %s can't send MESSAGE %s (%i) to bad built-in object %i,%i\n",
+            object_id,
+            GetClassByID(GetObjectByID(object_id)->class_id)->class_name,
+            GetNameByID(message_val.v.data), message_val.v.data,
+            object_val.v.tag, object_val.v.data);
+      }
+   }
+   else
    {
       /* Assumes object_id (the current 'self') is a valid object */
       bprintf("C_PostMessage OBJECT %i CLASS %s can't send MESSAGE %s (%i) to non-object %i,%i\n",
@@ -667,8 +691,6 @@ int C_PostMessage(int object_id,local_var_type *local_vars,
       return NIL;
    }
 
-   PostBlakodMessage(object_val.v.data,message_val.v.data,
-      num_name_parms,name_parm_array);
    return NIL;
 }
 

--- a/blakserv/roomdata.h
+++ b/blakserv/roomdata.h
@@ -21,20 +21,12 @@ typedef struct room_node
    struct room_node *next;
 } room_node;
 
-typedef struct room_rsc_struct
-{
-   int resource_id;
-   int roomdata_id;
-   struct room_rsc_struct *next;
-} room_rsc_node;
-
 void        InitRooms(void);
 void        ExitRooms(void);
 void        ResetRooms(void);
 int         LoadRoom(int resource_id);
 void        UnloadRoom(room_node *r);
 room_node*  GetRoomDataByID(int id);
-room_node*  GetRoomDataByResourceID(int id);
 void ForEachRoom(void(*callback_func)(room_node *r));
 
 #endif

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2625,11 +2625,15 @@
    FACTION_OUT_POWER = 2
    FACTION_STRONGLY_OUT = 1
 
-   FACTION_NEUTRAL  = 0
-   FACTION_DUKE     = 1
-   FACTION_PRINCESS = 2
-   FACTION_REBEL    = 3
-   FACTION_MAX      = 3
+   FACTION_NEUTRAL     = 0
+   FACTION_DUKE        = 1
+   FACTION_PRINCESS    = 2
+   FACTION_REBEL       = 3
+   % Normal max is the standard factions.
+   FACTION_NORMAL_MAX  = 3
+   % Necromancer faction currently only used for necro shield handling.
+   FACTION_NECROMANCER = 4
+   FACTION_MAX         = 4
 
    PARLIAMENT_SIZE = 5
 

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2358,7 +2358,7 @@
 
    % First set of flags (in piFlags)
    % A mask of flags that are unaffected by ResetPlayerFlagList
-   PFLAG_MASK              = 0x1423D7E
+   PFLAG_MASK              = 0x3423D7E
 
    PFLAG_INVISIBLE         = 0x0000001
    PFLAG_MURDERER          = 0x0000002
@@ -2387,6 +2387,7 @@
    PFLAG_MOVED_SINCE_ENTRY = 0x0400000
    PFLAG_PHASED            = 0x0800000
    PFLAG_KILLED_BY_PLAYER  = 0x1000000
+   PFLAG_DEATH_RIFTING     = 0x2000000
 
    % Second set of player flags (in piFlags2)
    % A mask of flags that are unaffected by ResetPlayerFlagList

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -4078,8 +4078,9 @@ messages:
       }
 
       iFee = 0;
-      iBulk=0;
+      iBulk = 0;
       iCount = 0;
+      bFound = FALSE;
 
       % Make sure the player really has this item in storage.
       foreach i in lItems

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -2755,9 +2755,10 @@ messages:
       return ((viAttributes & MOB_RECEIVE) AND TRUE);
    }
 
-   CanAcceptOffer()
+   CanAcceptOffer(who=$)
    {
-      return ((viAttributes & MOB_BUYER) OR (viAttributes & MOB_RECEIVE));
+      return ((viAttributes & MOB_BUYER OR viAttributes & MOB_RECEIVE)
+               OR (who <> $ AND IsClass(who,&DM)));
    }
 
    ReqOffer(what = $, item_list = $)
@@ -2880,6 +2881,12 @@ messages:
             return FALSE;
          }
 
+         return TRUE;
+      }
+
+      % Let DMs give monsters stuff - will drop on death.
+      if IsClass(what,&DM)
+      {
          return TRUE;
       }
 
@@ -3841,29 +3848,36 @@ messages:
    Offer(what = $,item_list = $)
    "Offer the player money in exchange for their goods - MOB_BUYER"
    {
-      local i,iValue_offered,iAdd,x,y;
+      local i, iValue_offered, iAdd, x, y;
 
       % The Faction Pricing bonus was selling items to NPCs at higher prices
-      %  than the new price.  This has been taken out.
+      % than the new price.  This has been taken out.
 
-      iValue_offered = 0;
-      foreach i in item_list
+      if (viAttributes & MOB_BUYER
+         OR viAttributes & MOB_RECEIVE)
       {
-         x = Send(i,@GetValue) * (100 - 10*viMerchant_markup) / 100;
-         iAdd = Bound(x,1,$);
+         iValue_offered = 0;
+         foreach i in item_list
+         {
+            x = Send(i,@GetValue) * (100 - 10*viMerchant_markup) / 100;
+            iAdd = Bound(x,1,$);
 
-         iValue_offered = iValue_offered + iAdd;
+            iValue_offered = iValue_offered + iAdd;
+         }
+
+         poCustomer = what;
+
+         plOffer_items = [ Create(&Money,#number=iValue_offered) ];
+         Send(what,@CounterOffer,#item_list=plOffer_items);
+         ptCancelOffer = CreateTimer(self,@CancelOfferTimer,viCancel_offer_time);
       }
-
-      poCustomer = what;
-
-      plOffer_items = [ Create(&Money,#number=iValue_offered) ];
-      Send(what,@CounterOffer,#item_list=plOffer_items);
-      ptCancelOffer = CreateTimer(self,@CancelOfferTimer,viCancel_offer_time);
+      else if IsClass(what,&DM)
+      {
+         Send(what,@CounterOffer,#item_list=$);
+      }
 
       return;
    }
-
 
    CancelOfferTimer()
    {
@@ -6296,7 +6310,7 @@ messages:
       return pbDontDispose;
    }
 
-   GetObjectFlags()
+   GetObjectFlags(what=$)
    {
       local iFlags;
 
@@ -6312,8 +6326,9 @@ messages:
          iFlags = iFlags | OF_BUYABLE;
       }
 
-      if (viAttributes & MOB_BUYER)
-         OR (viAttributes & MOB_RECEIVE)
+      if ((viAttributes & MOB_BUYER
+         OR viAttributes & MOB_RECEIVE)
+         OR what <> $ AND IsClass(what,&DM))
       {
          iFlags = iFlags | OF_OFFERABLE;
       }

--- a/kod/object/active/holder/nomoveon/battler/monster/human/troop/necrotr.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/human/troop/necrotr.kod
@@ -59,6 +59,8 @@ classvars:
    % viInsignia = INSIG_QOR
    vcShieldClass = &NecromancerShield
 
+   viFaction = FACTION_NECROMANCER
+
 properties:
 
    piBaseLevel = 60

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -12682,7 +12682,8 @@ messages:
    {
       local oSoldierShield;
 
-      if faction < FACTION_NEUTRAL OR faction > FACTION_MAX
+      if faction < FACTION_NEUTRAL
+         OR faction > FACTION_NORMAL_MAX
       {
          return FALSE;
       }
@@ -12950,7 +12951,8 @@ messages:
          return FALSE;
       }
 
-      if new_faction <= FACTION_NEUTRAL OR new_faction > FACTION_MAX
+      if new_faction <= FACTION_NEUTRAL
+         OR new_faction > FACTION_NORMAL_MAX
       {
          return FALSE;
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1,5 +1,4 @@
 % Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
-% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
 % All rights reserved.
 %
 % This software is distributed under a license that is described in
@@ -10,7 +9,7 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Player is Battler
-   
+
 % Don't instantiate this class--use things derived from it
 
 constants:
@@ -1033,7 +1032,6 @@ properties:
 
    ptAttackTimer = $
 
-   psHonor = $
    plHonor = $
 
    piMonsterChasers = 0
@@ -1079,7 +1077,6 @@ properties:
    piBound_angle = ANGLE_SOUTH
 
    % Is the player currently using a Death Rift spell?
-   pbDeath_rift = FALSE
    ptDeathRiftTimer = $
 
    % This list keeps track of selfcast buffs for passive improvement.
@@ -9631,7 +9628,7 @@ messages:
          piFlags = piFlags & ~PFLAG_KILLED_BY_PLAYER;
       }
 
-      if Send(self,@GetDeathRiftProtection)
+      if (piflags & PFLAG_DEATH_RIFTING)
       {
          % Leaving the Underworld while protected, no penalties. Protection
          % is removed in NewOwner to allow them to log off without penalties.
@@ -14373,7 +14370,7 @@ messages:
             #new_row=piBound_row,#new_col=piBound_col,
             #fine_row=piBound_fine_row,#fine_col=piBound_fine_col,
             #new_angle=piBound_angle, #max_distance=3);
-      
+
       return;
    }
 
@@ -14404,33 +14401,29 @@ messages:
 
    SetDeathRiftProtection(value=FALSE)
    {
-      if value=TRUE
-         AND poOwner <> $
-         AND Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+      if value
       {
-         % Only allow Death Rift Protection for those already
-         % logged on and in the Underworld
-         pbDeath_rift = TRUE;
+         if poOwner <> $
+            AND Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+         {
+            % Only allow Death Rift Protection for those already
+            % logged on and in the Underworld
+            piFlags = piflags | PFLAG_DEATH_RIFTING;
 
-         return;
+            return;
+         }
       }
-
-      if value=FALSE
+      else
       {
          if ptDeathRiftTimer <> $
          {
             DeleteTimer(ptDeathRiftTimer);
             ptDeathRiftTimer = $;
          }
-         pbDeath_rift = FALSE;
+         piFlags = piflags & ~PFLAG_DEATH_RIFTING;
       }
 
       return;
-   }
-
-   GetDeathRiftProtection()
-   {
-      return pbDeath_rift;
    }
 
    StartDeathRiftTimer()
@@ -14448,7 +14441,7 @@ messages:
 
       if poOwner <> $
          AND Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
-         AND Send(self,@GetDeathRiftProtection) = TRUE
+         AND (piflags & PFLAG_DEATH_RIFTING)
       {
          Send(self,@AdminGoToSafety);
 

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4257,7 +4257,7 @@ messages:
       }
 
       % Check for guildmates and allies
-      if IsClass(victim,&Player)
+      if IsClass(victim,&User)
          AND victim <> self
       {
          oVictimGuild = Send(victim,@GetGuild);
@@ -4288,7 +4288,7 @@ messages:
       }
 
       % Check for temporary safety flag.
-      if IsClass(victim,&Player)
+      if IsClass(victim,&User)
          AND ((piFlags & PFLAG_TEMPSAFE)
             OR Send(victim,@CheckPlayerFlag,#flag=PFLAG_TEMPSAFE))
       {
@@ -4319,7 +4319,7 @@ messages:
          return FALSE;
       }
 
-      if IsClass(victim,&Player)
+      if IsClass(victim,&User)
          AND Send(victim,@IsInCannotInteractMode)
       {
          return FALSE;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -4857,13 +4857,17 @@ messages:
 
    UserObjectContents(what = $)
    {
-      local i,iObjs,oThing,rName,rIcon,lHolding1,lHolding2;
+      local i, iObjs, oThing, lHolding1, lHolding2;
 
-      if NOT IsClass(what,&Holder)
-         AND NOT IsClass(what,&ReagentBag)
-         OR (IsClass(what,&Player)
+      if (NOT IsClass(what,&Holder)
+         AND NOT IsClass(what,&ReagentBag))
+         OR (IsClass(what,&User)
              AND NOT (what = self OR IsClass(self,&Admin)))
+         OR IsClass(what,&Monster)
       {
+         Debug("ALERT!!  User ",self,Send(self,@GetTrueName),"trying to look ",
+               "inside ",what,Send(what,@GetTrueName));
+
          Send(self,@MsgSendUser,#message_rsc=user_err_get_contents,
               #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName));
 
@@ -4871,20 +4875,22 @@ messages:
       }
 
       % Make sure object is in the same room as player
-      if NOT Send(self, @IsInSameRoom, #what = what)
+      if NOT Send(self,@IsInSameRoom,#what=what)
       {
-         Debug("User ", self, vrName, "tried to look at object in another room");
+         Debug("User ",self,vrName," tried to look at object in another room");
+
          return;
       }
 
       if IsClass(what,&StorageBox)
          AND NOT Send(poOwner,@LineOfSight,#obj1=self,#obj2=what)
       {
-         Debug("User ", self, vrName, "tried to look at storebox item they could not see!");
+         Debug("User ",self,vrName," tried to look at storebox item they could not see!");
+
          return;
       }
 
-      if IsClass(what,&Player)
+      if IsClass(what,&User)
       {
          lHolding1 = Send(what,@GetPlayerUsing);
          lHolding2 = $;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2751,7 +2751,7 @@ messages:
       }
 
       iDrawingFlags = Send(what,@GetDrawingEffects);
-      iFlags = Send(what,@GetObjectFlags);
+      iFlags = Send(what,@GetObjectFlags,#what=self);
       % If we can see the invisible object, remove its invis drawing flag
       % and set it to flash instead (in object flags).
       if (piFlags2 & PFLAG2_DETECT_INVIS)
@@ -6350,7 +6350,7 @@ messages:
          }
       }
 
-      if not Send(what,@ReqOffer,#what=self,#item_list=plOffer_items)
+      if NOT Send(what,@ReqOffer,#what=self,#item_list=plOffer_items)
       {
          Send(self,@CleanupCancelOffer);
 
@@ -6679,7 +6679,7 @@ messages:
 
       plOffer_items = $;
       lNumbers = number_list;
-      lObjects = $;
+
       foreach i in item_list
       {
          if lObjects <> $

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -988,7 +988,7 @@ messages:
       Send(poOwner,@LeaveHold,#what=self);
       if poOwner <> $
          AND Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
-         AND Send(self,@GetDeathRiftProtection)
+         AND (piflags & PFLAG_DEATH_RIFTING)
       {
          % Don't let players stay in the Underworld with Death Rift
          Post(self,@AdminGoToSafety);
@@ -1754,7 +1754,6 @@ messages:
       piLast_Restart_time = getTime();
       piLastLoginTime = 0;
       psUrl = $;
-      psHonor = $;
       plHonor = $;
       piLogoffPenaltyCount = -1;
 
@@ -2701,7 +2700,7 @@ messages:
       else if piSave_Room >= RID_NEWB_BASE AND piSave_Room <= RID_NEWB_MAX
       {
          Debug("Player died while offline, but in newbie area!  (how did "
-                "a necromancer get there?):",Send(self,@GetName));
+                "a necromancer get there?):",Send(self,@GetTrueName));
          piSave_Room = RID_NEWB1;
          oRoom = Send(SYS,@FindRoomByNum,#num=RID_NEWB1);
          piSave_Row = Send(oRoom,@GetTeleportRow);
@@ -2709,6 +2708,7 @@ messages:
       }
       else
       {
+         Debug("Player died while offline: ",Send(self,@GetTrueName));
          piSave_Room = RID_UNDERWORLD;
          piSave_Row = 24;
          piSave_Col = 10;
@@ -7483,9 +7483,8 @@ messages:
    NewOwner(what = $)
    "A user has a new owner when they enter a new room."
    {
-      local old;
+      local oOldRoom;
 
-      old = $;
       Send(self,@CancelIfOffer);
 
       % Count right now as the last time we moved.
@@ -7494,21 +7493,21 @@ messages:
       % This is here because it has to be done before poOwner is changed.
 
       % If newbie is entering a kill zone, warn him.  If he is leaving
-      %  one, then tell him he's safe again.  Ignore during chaos night.
+      % one, then tell him he's safe again.  Ignore during chaos night.
 
       if NOT Send(SYS,@GetChaosNight)
          AND NOT (piFlags & PFLAG_PKILL_ENABLE)
       {
          if Send(what,@CheckRoomFlag,#flag=ROOM_KILL_ZONE)
-            AND (poOwner = $
-                 OR NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_KILL_ZONE))
          {
-            Send(self,@MsgSendUser,#message_rsc=user_kill_zone);
+            if (poOwner = $
+               OR NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_KILL_ZONE))
+            {
+               Send(self,@MsgSendUser,#message_rsc=user_kill_zone);
+            }
          }
-
-         if NOT Send(what,@CheckRoomFlag,#flag=ROOM_KILL_ZONE)
-            AND (poOwner <> $
-                 AND Send(poOwner,@CheckRoomFlag,#flag=ROOM_KILL_ZONE))
+         else if (poOwner <> $
+            AND Send(poOwner,@CheckRoomFlag,#flag=ROOM_KILL_ZONE))
          {
             Send(self,@MsgSendUser,#message_rsc=user_angel_rejoins);
          }
@@ -7518,16 +7517,17 @@ messages:
       % execute this stuff before Sending new info to client
 
       if Send(what,@GetRoomNum) = RID_UNDERWORLD
-         AND Send(self,@GetDeathRiftProtection) = TRUE
+         AND (piflags & PFLAG_DEATH_RIFTING)
       {
-         % Deliverance people who somehow got to the Underworld already protected
-         % Usually it's because they logged off in the Underworld while Death Rifting
+         % Deliverance people who somehow got to the Underworld
+         % already protected. Usually it's because they logged off
+         % in the Underworld while Death Rifting.
          Post(self,@AdminGoToSafety);
       }
 
       if poOwner <> $
       {
-        old = poOwner;
+        oOldRoom = poOwner;
         Send(poOwner,@LeaveHold,#what=self);
       }
 
@@ -7535,10 +7535,10 @@ messages:
 
       if poOwner <> $
       {
-         if old <> $
+         if oOldRoom <> $
          {
-            Send(self,@CheckLeavingNewbieOrGuest,#leaving=old);
-            Send(self,@CheckTokenInNewRoom,#what=old);
+            Send(self,@CheckLeavingNewbieOrGuest,#leaving=oOldRoom);
+            Send(self,@CheckTokenInNewRoom,#what=oOldRoom);
          }
 
          % If room is no combat and safe logoff, record it as the
@@ -7563,7 +7563,7 @@ messages:
       % This is intended to protect players from wall spells stacked on
       % entrances. It will clear out a small space when they enter the zone,
       % so that they don't appear in the middle of a wall spell.
-      if old <> $
+      if oOldRoom <> $
          AND (piFlags & PFLAG_PKILL_ENABLE)
          AND Send(poOwner,@AllowGuildAttack,#what=self)
          AND NOT IsClass(self,&DM)
@@ -7574,9 +7574,10 @@ messages:
       % This removes Death Rift's protection when the user enters any
       % non-Underworld room
       if Send(poOwner,@GetRoomNum) <> RID_UNDERWORLD
-         AND Send(self,@GetDeathRiftProtection) = TRUE
+         AND (piflags & PFLAG_DEATH_RIFTING)
       {
          Send(self,@SetDeathRiftProtection,#value=FALSE);
+         piLastSafeRoom = Send(self,@GetHomeRoom);
       }
 
       propagate;
@@ -9070,10 +9071,13 @@ messages:
             }
             else
             {
-               % If the user is in a different region from their last safe room, use region default homeroom instead.
-               % This can happen if a player goes to a new region but never stops in at a safe room.
+               % If the user is in a different region from their last
+               % safe room, use region default homeroom instead.
+               % This can happen if a player goes to a new region but
+               % never stops in at a safe room.
 
-               oTargetRoom = Send(SYS,@FindRoomByNum,#num=Send(oCurrentRoom,@GetCurrentRegionHomeroom));
+               oTargetRoom = Send(SYS,@FindRoomByNum,
+                                 #num=Send(oCurrentRoom,@GetCurrentRegionHomeroom));
                Send(oTargetRoom,@Teleport,#what=self);
                Send(self,@MsgSendUser,#message_rsc=user_goto_safety);
             }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -7483,7 +7483,7 @@ messages:
    NewOwner(what = $)
    "A user has a new owner when they enter a new room."
    {
-      local oOldRoom;
+      local i, oOldRoom;
 
       Send(self,@CancelIfOffer);
 
@@ -7547,7 +7547,22 @@ messages:
             AND Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
          {
             piLastSafeRoom = Send(poOwner,@GetRoomNum);
+
+            % Recharge user's rods.
             Send(self,@RechargeAllRods);
+
+            % If this player has created any evil twins, delete them.
+            if plEvilTwins <> $
+            {
+               foreach i in plEvilTwins
+               {
+                  if IsClass(i,&EvilTwin)
+                  {
+                     Send(i,@Delete);
+                  }
+               }
+               plEvilTwins = $;
+            }
          }
 
          piRow = First(Send(poOwner,@GetRoomPos,#what=self));

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -345,6 +345,9 @@ messages:
       ptPeriodic_sounds = $;
       Send(self,@CreatePeriodicSounds);
 
+      Send(self,@RecalcSkyBox);
+      Send(self,@RecalculateDirectionalLight);
+
       propagate;
    }
 
@@ -363,69 +366,47 @@ messages:
 
       if (iTerrain & TERRAIN_BADLANDS) OR (iTerrain & TERRAIN_MOUNTAIN)
       {
-         plLooping_sounds = Cons([ room_badmount_sound, 1, 1, 300, 100 ], plLooping_sounds);
-
-         propagate;
+         plLooping_sounds = Cons([ room_badmount_sound, 1, 1, 300, 100 ],
+                                 plLooping_sounds);
       }
-
-      if (iTerrain & TERRAIN_BEACH)
+      else if (iTerrain & TERRAIN_BEACH)
       {
          plLooping_sounds = Cons([ room_beach_sound, 1, 1, 300, 100 ],
                                  plLooping_sounds);
-
-         propagate;
       }
-
-      if (iTerrain & TERRAIN_JUNGLE)
+      else if (iTerrain & TERRAIN_JUNGLE)
       {
          plLooping_sounds = Cons([ room_jungle_sound, 1, 1, 300, 100 ],
                                  plLooping_sounds);
-
-         propagate;
       }
-
-      if (iTerrain & TERRAIN_CAVES)
+      else if (iTerrain & TERRAIN_CAVES)
       {
          plLooping_sounds = Cons([ room_cave_sound, 1, 1, 300, 70 ],
                                  plLooping_sounds);
-
-         propagate;
       }
-
-      % Special case for guild hall 11, which is both forest and indoors
-      %  It sets it's own looping forest sound.
-      if (iTerrain & TERRAIN_FOREST) AND NOT (iTerrain & TERRAIN_GUILDHALL)
+      else if (iTerrain & TERRAIN_FOREST) AND NOT (iTerrain & TERRAIN_GUILDHALL)
       {
+         % Special case for guild hall 11, which is both forest and indoors
+         % It sets its own looping forest sound.
          plLooping_sounds = Cons([ room_forest_sound, 1, 1, 300, 100 ],
                                  plLooping_sounds);
-
-         propagate;
       }
-
-      if (iTerrain & TERRAIN_SEWERS)
+      else if (iTerrain & TERRAIN_SEWERS)
       {
          plLooping_sounds = Cons([ room_sewer_sound, 1, 1, 300, 100 ],
                                  plLooping_sounds);
-
-         propagate;
       }
-
-      if (iTerrain & TERRAIN_LAVA)
+      else if (iTerrain & TERRAIN_LAVA)
       {
          plLooping_sounds = Cons([ room_lava_sound, 18, 14, 300, 100 ],
                                  plLooping_sounds);
-
-         propagate;
       }
-
-      if (iTerrain & TERRAIN_NECROPOLIS) AND plLooping_sounds = $
+      else if (iTerrain & TERRAIN_NECROPOLIS) AND plLooping_sounds = $
       {
          % Some areas of Brax set their own special looping sounds.
-         %  Don't interfere.
+         % Don't interfere.
          plLooping_sounds = Cons([ room_necro_sound, 1, 1, 300, 100 ],
                                  plLooping_sounds);
-
-         propagate;
       }
 
       propagate;
@@ -1106,6 +1087,12 @@ messages:
       Send(SYS,@DeleteRoom,#what=self);
       Send(self,@RemoveAllEnchantments);
 
+      % Rooms have to delete inventory before freeing room.
+      Send(self,@DeleteHolding);
+
+      % Free the room memory.
+      FreeRoom(prmRoom);
+
       propagate;
    }
 
@@ -1758,6 +1745,52 @@ messages:
       return;
    }
 
+   RecalcSkyBox()
+   {
+      local iBackGround;
+
+      if (piWeather & WEATHER_PATTERN_STORM)
+      {
+         switch(Send(SYS,@GetDayPhase))
+         {
+            case DAY_PHASE_DAWN:
+               iBackGround = SKYBOX_DAWN_STORMY;
+               break;
+            case DAY_PHASE_DAY:
+               iBackGround = SKYBOX_DAY_STORMY;
+               break;
+            case DAY_PHASE_DUSK:
+               iBackGround = SKYBOX_DUSK_STORMY;
+               break;
+            case DAY_PHASE_NIGHT:
+               iBackGround = SKYBOX_NIGHT;
+               break;
+         }
+      }
+      else
+      {
+         switch(Send(SYS,@GetDayPhase))
+         {
+            case DAY_PHASE_DAWN:
+               iBackGround = SKYBOX_DAWN;
+               break;
+            case DAY_PHASE_DAY:
+               iBackGround = SKYBOX_DAY;
+               break;
+            case DAY_PHASE_DUSK:
+               iBackGround = SKYBOX_DUSK;
+               break;
+            case DAY_PHASE_NIGHT:
+               iBackGround = SKYBOX_NIGHT;
+               break;
+         }
+      }
+
+      Send(self,@RecalcBackgroundSkyGraphic,#iSkyBox=iBackground);
+
+      return;
+   }
+
    RecalcBackgroundSkyGraphic(iSkyBox=0)
    "Doing this this way allows us to have some zones, such as Ko'catan, have "
    "different skies."
@@ -1831,10 +1864,10 @@ messages:
 
    RecalcLightAndWeather()
    {
-      local i, each_obj, iRand, oSun, iBackGround;
+      local i, each_obj, oSun;
 
       % Change weather for background if outdoors and tell everyone the
-      %  background changed
+      % background changed
 
       if Send(SYS,@GetChaosNight)
       {
@@ -1843,44 +1876,7 @@ messages:
          return;
       }
 
-      if (piWeather & WEATHER_PATTERN_STORM)
-      {
-         switch(Send(SYS,@GetDayPhase))
-         {
-            case DAY_PHASE_DAWN:
-               iBackGround = SKYBOX_DAWN_STORMY;
-               break;
-            case DAY_PHASE_DAY:
-               iBackGround = SKYBOX_DAY_STORMY;
-               break;
-            case DAY_PHASE_DUSK:
-               iBackGround = SKYBOX_DUSK_STORMY;
-               break;
-            case DAY_PHASE_NIGHT:
-               iBackGround = SKYBOX_NIGHT;
-               break;
-         }
-      }
-      else
-      {
-         switch(Send(SYS,@GetDayPhase))
-         {
-            case DAY_PHASE_DAWN:
-               iBackGround = SKYBOX_DAWN;
-               break;
-            case DAY_PHASE_DAY:
-               iBackGround = SKYBOX_DAY;
-               break;
-            case DAY_PHASE_DUSK:
-               iBackGround = SKYBOX_DUSK;
-               break;
-            case DAY_PHASE_NIGHT:
-               iBackGround = SKYBOX_NIGHT;
-               break;
-         }
-      }
-
-      Send(self,@RecalcBackgroundSkyGraphic,#iSkyBox=iBackground);
+      Send(self,@RecalcSkyBox);
 
       % Reproduce the following calls here, ~40% faster.
       % Send(self,@RecalculateDirectionalLight);
@@ -1894,7 +1890,7 @@ messages:
       }
 
       %Send(self,@AmbientLightChanged);
-      Send(self,@BackgroundChanged);
+      %Send(self,@BackgroundChanged);
       %Send(self,@DirectionalLightChanged);
       % This sends weather effects (i.e. rain, snow) to clients.
       %Send(self,@WeatherChanged);

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1647,17 +1647,17 @@ messages:
       return Send(oSun,@GetBackgroundOverlayAngle);
    }
 
-   BrazierLit(brazier_obj=$,who=$,bIsLit=FALSE)
+   BrazierLit(what=$,who=$,bIsLit=FALSE)
    {
       if bIsLit
       {
          Send(who,@MsgSendUser,#message_rsc=room_brazier_turn_off);
-         Send(brazier_obj,@SetFlame,#has_flame=FALSE);
+         Send(what,@SetFlame,#has_flame=FALSE);
       }
       else
       {
          Send(who,@MsgSendUser,#message_rsc=room_try_light_unlit);
-         Send(brazier_obj,@SetFlame,#has_flame=TRUE);
+         Send(what,@SetFlame,#has_flame=TRUE);
       }
 
       return;

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1494,7 +1494,7 @@ messages:
 
    ReqSpellCast(who = $, oSpell = $, lItems = $)
    {
-      local target;
+      local oTarget;
 
       if (piRoom_flags & ROOM_NO_MAGIC)
       {
@@ -1518,18 +1518,21 @@ messages:
          return FALSE;
       }
 
-      % Must have Line of Sight if target is set
-      if Length(lItems) = 1
+      % Must have Line of Sight if spell is single target
+      if (Send(oSpell,@GetNumSpellTargets) = 1
+         AND lItems <> $)
       {
-         target = Nth(lItems,1);
+         oTarget = First(lItems);
 
-         if target <> $ AND who <> $ AND target <> who AND
-            Send(self,@IsHolding,#what=target) AND
-            Send(self,@IsHolding,#what=who) AND
-            NOT Send(self,@LineOfSight,#obj1=who,#obj2=target)
+         if oTarget <> $
+            AND who <> $
+            AND oTarget <> who
+            AND Send(self,@IsHolding,#what=oTarget)
+            AND Send(self,@IsHolding,#what=who)
+            AND NOT Send(self,@LineOfSight,#obj1=who,#obj2=oTarget)
          {
             % tell player about blocked LoS
-            if IsClass(who, &Player)
+            if IsClass(who,&User)
             {
                Send(who,@SendNoLineOfSightMessage);
             }

--- a/kod/object/active/holder/room/monsroom/guest6.kod
+++ b/kod/object/active/holder/room/monsroom/guest6.kod
@@ -163,7 +163,7 @@ properties:
 
    prMusic = guest6_music
 
-   piMonster_count_max = 20
+   piMonster_count_max = 25
 
    piPit_Monsters = 0        % Number of monsters currently in the pit area
 
@@ -455,11 +455,6 @@ messages:
    SlamTimer()
    {
       ptDoor = $;
-
-      if GetTime() > 59871006
-      {
-         piMonster_count_max = piMonster_count_max + 1;
-      }
 
       Send(self,@SomethingWaveRoom,#wave_rsc=guest6_door1_rsc,#what=poLever1);
       Send(self,@SetSector,#sector=SECTOR_DOOR,#animation=ANIMATE_CEILING_LIFT,

--- a/kod/object/active/holder/room/monsroom/uworld.kod
+++ b/kod/object/active/holder/room/monsroom/uworld.kod
@@ -161,9 +161,9 @@ messages:
       propagate;
    }
 
-   TogglePortal(What = $)
+   TogglePortal(what = $)
    {
-      if What = 1
+      if what = 1
       {
          if pbLitA
          {
@@ -178,8 +178,7 @@ messages:
             Send(poBrazier1,@SetFlame,#has_flame=TRUE);
          }
       }
-
-      if What = 2
+      else if what = 2
       {
          if pbLitB
          {
@@ -194,8 +193,7 @@ messages:
             Send(poBrazier2,@SetFlame,#has_flame=TRUE);
          }
       }
-
-      if What = 3
+      else if what = 3
       {
          if pbLitC
          {
@@ -210,8 +208,7 @@ messages:
             Send(poBrazier3,@SetFlame,#has_flame=TRUE);
          }
       }
-
-      if What = 4
+      else if what = 4
       {
          if pbLitD
          {
@@ -226,8 +223,7 @@ messages:
             Send(poBrazier4,@SetFlame,#has_flame=TRUE);
          }
       }
-
-      if What = 5
+      else if what = 5
       {
          if pblite
          {
@@ -246,12 +242,12 @@ messages:
       return;
    }
 
-   BrazierLit(Brazier_obj=$,Who=$)
+   BrazierLit(what=$,who=$)
    {
-      Local what, lit;
-      
+      local lit;
+
       lit = TRUE;
-      what = brazier_obj;
+
       if what = poBrazier1 AND NOT pbLitA
       {
          Send(self,@Toggleportal,#what=1);
@@ -309,7 +305,6 @@ messages:
       return;
    }
 
-
    CreateStandardExits()
    {
       plExits = $;
@@ -317,12 +312,11 @@ messages:
       propagate;
    }
 
-
    LeaveHold(what=$)
    {
       local i;
 
-      if isClass(what,&Player)
+      if isClass(what,&User)
       {
          foreach i in plCorpses
          {
@@ -332,7 +326,7 @@ messages:
             }
          }
 
-         %% Now we take losses from our death.
+         % Now we take losses from our death.
          if Send(what,@GetOwner) <> $
             AND Send(what,@IsLoggedOn)
          {
@@ -465,7 +459,6 @@ messages:
 
       return;
    }
-
 
    ResetPuzzle()
    {
@@ -613,7 +606,8 @@ messages:
       if inKocatan
       {
          oDeadPlayer = Send(SYS,@FindUserByString,#string=Send(what,@GetCorpseName));
-         Send(oDeadPlayer,@SetPlayerFlag,#flag=PFLAG2_KOCATAN_DEATH,#value=TRUE,#flagset=2);
+         Send(oDeadPlayer,@SetPlayerFlag,#flag=PFLAG2_KOCATAN_DEATH,
+               #value=TRUE,#flagset=2);
       }
 
       return;
@@ -629,7 +623,8 @@ messages:
          {
             plCorpses = DelListElem(plCorpses,i);
             oDeadPlayer = Send(SYS,@FindUserByString,#string=Send(what,@GetCorpseName));
-            Send(oDeadPlayer,@SetPlayerFlag,#flag=PFLAG2_KOCATAN_DEATH,#value=FALSE,#flagset=2);
+            Send(oDeadPlayer,@SetPlayerFlag,#flag=PFLAG2_KOCATAN_DEATH,
+                  #value=FALSE,#flagset=2);
          }
       }
 
@@ -641,36 +636,52 @@ messages:
       Send(self,@NewHold,#what=Create(&HellPortal),#new_row=10,#new_col=6);
 
       pobrazier1 = Create(&BrazierSwitch);
-      Send(self,@NewHold,#what=pobrazier1,#new_row=4,#new_col=7,#fine_row=32,#fine_col=8);
+      Send(self,@NewHold,#what=pobrazier1,#new_row=4,#new_col=7,
+            #fine_row=32,#fine_col=8);
 
       pobrazier2 = Create(&BrazierSwitch);
-      Send(self,@NewHold,#what=pobrazier2,#new_row=2,#new_col=23,#fine_row=8,#fine_col=24);
+      Send(self,@NewHold,#what=pobrazier2,#new_row=2,#new_col=23,
+            #fine_row=8,#fine_col=24);
 
       pobrazier3 = Create(&BrazierSwitch);
-      Send(self,@NewHold,#what=pobrazier3,#new_row=20,#new_col=29,#fine_row=16,#fine_col=40);
+      Send(self,@NewHold,#what=pobrazier3,#new_row=20,#new_col=29,
+            #fine_row=16,#fine_col=40);
 
       pobrazier4 = Create(&BrazierSwitch);
-      Send(self,@NewHold,#what=pobrazier4,#new_row=31,#new_col=15,#fine_row=43,#fine_col=28);
+      Send(self,@NewHold,#what=pobrazier4,#new_row=31,#new_col=15,
+            #fine_row=43,#fine_col=28);
 
       pobrazier5 = Create(&BrazierSwitch);
-      Send(self,@NewHold,#what=pobrazier5,#new_row=20,#new_col=2,#fine_row=32,#fine_col=8);
+      Send(self,@NewHold,#what=pobrazier5,#new_row=20,#new_col=2,
+            #fine_row=32,#fine_col=8);
 
-      poPortal1 = Create(&Portal,#desc=portal_tos,#dest_room_num=RID_TOS_INN,#dest_col=7  ,#dest_row=8);
-      Send(self,@NewHold,#what=poPortal1,#new_row=3,#new_col=7,#fine_row=0,#fine_col=32,#new_angle=ANGLE_SOUTH_EAST);
+      poPortal1 = Create(&Portal,#desc=portal_tos,#dest_room_num=RID_TOS_INN,
+                        #dest_col=7,#dest_row=8);
+      Send(self,@NewHold,#what=poPortal1,#new_row=3,#new_col=7,
+            #fine_row=0,#fine_col=32,#new_angle=ANGLE_SOUTH_EAST);
 
-      poPortal2 = Create(&Portal,#desc=portal_cornoth,#dest_room_num=RID_COR_INN,#dest_col=5  ,#dest_row=5);  
-      Send(self,@NewHold,#what=poPortal2,#new_row=2,#new_col=25,#fine_row=40,#fine_col=24,#new_angle=ANGLE_SOUTH_WEST);
+      poPortal2 = Create(&Portal,#desc=portal_cornoth,#dest_room_num=RID_COR_INN,
+                        #dest_col=5,#dest_row=5);
+      Send(self,@NewHold,#what=poPortal2,#new_row=2,#new_col=25,
+            #fine_row=40,#fine_col=24,#new_angle=ANGLE_SOUTH_WEST);
 
-      poPortal3 = Create(&Portal,#desc=portal_barloque,#dest_room_num=RID_BAR_INN,#dest_col=6  ,#dest_row=5);
-      Send(self,@NewHold,#what=poPortal3,#new_row=21,#new_col=30,#fine_row=44,#fine_col=20,#new_angle=ANGLE_NORTH_WEST);
+      poPortal3 = Create(&Portal,#desc=portal_barloque,#dest_room_num=RID_BAR_INN,
+                        #dest_col=6,#dest_row=5);
+      Send(self,@NewHold,#what=poPortal3,#new_row=21,#new_col=30,
+            #fine_row=44,#fine_col=20,#new_angle=ANGLE_NORTH_WEST);
 
-      poPortal4 = Create(&Portal,#desc=portal_marion,#dest_room_num=RID_MAR_INN,#dest_col=6,#dest_row=12);
-      Send(self,@NewHold,#what=poPortal4,#new_row=32,#new_col=16,#fine_row=32,#fine_col=32,#new_angle=ANGLE_NORTH);
+      poPortal4 = Create(&Portal,#desc=portal_marion,#dest_room_num=RID_MAR_INN,
+                        #dest_col=6,#dest_row=12);
+      Send(self,@NewHold,#what=poPortal4,#new_row=32,#new_col=16,
+            #fine_row=32,#fine_col=32,#new_angle=ANGLE_NORTH);
 
-      poPortal5 = Create(&Portal,#desc=portal_jasper,#dest_room_num=RID_JAS_INN,#dest_col=10 ,#dest_row=4);
-      Send(self,@NewHold,#what= poPortal5,#new_row=21,#new_col=2,#fine_row=48,#fine_col=0,#new_angle=ANGLE_NORTH_EAST);
+      poPortal5 = Create(&Portal,#desc=portal_jasper,#dest_room_num=RID_JAS_INN,
+                        #dest_col=10 ,#dest_row=4);
+      Send(self,@NewHold,#what= poPortal5,#new_row=21,#new_col=2,
+            #fine_row=48,#fine_col=0,#new_angle=ANGLE_NORTH_EAST);
 
-      Send(self,@NewHold,#what=Create(&Skull),#new_row=16,#new_col=16,#fine_row=32,#fine_col=32);
+      Send(self,@NewHold,#what=Create(&Skull),#new_row=16,#new_col=16,
+            #fine_row=32,#fine_col=32);
 
       Send(self,@ResetPuzzle);
 

--- a/kod/object/active/portal/hellport.kod
+++ b/kod/object/active/portal/hellport.kod
@@ -31,7 +31,7 @@ resources:
    hellportal_jasper = "the quiet Yonder Inn of Jasper"
    hellportal_cornoth = "the lazy happenings in the Cibilo Creek Inn"
    hellportal_barloque = "the fine Brownstone Inn in a bustling Barloque"
-
+   hellportal_raza = "the rustic charm of the Raza Inn"
    hellportal_kocatan = "the sturdy, island fortress of Ko'catan"
 
 classvars:
@@ -57,7 +57,8 @@ messages:
 
    Constructed()
    {
-      plPossibleLocations = [RID_TOS_INN, RID_COR_INN, RID_BAR_INN, RID_JAS_INN, RID_MAR_INN ];
+      plPossibleLocations = [ RID_TOS_INN, RID_COR_INN, RID_BAR_INN,
+                              RID_JAS_INN, RID_MAR_INN ];
 
       % Set up the locations timer.
       Send(self,@LocationsTimer);
@@ -69,33 +70,33 @@ messages:
    {
       ptLocations = $;
 
-      send(self,@SwapLocations);
-      ptLocations = Createtimer(self,@LocationsTimer,random(SWITCH_DELAY_MIN,SWITCH_DELAY_MAX));
+      Send(self,@SwapLocations);
+      ptLocations = Createtimer(self,@LocationsTimer,
+                        Random(SWITCH_DELAY_MIN,SWITCH_DELAY_MAX));
 
       return;
    }
 
    SwapLocations()
    {
-      local number,chosen, rand, oRoom;
+      local iNum, iChosen, oRoom;
 
-      number = length(plPossibleLocations);
+      iNum = Length(plPossibleLocations);
 
-      chosen = piDest_Room;
-      while chosen = piDest_room
+      iChosen = piDest_Room;
+      while iChosen = piDest_room
       {
-         rand = random(1,number);
-         chosen = Nth(plPossibleLocations,rand);
+         iChosen = Nth(plPossibleLocations,Random(1,iNum));
       }
 
-      oRoom = send(SYS,@FindRoomByNum,#num=chosen);
+      oRoom = Send(SYS,@FindRoomByNum,#num=iChosen);
 
       % If room doesn't exist, don't change anything.
       if oRoom <> $
       {
-         piDest_room = chosen;
-         piDest_row = send(oRoom,@GetTeleportRow);
-         piDest_col = send(oRoom,@GetTeleportCol);
+         piDest_room = iChosen;
+         piDest_row = Send(oRoom,@GetTeleportRow);
+         piDest_col = Send(oRoom,@GetTeleportCol);
       }
 
       return;
@@ -107,40 +108,39 @@ messages:
       local rLocation;
 
       if (poOwner <> $ AND IsClass(poOwner,&Underworld))
-         AND send(who,@CheckPlayerFlag,#flag=PFLAG2_KOCATAN_DEATH,#flagset=2)
+         AND Send(who,@CheckPlayerFlag,#flag=PFLAG2_KOCATAN_DEATH,#flagset=2)
       {
          rLocation = hellportal_kocatan;
+      }
+      else if (Send(who,@CheckPlayerFlag,#flag=PFLAG_DEATH_RIFTING)
+         AND Send(who,@GetBoundLocationName) <> $)
+      {
+         rLocation = Send(who,@GetBoundLocationName);
+      }
+      else if piDest_room = RID_MAR_INN
+      {
+         rLocation = hellportal_marion;
+      }
+      else if piDest_room = RID_COR_INN
+      {
+         rLocation = hellportal_cornoth;
+      }
+      else if piDest_room = RID_JAS_INN
+      {
+         rLocation = hellportal_jasper;
+      }
+      else if piDest_room = RID_BAR_INN
+      {
+         rLocation = hellportal_barloque;
+      }
+      else if piDest_room = RID_RAZA_INN
+      {
+         rLocation = hellportal_raza;
       }
       else
       {
          % Default
-         rLocation = hellportal_tos; 
-
-         if piDest_room = RID_MAR_INN
-         {
-            rLocation = hellportal_marion;
-         }
-
-         if piDest_room = RID_COR_INN
-         {
-            rLocation = hellportal_cornoth;
-         }
-
-         if piDest_room = RID_JAS_INN
-         {
-            rLocation = hellportal_jasper;
-         }
-
-         if piDest_room = RID_BAR_INN
-         {
-            rLocation = hellportal_barloque;
-         }
-      }
-      
-      if Send(who,@GetDeathRiftProtection) = TRUE
-         AND Send(who,@GetBoundLocationName) <> $
-      {
-         rLocation = Send(who,@GetBoundLocationName);
+         rLocation = hellportal_tos;
       }
 
       AddPacket(4,vrDesc,4,rLocation);
@@ -154,24 +154,27 @@ messages:
       local oRoom;
       
       % Check for Death Rifters.
-      if poOwner <> $ and isClass(poOwner,&Underworld)
-         AND IsClass(what,&Player)
-         AND Send(what,@GetDeathRiftProtection) = TRUE
+      if poOwner <> $
+         AND IsClass(poOwner,&Underworld)
+         AND IsClass(what,&User)
+         AND Send(what,@CheckPlayerFlag,#flag=PFLAG_DEATH_RIFTING)
          AND Send(what,@GetBoundLocationName) <> $
       {
          Send(what,@SendPlayerToBoundLocation);
+
          return;
       }
 
       % Check for Ko'catanites.
-      if poOwner <> $ and isClass(poOwner,&Underworld)
-         AND IsClass(what,&Player)
-         AND send(what,@CheckPlayerFlag,#flag=PFLAG2_KOCATAN_DEATH,#flagset=2)
+      if poOwner <> $
+         AND IsClass(poOwner,&Underworld)
+         AND IsClass(what,&User)
+         AND Send(what,@CheckPlayerFlag,#flag=PFLAG2_KOCATAN_DEATH,#flagset=2)
       {
          % Allow them to head to the island.
-         send(what,@SetPlayerFlag,#flag=PFLAG2_KOCATAN_DEATH,#value=FALSE,#flagset=2);
-         oRoom = send(SYS,@FindRoomByNum,#num=RID_KOC_INN);
-         send(oRoom,@Teleport,#what=what);
+         Send(what,@SetPlayerFlag,#flag=PFLAG2_KOCATAN_DEATH,#value=FALSE,#flagset=2);
+         oRoom = Send(SYS,@FindRoomByNum,#num=RID_KOC_INN);
+         Send(oRoom,@Teleport,#what=what);
 
          return;
       }
@@ -189,7 +192,6 @@ messages:
 
       propagate;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/defmod/shield/soldshld/necshield.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld/necshield.kod
@@ -45,7 +45,7 @@ classvars:
    prShield_emblem_drop = necshield_emblem_drop
    prShield_emblem_back = necshield_emblem_back
 
-   viFaction = FACTION_DUKE
+   viFaction = FACTION_NECROMANCER
    viColor = XLAT_REDTOBLACK
 
    % Stuff for rank

--- a/kod/object/item/passitem/qormasgift.kod
+++ b/kod/object/item/passitem/qormasgift.kod
@@ -89,9 +89,9 @@ properties:
    pbKriipaMask = TRUE
 
    % Set this in qormas kod, leave this one alone
-   pbMaskPossible = FALSE   
-   
-messages:   
+   pbMaskPossible = FALSE
+
+messages:
 
    Constructor(mask=FALSE,qormas_obj=$)
    {
@@ -109,23 +109,32 @@ messages:
       propagate;
    }
 
+   Delete()
+   {
+      % Clear object references.
+      poQormas = $;
+      poRecipient = $;
+
+      propagate;
+   }
+
    DestroyDisposable()
    {
       return;
    }
-   
+
    GetRecipient()
    {
       return poRecipient;
    }
-   
+
    SetRecipient(who=$)
    {
       poRecipient = who;
       
       return;
    }
-   
+
    SetRandomPaper()
    {
       local iRandom;
@@ -401,6 +410,9 @@ messages:
          if (IsClass(what,&User))
          {
             Send(poQormas,@GiftClaimed,#what=self,#who=what);
+
+            % Clear Qormas reference
+            poQormas = $;
          }
       }
 

--- a/kod/object/passive/brain.kod
+++ b/kod/object/passive/brain.kod
@@ -125,7 +125,8 @@ messages:
       % Monsters should ONLY be waiting or moving at this point.
       if (state & STATE_CHASE) OR (state & STATE_ATTACK)
       {
-         Debug("Unreachable. Illegal state.");
+         Debug("Unreachable. Illegal state for ",mob," in room ",
+               Send(Send(mob,@GetOwner),@GetName));
       }
 
       return;

--- a/kod/object/passive/flikerer/bswitch.kod
+++ b/kod/object/passive/flikerer/bswitch.kod
@@ -89,7 +89,7 @@ messages:
          return TRUE;
       }
 
-      Send(poOwner,@BrazierLit,#brazier_obj=self,#who=who,#bIsLit=pbIsLit);
+      Send(poOwner,@BrazierLit,#what=self,#who=who,#bIsLit=pbIsLit);
 
       return TRUE;
    }

--- a/kod/object/passive/guild.kod
+++ b/kod/object/passive/guild.kod
@@ -1801,17 +1801,18 @@ messages:
 
       if NOT Send(self,@ismember, #who=who)
       {
-         Debug("Somehow, someone's voting in a guild that is not their own!");
+         Debug(who,Send(who,@GetTrueName)," voting in a guild that is not their own!");
 
          return FALSE;
       }
 
       if NOT IsClass(candidate,&User)
       {
-         Debug("voted for an inanimate object of some sort!");
+         Debug(who,Send(who,@GetTrueName)," guild voted for inanimate object ",
+               Send(candidate,@GetTrueName));
          Send(who,@MsgSendUser,#message_rsc=guild_cant_vote_nonuser,
-              #parm1=Send(candidate,@getcapdef),
-              #parm2=Send(candidate,@GetTrueName));
+               #parm1=Send(candidate,@GetCapDef),
+               #parm2=Send(candidate,@GetTrueName));
 
       }
 
@@ -1880,7 +1881,8 @@ messages:
          }
       }
 
-      Debug("Somehow, someone's voting for someone outside their guild!");
+      Debug(who,Send(who,@GetTrueName)," is voting for someone outside guild ",
+            Send(self,@GetName),self);
       Send(who,@MsgSendUser,#message_rsc=guild_cant_vote_outsider,
             #parm1=Send(candidate,@GetDef),
             #type2=STRING_RESOURCE,#parm2=Send(candidate,@GetTrueName),

--- a/kod/object/passive/itematt/weapatt/wafactn.kod
+++ b/kod/object/passive/itematt/weapatt/wafactn.kod
@@ -136,7 +136,7 @@ messages:
             % Choose a random faction, because either the weapatt 
             %  failed the random check, or the player isn't allied with either.
 
-            iFact = Random(FACTION_NEUTRAL+1, FACTION_MAX);
+            iFact = Random(FACTION_NEUTRAL + 1, FACTION_NORMAL_MAX);
          }
       }
 
@@ -156,11 +156,12 @@ messages:
 
    ReqAddToItem(state1=$)
    {
-      if state1 <= FACTION_NEUTRAL or state1 > FACTION_MAX
+      if state1 <= FACTION_NEUTRAL
+         OR state1 > FACTION_NORMAL_MAX
       {
          Debug("Illegal faction chosen.  No attribute added.");
 
-         return FALSE; 
+         return FALSE;
       }
 
       propagate;
@@ -344,7 +345,7 @@ messages:
 
    FakeAttData()
    {
-      return Random(FACTION_DUKE,FACTION_MAX);
+      return Random(FACTION_DUKE,FACTION_NORMAL_MAX);
    }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/teleportspell/deathrift.kod
+++ b/kod/object/passive/spell/teleportspell/deathrift.kod
@@ -26,17 +26,28 @@ resources:
       "Underworld while still retaining life. The interdimensional "
       "pathways can lead Qor's favored to many locations, including "
       "one dedicated destination of their choosing."
-      "Requires a large number of dark angel feathers to cast."
+      "Requires four dark angel feathers to cast."
 
    DeathRift_sound = qdthdoor.wav
 
-   DeathRift_no_angeled = "You cannot call upon such an evil pact while your guardian angel watches over you."
-   DeathRift_bind = "You leave a smattering of blood at the ground beneath your feet, binding a small part of your soul to this location."
-   DeathRift_travel = "A vast passage of flames opens, and you find yourself pulled to the Underworld!"
-   DeathRift_travel_notify = "A fiery portal flares open briefly, dragging %s to the Underworld!"
-   DeathRift_travel_notify_with_dest = "A fiery portal flares open briefly, dragging %s through the Underworld and toward %s!"
-   DeathRift_generic_fail = "The evil pact's magic fails. Something seems amiss."
-   DeathRift_warning = "~BYou sense a nearby connection forming between dimensions!"
+   DeathRift_no_angeled = \
+      "You cannot call upon such an evil pact while your guardian "
+      "angel watches over you."
+   DeathRift_bind = \
+      "You leave a smattering of blood at the ground beneath your "
+      "feet, binding a small part of your soul to this location."
+   DeathRift_travel = \
+      "A vast passage of flames opens, and you find yourself "
+      "pulled to the Underworld!"
+   DeathRift_travel_notify = \
+      "A fiery portal flares open briefly, dragging %s to the Underworld!"
+   DeathRift_travel_notify_dest = \
+      "A fiery portal flares open briefly, dragging %s through "
+      "the Underworld and toward %s!"
+   DeathRift_generic_fail = \
+      "The evil pact's magic fails. Something seems amiss."
+   DeathRift_warning = \
+      "~BYou sense a nearby connection forming between dimensions!"
    
 classvars:
 
@@ -56,6 +67,8 @@ classvars:
 
    vrSucceed_wav = DeathRift_sound
 
+   vbAngeledCast = FALSE
+
 properties:
 
 messages:
@@ -70,36 +83,47 @@ messages:
 
    CanPayCosts(who = $, lTargets = $, bItemCast = FALSE)
    {
-      local oRoom;
+      local oRoom, iRegion;
 
       if who = $
       {
-         return false;
+         return FALSE;
       }
-      
-      if NOT Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+
+      if (NOT vbAngeledCast
+         AND NOT Send(who,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE))
       {
-         Send(who,@MsgSendUser,#message_rsc = DeathRift_no_angeled);
-         return false;
+         Send(who,@MsgSendUser,#message_rsc=DeathRift_no_angeled);
+
+         return FALSE;
       }
-      
+
       oRoom = Send(who,@GetOwner);
-      
-      if oRoom = $
-         OR NOT Send(oRoom,@CanHavePlayerPortal)
-         OR Send(oRoom, @GetRegion) = RID_NEWB_BASE
-         OR Send(oRoom, @GetRegion) = RID_GUEST_BASE
+
+      if (oRoom = $)
       {
-         Send(who,@MsgSendUser,#message_rsc = DeathRift_generic_fail);
-         return false;
+         Send(who,@MsgSendUser,#message_rsc=DeathRift_generic_fail);
+
+         return FALSE;
       }
-      
+
+      iRegion = Send(oRoom,@GetRegion);
+
+      if (NOT Send(oRoom,@CanHavePlayerPortal)
+         OR iRegion = RID_NEWB_BASE
+         OR iRegion = RID_GUEST_BASE)
+      {
+         Send(who,@MsgSendUser,#message_rsc=DeathRift_generic_fail);
+
+         return FALSE;
+      }
+
       propagate;
    }
 
    GetTranceTime(iSpellpower=0,who=$)
    {
-      return bound(viCast_time-(iSpellpower*500),10000,60000);
+      return Bound(viCast_time - (iSpellpower * 500),10000,60000);
    }
 
    GetNumSpellTargets()
@@ -109,54 +133,56 @@ messages:
 
    CastSpell(who = $, lTargets = $)
    {
-      local poOwner, oTargetRoom, i, each_active;
+      local oOwner, oTargetRoom, i, each_obj;
 
-      poOwner = Send(who,@GetOwner);
-      
-      if poOwner = $
+      oOwner = Send(who,@GetOwner);
+
+      if oOwner = $
       {
          return;
       }
-      
-      if Send(poOwner,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
-         AND Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
+
+      if Send(oOwner,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
+         AND Send(oOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
       {
          Send(who,@MsgSendUser,#message_rsc=DeathRift_travel);
-         
-         oTargetRoom = Send(SYS,@FindRoomByNum,#num=Send(who,@GetBoundLocationRoomNum));
+
+         oTargetRoom = Send(SYS,@FindRoomByNum,
+                           #num=Send(who,@GetBoundLocationRoomNum));
          if oTargetRoom <> $
          {
             foreach i in Send(oTargetRoom,@GetHolderActive)
             {
-               each_active = Send(oTargetRoom,@HolderExtractObject,#data=i);
-               if IsClass(each_active,&User)
+               each_obj = Send(oTargetRoom,@HolderExtractObject,#data=i);
+               if IsClass(each_obj,&User)
                {
-                  Send(each_active,@MsgSendUser,#message_rsc=DeathRift_warning);
-                  Send(each_active,@WaveSendUser,#row=Send(who,@GetBoundLocationRow),
-                       #col=Send(who,@GetBoundLocationCol),#wave_rsc=DeathRift_sound);
+                  Send(each_obj,@MsgSendUser,#message_rsc=DeathRift_warning);
+                  Send(each_obj,@WaveSendUser,#wave_rsc=DeathRift_sound,
+                        #row=Send(who,@GetBoundLocationRow),
+                        #col=Send(who,@GetBoundLocationCol));
                }
             }
          }
-         
-         foreach i in Send(poOwner,@GetHolderActive)
+
+         foreach i in Send(oOwner,@GetHolderActive)
          {
-            each_active = Send(poOwner,@HolderExtractObject,#data=i);
-            If IsClass(each_active,&User)
-               AND each_active <> who
+            each_obj = Send(oOwner,@HolderExtractObject,#data=i);
+            if IsClass(each_obj,&User)
+               AND each_obj <> who
             {
                if oTargetRoom <> $
                {
-                  Send(each_active,@MsgSendUser,#message_rsc=DeathRift_travel_notify_with_dest,
-                       #parm1=Send(who,@GetName),#parm2=Send(oTargetRoom,@GetName));
+                  Send(each_obj,@MsgSendUser,#message_rsc=DeathRift_travel_notify_dest,
+                        #parm1=Send(who,@GetName),#parm2=Send(oTargetRoom,@GetName));
                }
                else
                {
-                  Send(each_active,@MsgSendUser,#message_rsc=DeathRift_travel_notify,
-                       #parm1=Send(who,@GetName));
+                  Send(each_obj,@MsgSendUser,#message_rsc=DeathRift_travel_notify,
+                        #parm1=Send(who,@GetName));
                }
             }
          }
-         
+
          Post(who,@UserGotoDeadRoom);
          Post(who,@SetDeathRiftProtection,#value=TRUE);
          Post(who,@StartDeathRiftTimer);
@@ -172,7 +198,7 @@ messages:
 
    SuccessChance(who=$)
    {
-      return true;
+      return TRUE;
    }
 
 end

--- a/kod/util/factgame/territry.kod
+++ b/kod/util/factgame/territry.kod
@@ -559,7 +559,7 @@ messages:
 
       % last, tell the faction scenario if necessary.
       iFaction = 0;
-      while iFaction <= FACTION_MAX
+      while iFaction <= FACTION_NORMAL_MAX
       {
          iFaction = iFaction + 1;
          if Nth(lFlagCounts, iFaction) <> Nth(plFlagCounts, iFaction)
@@ -723,7 +723,7 @@ messages:
          Send(create(&PrincessFlag),@TeleportHome);
       }
 
-      if (FACTION_MAX > FACTION_PRINCESS) and
+      if (FACTION_NORMAL_MAX > FACTION_PRINCESS) and
             ((Nth(plFlagCounts, (FACTION_REBEL+1)) + piRebelFlagItemCount) < iMaxFlagItems)
       {
          Send(create(&RebelFlag),@TeleportHome);

--- a/kod/util/gameevent.kod
+++ b/kod/util/gameevent.kod
@@ -59,6 +59,11 @@ messages:
       return;
    }
 
+   Recreate()
+   {
+      return;
+   }
+
    IsUnique()
    {
       return vbUnique;

--- a/kod/util/gameevent/qormas.kod
+++ b/kod/util/gameevent/qormas.kod
@@ -95,6 +95,20 @@ messages:
       return;
    }
 
+   Recreate()
+   "Turns Qormas off so rooms can be recreated properly, then turns it "
+   "back on. StartQormas has to be posted, so that it occurs after room "
+   "creation."
+   {
+      if (pbActive)
+      {
+         Send(self,@EndQormas,#bDisplayMessage=FALSE);
+         Post(self,@StartQormas,#bDisplayMessage=FALSE);
+      }
+
+      return;
+   }
+
    % required GameEvent Overload
    StartEvent()
    {
@@ -114,11 +128,18 @@ messages:
    % not required to overload, but a good idea for cleanup
    EndEvent()
    {
+      % In case this is called manually, let RealTime know to delete
+      % the callback.
+      Post(REALTIME_OBJECT,@DeleteCallback,#what=self);
+
       Send(self,@EndQormas);
+
       propagate;
    }
 
    StartQormas(override=FALSE,bDisplayMessage=TRUE)
+   "Shouldn't call this manually to start Qormas - use 'send c GameEventEngine "
+   "EventStart parm1 c Qormas'."
    {
       local oDecoration, oRoom;
 
@@ -467,13 +488,16 @@ messages:
       % If snow is turned on, set all rooms to start snowing.
       if pbSnow
       {
-         Send(&Room,@StartSnow);
+         SendList(Send(SYS,@GetRooms),0,@StartSnow);
       }
 
       return TRUE;
    }
 
    EndQormas(reporter=$,bDisplayMessage=TRUE)
+   "Shouldn't call this message manually to end Qormas - use the "
+   "@NotifyEngineEndEvent on the Qormas object, or send EventEnd directly to "
+   "GameEventEngine with the Qormas object as parm1."
    {
       Send(self,@RemoveDecorations);
 
@@ -481,7 +505,7 @@ messages:
       Send(self,@RemoveGifts);
 
       % If snow is turned on, stop snowing in all rooms.
-      Send(&Room,@EndSnow);
+      SendList(Send(SYS,@GetRooms),0,@EndSnow);
 
       pbActive = FALSE;
 
@@ -490,7 +514,7 @@ messages:
 
    RemoveDecorations()
    {
-      local i;
+      local i, oRoom;
 
       foreach i in plDecorations
       {
@@ -499,10 +523,11 @@ messages:
 
       foreach i in plWreaths
       {
-         if Nth(i,1) <> $
-            AND IsClass(Nth(i,1),&Room)
+         oRoom = First(i);
+         if oRoom <> $
+            AND IsClass(oRoom,&Room)
          {
-            Send(Nth(i,1),@RemoveTextureChange,#id=Nth(i,2));
+            Send(oRoom,@RemoveTextureChange,#id=Nth(i,2));
          }
          plWreaths = DelListElem(plWreaths,i);
       }
@@ -523,54 +548,54 @@ messages:
 
       % Tos Inn
       oRoom = Send(SYS,@FindRoomByNum,#num=RID_TOS_INN);
-      oTree = Nth(Send(self,@FindTrees,#oRoom=oRoom),1);
+      oTree = First(Send(self,@FindTrees,#oRoom=oRoom));
       Send(self,@PlaceGiftsAroundTree,#oTree=oTree,#bE=FALSE,
             #bSE=FALSE,#bNE=FALSE);
 
       % Tos Hall
       oRoom = Send(SYS,@FindRoomByNum,#num=RID_TOS_HALL);
-      oTree = Nth(Send(self,@FindTrees,#oRoom=oRoom),1);
+      oTree = First(Send(self,@FindTrees,#oRoom=oRoom));
       Send(self,@PlaceGiftsAroundTree,#oTree=oTree,#bE=FALSE,
             #bSE=FALSE,#bNE=FALSE);
 
       % Barloque Inn
       oRoom = Send(SYS,@FindRoomByNum,#num=RID_BAR_INN);
-      oTree = Nth(Send(self,@FindTrees,#oRoom=oRoom),1);
+      oTree = First(Send(self,@FindTrees,#oRoom=oRoom));
       Send(self,@PlaceGiftsAroundTree,#oTree=oTree,#bW=FALSE,
             #bSW=FALSE,#bNW=FALSE);
 
       % Barloque Hall
       oRoom = Send(SYS,@FindRoomByNum,#num=RID_BAR_HALL);
-      oTree = Nth(Send(self,@FindTrees,#oRoom=oRoom),1);
+      oTree = First(Send(self,@FindTrees,#oRoom=oRoom));
       Send(self,@PlaceGiftsAroundTree,#oTree=oTree);
 
       % Cor Noth Inn
       oRoom = Send(SYS,@FindRoomByNum,#num=RID_COR_INN);
-      oTree = Nth(Send(self,@FindTrees,#oRoom=oRoom),1);
+      oTree = First(Send(self,@FindTrees,#oRoom=oRoom));
       Send(self,@PlaceGiftsAroundTree,#oTree=oTree,#bW=FALSE,
             #bSW=FALSE,#bS=FALSE);
 
       % Cor Noth Hall
       oRoom = Send(SYS,@FindRoomByNum,#num=RID_COR_HALL);
-      oTree = Nth(Send(self,@FindTrees,#oRoom=oRoom),1);
+      oTree = First(Send(self,@FindTrees,#oRoom=oRoom));
       Send(self,@PlaceGiftsAroundTree,#oTree=oTree,#bW=FALSE,
             #bN=FALSE,#bNW=FALSE);
 
       % Jasper Inn
       oRoom = Send(SYS,@FindRoomByNum,#num=RID_JAS_INN);
-      oTree = Nth(Send(self,@FindTrees,#oRoom=oRoom),1);
+      oTree = First(Send(self,@FindTrees,#oRoom=oRoom));
       Send(self,@PlaceGiftsAroundTree,#oTree=oTree,#bE=FALSE,
             #bS=FALSE,#bSE=FALSE);
 
       % Jasper Hall
       oRoom = Send(SYS,@FindRoomByNum,#num=RID_JAS_HALL);
-      oTree = Nth(Send(self,@FindTrees,#oRoom=oRoom),1);
+      oTree = First(Send(self,@FindTrees,#oRoom=oRoom));
       Send(self,@PlaceGiftsAroundTree,#oTree=oTree,#bW=FALSE,
             #bSW=FALSE,#bS=FALSE);
 
       % Marion Inn
       oRoom = Send(SYS,@FindRoomByNum,#num=RID_MAR_INN);
-      oTree = Nth(Send(self,@FindTrees,#oRoom=oRoom),1);
+      oTree = First(Send(self,@FindTrees,#oRoom=oRoom));
       if (Send(oTree,@GetRow) = 14 AND Send(oTree,@GetCol) = 15)
       {
          Send(self,@PlaceGiftsAroundTree,#oTree=oTree,#bE=FALSE,#bSE=FALSE);
@@ -594,19 +619,19 @@ messages:
 
       % Marion Hall
       oRoom = Send(SYS,@FindRoomByNum,#num=RID_MAR_HALL);
-      oTree = Nth(Send(self,@FindTrees,#oRoom=oRoom),1);
+      oTree = First(Send(self,@FindTrees,#oRoom=oRoom));
       Send(self,@PlaceGiftsAroundTree,#oTree=oTree,#bW=FALSE,
             #bSW=FALSE,#bS=FALSE);
 
       % Kocatan Inn
       oRoom = Send(SYS,@FindRoomByNum,#num=RID_KOC_INN);
-      oTree = Nth(Send(self,@FindTrees,#oRoom=oRoom),1);
+      oTree = First(Send(self,@FindTrees,#oRoom=oRoom));
       Send(self,@PlaceGiftsAroundTree,#oTree=oTree,#bW=FALSE,
             #bN=FALSE,#bNW=FALSE);
 
       % Kocatan Tavern
       oRoom = Send(SYS,@FindRoomByNum,#num=RID_KOC_TAVERN);
-      oTree = Nth(Send(self,@FindTrees,#oRoom=oRoom),1);
+      oTree = First(Send(self,@FindTrees,#oRoom=oRoom));
       Send(self,@PlaceGiftsAroundTree,#oTree=oTree);
 
       return;
@@ -675,8 +700,8 @@ messages:
       % North
       if bN
       {
-         iNewRow=iRow;
-         iNewCol=iCol;
+         iNewRow = iRow;
+         iNewCol = iCol;
          iNewFineRow = iFineRow - TREE_DISTANCE;
          iNewFineCol = iFineCol;
          
@@ -922,11 +947,9 @@ messages:
       {
          if (Send(i,@GetRecipient) <> $)
          {
-            lGiftsBackup = Cons([Send(i,@GetRow),
-                                 Send(i,@GetCol),
-                                 Send(i,@GetFineRow),
-                                 Send(i,@GetFineCol),
-                                 Send(i,@GetRecipient)],lGiftsBackup);
+            lGiftsBackup = Cons([ Send(i,@GetRow), Send(i,@GetCol),
+                                  Send(i,@GetFineRow), Send(i,@GetFineCol),
+                                  Send(i,@GetRecipient) ], lGiftsBackup);
          }
       }
 
@@ -939,13 +962,13 @@ messages:
          {
             foreach j in plGifts
             {
-               if (Nth(i,1) = Send(j,@GetRow))
+               if (First(i) = Send(j,@GetRow))
                   AND (Nth(i,2) = Send(j,@GetCol))
                   AND (Nth(i,3) = Send(j,@GetFineRow))
                   AND (Nth(i,4) = Send(j,@GetFineCol))
-                  {
-                     Send(j,@SetRecipient,#who=Nth(i,5));
-                  }
+               {
+                  Send(j,@SetRecipient,#who=Nth(i,5));
+               }
             }
          }
       }
@@ -955,7 +978,7 @@ messages:
 
    RemoveGifts()
    {
-      local i,oOwner;
+      local i, oOwner;
 
       if plGifts = $
       {
@@ -979,7 +1002,7 @@ messages:
 
    RemoveGiftsFromPlayers()
    {
-      local i,oOwner;
+      local i, oOwner;
 
       if plGifts = $
       {
@@ -1210,7 +1233,7 @@ messages:
       {
          if (Length(lIslandGifts) > 0)
          {
-            return (Nth(lIslandGifts,1));
+            return First(lIslandGifts);
          }
          else if (Length(lMainlandGifts) > 0)
          {

--- a/kod/util/gameeventengine.kod
+++ b/kod/util/gameeventengine.kod
@@ -35,7 +35,6 @@ properties:
 
 messages:
 
-   
    Constructor()
    {
       Send(self,@Recreate);
@@ -62,8 +61,14 @@ messages:
 
    Recreate()
    {
+      local i;
+
+      foreach i in plActiveEvents
+      {
+         Send(i,@Recreate);
+      }
+
       plRandomEvents = $;
-      plActiveEvents = $;
 
       Debug("Creating Events");
       plRandomEvents = Cons(&RatInvasion,plRandomEvents);

--- a/kod/util/parlia.kod
+++ b/kod/util/parlia.kod
@@ -206,7 +206,7 @@ messages:
          Send(self,@DeleteLieges);
       }
       
-      i = FACTION_MAX;
+      i = FACTION_NORMAL_MAX;
       while i > FACTION_NEUTRAL
       {
          plLieges=Cons(Create(Send(self,@FactionLiegeClass,#num=i)),plLieges);
@@ -240,7 +240,7 @@ messages:
    {
       local i;
       
-      i = FACTION_MAX;
+      i = FACTION_NORMAL_MAX;
       while i >= FACTION_NEUTRAL
       {
          plFactions=Cons([i,$],plFactions);
@@ -439,7 +439,7 @@ messages:
       change = FALSE;
       fact = FACTION_NEUTRAL;
       
-      while fact<=FACTION_MAX
+      while fact <= FACTION_NORMAL_MAX
       {
          count = 0;
          power = 0;
@@ -723,7 +723,7 @@ messages:
       }
       else
       {
-         rnd = Random(FACTION_NEUTRAL,FACTION_MAX);
+         rnd = Random(FACTION_NEUTRAL, FACTION_NORMAL_MAX);
       }
 
       iRumor = random(1,100);
@@ -837,14 +837,14 @@ messages:
       
       iFact = faction;
 
-      if iFact <= 0 OR iFact > FACTION_MAX
+      if iFact <= 0 OR iFact > FACTION_NORMAL_MAX
       {
          iFact = Send(mob,@GetFaction);
       }
 
       if iFact = FACTION_NEUTRAL
       {
-         iFact = random((FACTION_NEUTRAL+1),FACTION_MAX);
+         iFact = Random((FACTION_NEUTRAL + 1),FACTION_NORMAL_MAX);
       }
       
       if IsClass(mob,&Factions)

--- a/kod/util/realtime.kod
+++ b/kod/util/realtime.kod
@@ -432,9 +432,28 @@ messages:
       return;
    }
 
+   DeleteCallback(what = $)
+   "Deletes all callbacks matching the given object. Returns number deleted."
+   {
+      local i, iDeleted;
+
+      iDeleted = 0;
+
+      foreach i in plCallbacks
+      {
+         if (Nth(i,2) = what)
+         {
+            plCallbacks = DelListElem(plCallbacks,i);
+            ++iDeleted;
+         }
+      }
+
+      return iDeleted;
+   }
+
    NewMinute()
    {
-      local i, iYear, iMonth, iDay, iHour, iMinute;
+      local lCallbackTime, i, iYear, iMonth, iDay, iHour, iMinute;
 
       Send(EVENTENGINE_OBJECT,@NewMinute);
 
@@ -448,12 +467,14 @@ messages:
 
          foreach i in plCallbacks
          {
-            if Nth(Nth(i,1),3) <= iYear
-               AND Nth(Nth(i,1),1) <= iMonth
-               AND Nth(Nth(i,1),2) <= iDay
-               AND Nth(Nth(i,1),4) <= iHour
+            lCallbackTime = First(i);
+
+            if Nth(lCallbackTime,3) <= iYear
+               AND First(lCallbackTime) <= iMonth
+               AND Nth(lCallbackTime,2) <= iDay
+               AND Nth(lCallbackTime,4) <= iHour
             {
-               if Nth(Nth(i,1),5) = iMinute
+               if Nth(lCallbackTime,5) = iMinute
                {
                      % foreach creates a copy of the list so i exists even if we
                      % delete it from the original list
@@ -464,22 +485,19 @@ messages:
                         #parm7=Nth(i,10),#parm8=Nth(i,11),#parm9=Nth(i,12),
                         #parm10=Nth(i,13),#parm11=Nth(i,14),#parm12=Nth(i,15),
                         #parm13=Nth(i,16),#parm14=Nth(i,17),#parm15=Nth(i,18));
-                }
-               else
+               }
+               else if Nth(lCallbackTime,5) < iMinute
                {
-                  if Nth(Nth(i,1),5) < iMinute
-                  {
-                     Debug("Deleting expired event that would never have started! (event time is less than current time)");
-                     plCallbacks = DelListElem(plCallbacks,i);
-                  }
+                  Debug("Deleting expired event that would never have started! (event time is less than current time)");
+                  plCallbacks = DelListElem(plCallbacks,i);
                }
             }
          }
       }
-   
+
       return;
    }
-   
+
    NewHour()
    {
       Send(EVENTENGINE_OBJECT,@NewHour);


### PR DESCRIPTION
#### Commit 1
Added necromancer faction constant. Necromancer soldier shields need to have their own faction constant to be equippable by necromancer troops (which should also have the same faction constant). This constant isn't used for anything else at the moment.

#### Commit 2
Allow DMs to offer items to monsters - these items go in the monsters' plPassive list, and will be dropped upon the monster's death. Allows faster setting up during events.

#### Commit 3
Fix uninitialized variable in VaultWithdrawl (needs to start as FALSE, not the default $).

#### Commit 4
* Room 'blockers' are tied to the roomdata so duplicate rooms can no longer reuse roomdata. Creating a duplicate room will now load a copy of that room from disk. We should likely improve this later to keep a master copy of each available room in memory and load from this for speed.
* Deleting a room will now free the associated memory.
* Added a "show blockers" admin command that takes a room's roomdata as parameter and shows the blockers in that room.
* Fixed the missing background issue on room creation.
* Cleaned up room's Constructed() message a bit.

#### Commit 5
Spell LoS only needs to apply on single target spells. There is a special case where perhaps Ice Nova damage shouldn't be applied if the caster/target don't have LoS but this should be handled in the damage/final target list code.

#### Commit 6
Add admin "show suspended" command to show all suspended accounts.

#### Commit 7
Add more info to some recently called debug strings.

#### Commit 8
* Death Rift boolean property in Player is now a PFLAG.
* Phasing/logging after death rifting no longer takes players back to the UW.
* Cleaned up some code in HellPortal and Underworld classes, added a portal string for Raza Inn.
* Added an option for Death Rift to be cast by angeled players (default off).
* Removed deprecated psHonor property.

#### Commit 9
* Fix code error in Raza Mausoleum.

#### Commit 10
Attacks against minions are calculated as if the attack was on the master. Minions will follow their master on screen change, except for ETs which stay with the victim. ETs will now be deleted when the caster goes safe to prevent any attack issues.

#### Commit 11
Currently Qormas won't persist correctly over a recreate, as the active event list in GameEventEngine is set to $ and the recreated rooms won't have the Qormas decorations.

* GameEventEngine will now call Recreate on any active events. When recreated, Qormas will end itself and post a StartQormas, which is called after rooms get recreated (as both happen in the first part of RecreateAll).
* To avoid calling messages on deleted rooms, StartSnow and EndSnow now use System's room list to determine which rooms to affect.
* Qormas will now try to delete its ending callback when EndEvent is called, in case it is ended manually. This is posted to avoid any potential issue (though this is already handled, post is still safer).
*Added the ability to Post to object constants to facilitate the above Posting of callback deletion.
*Added a DeleteCallback message to RealTime which takes an object and tries to delete all callbacks for that object.
*Changed some Nth(i,1) calls to First(i).