### PR TITLE
Allow sporeburst to be targeted (default for this is off), adjust hold time/chance.

### DIFF
--- a/kod/object/active/wallelem/asburstc.kod
+++ b/kod/object/active/wallelem/asburstc.kod
@@ -14,9 +14,6 @@ constants:
 
    include blakston.khd
 
-   % What's the base duration for the hold effect in milliseconds?
-   BASE_HOLD_DURATION = 5000
-
 resources:
 
    include asburstc.lkod
@@ -47,22 +44,25 @@ classvars:
 
    vbPeriodic = FALSE
 
+   % Hold min percent is the base chance to hold a target. This number
+   % then has spellpower/2 added to it.
+   viHoldMinPercent = 40
+
 properties:
 
    piDrawFx = DRAWFX_TRANSLUCENT_50
-
-   piRangeSquared = 1
-   piBonus = 1000 % Milliseconds.
+   piSpellPower = 1
 
 messages:
 
-   Constructor(caster=$,duration=$,range=$)
+   Constructor(caster=$,duration=$,range=$,iSpellPower=1)
    {
       if range <> $
       {
          piRange = range;
-         piBonus = range * 1000;
       }
+
+      piSpellPower = iSpellPower;
 
       propagate;
    }
@@ -71,10 +71,16 @@ messages:
    {
       local oSpell;
 
+      if (Random(1,100) > viHoldMinPercent + piSpellPower/2)
+      {
+         propagate;
+      }
+
       oSpell = Send(SYS,@FindSpellByNum,#num=SID_HOLD);
 
-      Send(oSpell,@DoSpell,#what=self,#otarget=what,
-            #iDuration=BASE_HOLD_DURATION + piBonus);
+      Send(oSpell,@DoSpell,#what=self,#oTarget=what,
+            #iDuration=Send(oSpell,@GetDuration,#iSpellPower=piSpellPower));
+
       Send(poOwner,@SomethingAttacked,#what=poCaster,#victim=what,
             #use_weapon=self,#stroke_obj=self);
 
@@ -83,7 +89,7 @@ messages:
 
    SendAnimation()
    {
-      AddPacket(1,ANIMATE_CYCLE, 4,random(240,280), 2,1, 2,5);
+      AddPacket(1,ANIMATE_CYCLE, 4,Random(240,280), 2,1, 2,5);
 
       return;
    }

--- a/kod/object/passive/spell/walspell/rngflame.kod
+++ b/kod/object/passive/spell/walspell/rngflame.kod
@@ -48,13 +48,13 @@ classvars:
    vrSucceed_wav = RingOfFlames_sound
 
    viHarmful = TRUE
-   viOutlaw = TRUE
 
    % We technically have 12 elements, but that would never let us cast this while
    %  another wall spell is active.  A little cheat here, only count 9 elements.
    viNumElements = 9
-
    vrSummonLimitMsg = RingOfFlames_failed_rsc
+   % If TRUE, can target others with this spell.
+   vbCanCastOnOthers = TRUE
 
 properties:
 
@@ -71,10 +71,10 @@ messages:
 
    GetNumSpellTargets()
    {
-      return 1;
+      return vbCanCastOnOthers;
    }
 
-   CastSpell(who=$,lTargets=$,iSpellPower=0)
+   CastSpell(who=$,lTargets=$,iSpellPower=1)
    {
       local oTarget;
 
@@ -102,13 +102,21 @@ messages:
       propagate;
    }
 
-   PlaceWallElements(who=$,lTargets=$,iSpellPower=0)
+   PlaceWallElements(who=$,lTargets=$,iSpellPower=1)
    {
       local oRoom, iRow, iCol, iFine_Row, iFine_Col, iXStep, iYStep,
             iAngle, iMaxDamage, iDuration, iHalfrow, iHalfCol, iHalfFine_Row,
             iHalfFine_Col, oElement, oTarget;
 
-      oTarget = First(lTargets);
+      if (lTargets = $
+         OR NOT vbCanCastOnOthers)
+      {
+         oTarget = who;
+      }
+      else
+      {
+         oTarget = First(lTargets);
+      }
 
       iAngle = Send(oTarget,@GetAngle);
       iMaxDamage = iSpellPower / 5;

--- a/kod/object/passive/spell/walspell/sporbrst.kod
+++ b/kod/object/passive/spell/walspell/sporbrst.kod
@@ -31,7 +31,6 @@ resources:
       "There is too much summoning magic focused here to cause a spore burst."
    SporeBurst_sound = farenspore822m.wav
 
-
 classvars:
 
    vrName = SporeBurst_name_rsc
@@ -62,8 +61,10 @@ classvars:
 
    vrSummonLimitMsg = SporeBurst_failed_rsc
 
-properties:
+   % If TRUE, can target others with this spell.
+   vbCanCastOnOthers = FALSE
 
+properties:
 
 messages:
 
@@ -76,31 +77,44 @@ messages:
       return;
    }
 
-   CastSpell(who = $, lTargets = $, iSpellPower = 0)
+   GetNumSpellTargets()
+   {
+      return vbCanCastOnOthers;
+   }
+
+   CastSpell(who = $, lTargets = $, iSpellPower = 1)
    {
       Send(who,@MsgSendUser,#message_rsc=SporeBurst_cast_rsc);
 
       propagate;
    }
 
-   PlaceWallElements(who = $, iSpellPower = 0)
+   PlaceWallElements(who = $, lTargets = $, iSpellPower = 1)
    {
       local i, oRoom, iCounter, iDiff, oActiveFog, oPassiveFog, iRadius,
-            iDuration, iCasterRow, iCasterCol, iCasterFineRow, iCasterFineCol;
+            iDuration, iRow, iCol, oTarget;
+
+      if (lTargets = $
+         OR NOT vbCanCastOnOthers)
+      {
+         oTarget = who;
+      }
+      else
+      {
+         oTarget = First(lTargets);
+      }
 
       oRoom = Send(who,@GetOwner);
       iRadius = Bound(iSpellpower/30,1,3);
       iDuration = Send(self,@GetDuration,#iSpellpower=iSpellpower);
 
-      iCasterRow = Send(who,@GetRow);
-      iCasterCol = Send(who,@GetCol);
-      iCasterFineRow = Send(who,@GetFineRow);
-      iCasterFineCol = Send(who,@GetFineCol);
+      iRow = Send(oTarget,@GetRow);
+      iCol = Send(oTarget,@GetCol);
 
       % Active element, placed in the center of it all.
       oActiveFog = Create(&ActiveSporeCloud,#Caster=who,#duration=iDuration,
-                          #range=iRadius);
-      Send(oRoom,@NewHold,#what=oActiveFog,#new_row=iCasterRow,#new_col=iCasterCol);
+                          #range=iRadius,#iSpellPower=iSpellPower);
+      Send(oRoom,@NewHold,#what=oActiveFog,#new_row=iRow,#new_col=iCol);
 
       % Place the inactive elems.
       % Our goal is to place the clouds in such a way that it gives the illusion of a
@@ -113,22 +127,22 @@ messages:
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+1,#new_col=iCasterCol);
+              #new_row=iRow+1,#new_col=iCol);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-1,#new_col=iCasterCol);
+              #new_row=iRow-1,#new_col=iCol);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow,#new_col=iCasterCol+1);
+              #new_row=iRow,#new_col=iCol+1);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow,#new_col=iCasterCol-1);
+              #new_row=iRow,#new_col=iCol-1);
       }
 
       if iRadius >= 2
@@ -137,42 +151,42 @@ messages:
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+2,#new_col=iCasterCol);
+              #new_row=iRow+2,#new_col=iCol);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+1,#new_col=iCasterCol+1);
+              #new_row=iRow+1,#new_col=iCol+1);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+1,#new_col=iCasterCol-1);
+              #new_row=iRow+1,#new_col=iCol-1);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow,#new_col=iCasterCol+2);
+              #new_row=iRow,#new_col=iCol+2);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow,#new_col=iCasterCol-2);
+              #new_row=iRow,#new_col=iCol-2);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-1,#new_col=iCasterCol+1);
+              #new_row=iRow-1,#new_col=iCol+1);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-1,#new_col=iCasterCol-1);
+              #new_row=iRow-1,#new_col=iCol-1);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-2,#new_col=iCasterCol);
+              #new_row=iRow-2,#new_col=iCol);
       }
 
       if iRadius >= 3
@@ -184,69 +198,69 @@ messages:
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+3,#new_col=iCasterCol+1,
+              #new_row=iRow+3,#new_col=iCol+1,
               #fine_row=0,#fine_col=0);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+3,#new_col=iCasterCol-1,
+              #new_row=iRow+3,#new_col=iCol-1,
               #fine_row=0,#fine_col=FINENESS);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+2,#new_col=iCasterCol+2);
+              #new_row=iRow+2,#new_col=iCol+2);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+2,#new_col=iCasterCol-2);
+              #new_row=iRow+2,#new_col=iCol-2);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+1,#new_col=iCasterCol+3,
+              #new_row=iRow+1,#new_col=iCol+3,
               #fine_row=0,#fine_col=0);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+1,#new_col=iCasterCol-3,
+              #new_row=iRow+1,#new_col=iCol-3,
               #fine_row=0,#fine_col=FINENESS);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-1,#new_col=iCasterCol+3,
+              #new_row=iRow-1,#new_col=iCol+3,
               #fine_row=FINENESS,#fine_col=0);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-1,#new_col=iCasterCol-3,
+              #new_row=iRow-1,#new_col=iCol-3,
               #fine_row=FINENESS,#fine_col=FINENESS);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-2,#new_col=iCasterCol+2);
+              #new_row=iRow-2,#new_col=iCol+2);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-2,#new_col=iCasterCol-2);
+              #new_row=iRow-2,#new_col=iCol-2);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-3,#new_col=iCasterCol+1,
+              #new_row=iRow-3,#new_col=iCol+1,
               #fine_row=FINENESS,#fine_col=0);
 
          oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
                               #Caster=who,#duration=iDuration);
          Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-3,#new_col=iCasterCol-1,
+              #new_row=iRow-3,#new_col=iCol-1,
               #fine_row=FINENESS,#fine_col=FINENESS);
       }         
 


### PR DESCRIPTION
* Sporeburst now has a setting to make it a targetable spell (like RoF). Setting is off by default (also added the setting to RoF).

* Sporeburst hold time now matches that of the spell, rather than always being 6+ seconds (spell is 3-6 seconds).

* Sporeburst hold chance is now base 40% + spellpower/2. In practice, players will always get held a few times before they can exit the cloud but the time can be adjusted live (i.e. we can start with similar to current behavior and adjust down if necessary).