### PR TITLE
Fix compiler and prefix/postfix operator errors.

### DIFF
--- a/blakcomp/actions.c
+++ b/blakcomp/actions.c
@@ -878,14 +878,13 @@ param_type make_parameter(id_type id, expr_type e)
       break;
 
    case I_UNDEFINED:   /* New parameter # */
-      id->ownernum = st.curmessage;
+      id->ownernum = st.curmessage; // Invalid, but replaced later.
       add_identifier(id, I_PARAMETER);
       break;
 
    case I_PARAMETER:
-      /* Legal only if it hasn't yet appeared in this message */
-      if (id->ownernum == st.curmessage && id->source == COMPILE)
-	 action_error("Parameter %s appears twice", id->name);
+      // Can't check for duplicates here, current message ID is invalid
+      // due to parameters being parsed before message name.
       break;
 
    default:            /* Other types indicate name already used */
@@ -1610,14 +1609,15 @@ message_header_type make_message_header(id_type id, list_type args)
    }
 
    s->message_id = id;
-   /* Sort parameters in increasing id # order */
+   /* Sort parameters in increasing id # order.
+      SortParameterList will throw action_error on duplicate parameters. */
    s->params = SortParameterList(args);
 
    /* Add parameters as handler's local variables--this must be done AFTER sorting */
    for (l = s->params; l != NULL; l = l->next)
    {
       param = (param_type) l->data;
-      
+      param->lhs->ownernum = id->idnum;
       /* Make a copy of the id for the local table */
       temp_id = duplicate_id(param->lhs);
       temp_id->type = I_LOCAL;

--- a/blakcomp/sort.c
+++ b/blakcomp/sort.c
@@ -19,6 +19,8 @@ int CompareParameters(void *param1, void *param2)
 {
    param_type p1 = (param_type) param1;
    param_type p2 = (param_type) param2;
+   if (p1->lhs->idnum == p2->lhs->idnum)
+      action_error("Duplicate parameter %s!", p1->lhs->name);
 
    return (p1->lhs->idnum < p2->lhs->idnum);
 }

--- a/blakserv/sendmsg.c
+++ b/blakserv/sendmsg.c
@@ -840,10 +840,11 @@ void InterpretUnaryAssign(int object_id,local_var_type *local_vars,opcode_type o
             source_data.v.tag,source_data.v.data);
          break;
       }
-      if (opnode->source != opnode->dest)
+      if (opnode->source != opnode->dest
+         || opcode.source1 != opcode.dest)
          StoreValue(object_id, local_vars, opcode.dest, opnode->dest, source_data);
       ++source_data.v.data;
-      StoreValue(object_id, local_vars, opcode.dest, opnode->source, source_data);
+      StoreValue(object_id, local_vars, opcode.source1, opnode->source, source_data);
       return;
    case PRE_INCREMENT:
       if (source_data.v.tag != TAG_INT)
@@ -853,8 +854,9 @@ void InterpretUnaryAssign(int object_id,local_var_type *local_vars,opcode_type o
          break;
       }
       ++source_data.v.data;
-      if (opnode->source != opnode->dest)
-         StoreValue(object_id, local_vars, opcode.dest, opnode->source, source_data);
+      if (opnode->source != opnode->dest
+         || opcode.source1 != opcode.dest)
+         StoreValue(object_id, local_vars, opcode.source1, opnode->source, source_data);
       break;
    case POST_DECREMENT :
       if (source_data.v.tag != TAG_INT)
@@ -863,10 +865,11 @@ void InterpretUnaryAssign(int object_id,local_var_type *local_vars,opcode_type o
             source_data.v.tag,source_data.v.data);
          break;
       }
-      if (opnode->source != opnode->dest)
+      if (opnode->source != opnode->dest
+         || opcode.source1 != opcode.dest)
          StoreValue(object_id, local_vars, opcode.dest, opnode->dest, source_data);
       --source_data.v.data;
-      StoreValue(object_id, local_vars, opcode.dest, opnode->source, source_data);
+      StoreValue(object_id, local_vars, opcode.source1, opnode->source, source_data);
       return;
    case PRE_DECREMENT:
       if (source_data.v.tag != TAG_INT)
@@ -876,8 +879,9 @@ void InterpretUnaryAssign(int object_id,local_var_type *local_vars,opcode_type o
          break;
       }
       --source_data.v.data;
-      if (opnode->source != opnode->dest)
-         StoreValue(object_id, local_vars, opcode.dest, opnode->source, source_data);
+      if (opnode->source != opnode->dest
+         || opcode.source1 != opcode.dest)
+         StoreValue(object_id, local_vars, opcode.source1, opnode->source, source_data);
       break;
    default :
       bprintf("InterpretUnaryAssign can't perform unary op %i\n",info);


### PR DESCRIPTION
#### Commit 1 (message/params compiler bug)

Duplicate parameters were being checked using the current message ID for
comparison, however as the parameters are parsed before the message
header, these message IDs referred to the previous message.

This works fine nearly all the time (and the message ID isn't used for
anything else by the parameters) however if a set of parameters is being
parsed and the previous message in that class has a copy in another
(parsed in this batch) class followed by a message containing a
parameter with the same name, the compiler will return a false positive
for a duplicate parameter.

This change removes the duplicate check during parameter parsing and
moves it to the parameter list sorting.

#### Commit 2 (pre/postfix operator bug)

The existing code worked for simple calculations however trying to use
the prefix/postfix operators in complex statements where the result
(from a calc on a property) needs to be stored in a temp local var, the
mismatch here between source and dest types was causing errors.

Briefly, prefix ops should perform the operation then if the source is
not the destination, store the result in both places (opcode.dest gives
dest type, source1 gives source type, opnode->source gives source ID,
opnode->dest gives dest ID). Postfix ops should store the initial value
in the destination if not equal to the source location, perform the op
then store the result in the source location (basically a cheaper +/-1).

All existing operator usage works (have to use it on a property as part
of a larger calculation to trigger the error).