### PR TITLE
Kill caster's ETs in any safe room, fix attacks on minions.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4169,7 +4169,7 @@ messages:
    }
 
    AllowPlayerAttack(victim=$,stroke_obj=$,use_weapon=$,report=TRUE,
-                     actual=TRUE,minion=FALSE)
+                     actual=TRUE,minion=FALSE,oMinionRoom=$)
    "Will not let a person attack someone who isn't pkill_enabled."
    "Will not let a person who isn't pkill_enabled attack another person."
    {
@@ -4183,7 +4183,15 @@ messages:
       if victim <> $
          AND Send(victim,@GetOwner) <> poOwner
       {
-         oRoom = Send(victim,@GetOwner);
+         if (minion
+            AND oMinionRoom <> $)
+         {
+            oRoom = oMinionRoom;
+         }
+         else
+         {
+            oRoom = Send(victim,@GetOwner);
+         }
       }
 
       % No attacking logged out players under any circumstances
@@ -4358,7 +4366,8 @@ messages:
                if NOT Send(self,@AllowPlayerAttack,
                            #victim=Send(victim,@GetMaster),
                            #use_weapon=use_weapon,#stroke_obj=stroke_obj,
-                           #report=report,#actual=actual,#minion=TRUE)
+                           #report=report,#actual=actual,#minion=TRUE,
+                           #oMinionRoom=oRoom)
                {
                   return FALSE;
                }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -7596,12 +7596,14 @@ messages:
          % If room is no combat and safe logoff, record it as the
          % player's last safe location
          if Send(poOwner,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
-            AND Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
          {
-            piLastSafeRoom = Send(poOwner,@GetRoomNum);
+            if Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
+            {
+               piLastSafeRoom = Send(poOwner,@GetRoomNum);
 
-            % Recharge user's rods.
-            Send(self,@RechargeAllRods);
+               % Recharge user's rods.
+               Send(self,@RechargeAllRods);
+            }
 
             % If this player has created any evil twins, delete them.
             if plEvilTwins <> $


### PR DESCRIPTION
Casters will lose their ETs on entering any safe room (the previous fix
enabled this only for Inns/adv halls and not shops etc.).

Attacks on minions now use the correct room (minion's room) and not the
master/caster's room as in the case of ET this breaks down, specifically
for guilded vs. non-guilded screens given the above change to ET
deletion.