### PR TITLE
Duplicate player name for database entry.

### DIFF
--- a/blakserv/database.c
+++ b/blakserv/database.c
@@ -593,6 +593,8 @@ BOOL MySQLRecordPlayer(int account_id, char* name, char* home, char* bind, char*
    {
       free(record->name);
       free(record->guild);
+      free(record->home);
+      free(record->bind);
 
       free(record);
       free(node);
@@ -616,7 +618,7 @@ BOOL MySQLRecordPlayerSuicide(int account_id, char* name)
 
    // set values
    record->account_id = account_id;
-   record->name = name;
+   record->name = _strdup(name);
 
    // attach to node
    node->type = STAT_PLAYERSUICIDE;

--- a/blakserv/synched.c
+++ b/blakserv/synched.c
@@ -194,21 +194,21 @@ void SynchedProtocolParse(session_node *s,client_msg *msg)
       // The following line was commented out because I added support for the 3 4-byte integers
       // index += 12; /* 12 bytes future expansion space */
 
-      len = *(short *)(msg->data+index);
+      len = *(short *)(msg->data + index);
       if (index + 2 + len > msg->len) /* 2 = length word len */
-	 break;
+         break;
       if (len > sizeof(name))
-	 break;
-      memcpy(name,msg->data+index+2,len);
+         break;
+      memcpy(name, msg->data + index + 2, len);
       name[len] = 0; /* null terminate string */
       index += 2 + len;
       
-      len = *(short *)(msg->data+index);
+      len = *(short *)(msg->data + index);
       if (index + 2 + len > msg->len)
-	 break;
-      if (len > sizeof(name))
-	 break;
-      memcpy(password,msg->data+index+2,len);
+         break;
+      if (len > sizeof(password))
+         break;
+      memcpy(password, msg->data + index + 2, len);
       password[len] = 0; /* null terminate string */
       index += 2 + len;
       


### PR DESCRIPTION
Not doing so can lead to player name being freed later on, crashing the server.