### PR TITLE
Set attack-request interval to 250ms

### DIFF
--- a/clientd3d/gameuser.c
+++ b/clientd3d/gameuser.c
@@ -11,7 +11,7 @@
 
 #include "client.h"
 
-#define ATTACK_DELAY 1000  // Minimum number of milliseconds between user attacks
+#define ATTACK_DELAY 250  // Minimum number of milliseconds between user attacks
 
 extern player_info player;
 extern room_type current_room;


### PR DESCRIPTION
This will reduce the attack request interval from 1000ms to 250ms in the old client.
Note: The sever-side limitation to one attack per second of course stays untouched.

OgreClient is using the 250ms and has been reported to be more efficiently using all possible attack intervals on the server-side.

Here's an image why a lower rate is better. This does not mean we should hammer the server, due to TCP this can have the opposite result. Still, a request-rate which is the server-allowed rate divided by full small number, like /2, /3 etc. but no less than ~200ms is the best solution for global TCP IMO.

<img src="https://googledrive.com/host/0B-6rsj6uHlolV2ZGMjNQLUZiLXc/attack-request-rate.png" />


PS: This image show losless TCP traffic, things are quite different on heavy lossy connections.
So this is just the usual latency fluctuation (=normal case for most players without bad links)
