### PR TITLE
Small kod makefile cleanup, fix some incorrect resources.

### DIFF
--- a/kod/kod.mak
+++ b/kod/kod.mak
@@ -9,14 +9,14 @@ BCFLAGS = -d -I $(KODINCLUDEDIR) -K $(KODDIR)\kodbase.txt
 
 .lkod.kod::
 .kod.bof::
-	$(BC) $(BCFLAGS) $<
+	@$(BC) $(BCFLAGS) $<
 	@for %i in ($<) do @$(KODDIR)\bin\instbofrsc $(TOPDIR) $(BLAKSERVRUNDIR) %i
 
-all : $(BOFS) $(BOFS2) $(BOFS3) $(BOFS4) $(BOFS5) $(BOFS6) $(BOFS7) $(BOFS8)
-	@for %i in ($(BOFS:.bof=) $(BOFS2:.bof=) $(BOFS3:.bof=.) $(BOFS4:.bof=.) $(BOFS5:.bof=.) $(BOFS6:.bof=.) $(BOFS7:.bof=.) $(BOFS8:.bof=.)) do @if EXIST %i (echo Building %i & cd %i & $(MAKE) /$(MAKEFLAGS) TOPDIR=..\$(TOPDIR) & cd ..)
+all : $(BOFS)
+	@for %i in ($(BOFS:.bof=)) do @if EXIST %i (echo Building %i & cd %i & $(MAKE) /$(MAKEFLAGS) TOPDIR=..\$(TOPDIR) & cd ..)
 
 
-$(BOFS) $(BOFS2) $(BOFS3) $(BOFS4) $(BOFS5) $(BOFS6) $(BOFS7) $(BOFS8): $(DEPEND)
+$(BOFS): $(DEPEND)
 
 clean :
 	@-$(RM) *.bof *.rsc kodbase.txt >nul 2>&1

--- a/kod/makefile
+++ b/kod/makefile
@@ -16,11 +16,11 @@ BOFS = util.bof object.bof
 BCFLAGS = -d -I $(KODINCLUDEDIR) -K $(KODDIR)\kodbase.txt
 
 .kod.bof::
-	$(BC) $(BCFLAGS) $<
+	@$(BC) $(BCFLAGS) $<
 	@for %i in ($<) do @$(KODDIR)\bin\instbofrsc $(TOPDIR) $(BLAKSERVRUNDIR) %i
 
-all : $(BOFS) $(BOFS2) $(BOFS3) $(BOFS4) $(BOFS5) $(BOFS6) $(BOFS7) $(BOFS8)
-	@for %i in ($(BOFS:.bof=) $(BOFS2:.bof=) $(BOFS3:.bof=.) $(BOFS4:.bof=.) $(BOFS5:.bof=.) $(BOFS6:.bof=.) $(BOFS7:.bof=.) $(BOFS8:.bof=.)) do @if EXIST %i (echo Building %i & cd %i & $(MAKE) /$(MAKEFLAGS) TOPDIR=..\$(TOPDIR) & cd ..)
+all : $(BOFS)
+	@for %i in ($(BOFS:.bof=)) do @if EXIST %i (echo Building %i & cd %i & $(MAKE) /$(MAKEFLAGS) TOPDIR=..\$(TOPDIR) & cd ..)
 	@echo Copying kodbase.txt and kod include files
 	-@$(CP) $(KODDIR)\kodbase.txt $(BLAKSERVRUNDIR) 2>&1
 	-@$(CP) $(KODDIR)\include\*.khd $(BLAKSERVRUNDIR) 2>&1

--- a/kod/object/active/holder/nomoveon/battler/monster/deadlich.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/deadlich.kod
@@ -157,7 +157,7 @@ messages:
          return;
       }
 
-      Post(poOwner,@SomeoneSaid,#what=self,#string=lich_respel,
+      Post(poOwner,@SomeoneSaid,#what=self,#string=deadlich_respel,
             #type=SAY_MESSAGE);
 
       pbIllusioned = TRUE;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/jasprtwn/makefile
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/jasprtwn/makefile
@@ -5,7 +5,7 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\jasprtwn.bof
-BOFS  = jsbanker.bof jsmerch.bof jselder.bof jssmith.bof jsbart.bof jsinnk.bof jasvaultm.bof
-BOFS2 = jsurchin.bof
+BOFS  = jsbanker.bof jsmerch.bof jselder.bof jssmith.bof jsbart.bof jsinnk.bof \
+        jasvaultm.bof jsurchin.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcbonepr.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcbonepr.kod
@@ -160,7 +160,7 @@ messages:
    {
       local i;
 
-      if StringEqual(string,MrEl_stat_window_trigger)
+      if StringEqual(string,KocatanBonePriestess_stat_window_trigger)
       {
          if Send(what,@FindHolding,#class=&StatsResetToken) <> $
             OR (Send(what,@GetBaseMaxHealth)

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcshopk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcshopk.kod
@@ -89,7 +89,7 @@ messages:
          Send(self,@SetMood,#new_mood=piMood-2);
       }
 
-      Post(who,@SomeoneSaid,#what=self,#string=KocatanTailor_entry_welcome,
+      Post(who,@SomeoneSaid,#what=self,#string=kocatanShopkeeper_entry_welcome,
             #type=SAY_RESOURCE);
 
       return;

--- a/kod/object/active/holder/room/monsroom/makefile
+++ b/kod/object/active/holder/room/monsroom/makefile
@@ -6,19 +6,19 @@
 
 DEPEND = ..\monsroom.bof
 
-BOFS =  badland1.bof a5.bof a6.bof c4.bof c6.bof castle1b.bof d4.bof \
-	 d5.bof e2.bof e4.bof e5.bof e7.bof f2.bof f3.bof f4.bof f6.bof f7.bof forest2.bof forest3.bof \
-         forest4.bof g4.bof g5.bof g6.bof g7.bof g8.bof g9.bof h3.bof h5.bof \
-	 h6.bof h7.bof h8.bof i3.bof i6.bof i7.bof i8.bof i9.bof nest1.bof \
-	 objroom.bof throne1.bof toscrypt.bof tosgrave.bof \
-         uworld.bof d6.bof d7.bof f8.bof barlsew.bof j3.bof feyforst.bof \
-         guest6.bof barlsew2.bof barlsew3.bof jassew1.bof jassew2.bof jassew3.bof \
-         orccave1.bof orccave2.bof orccave3.bof orccave4.bof orccave5.bof \
-         orccave6.bof orcpita.bof orcpitb.bof kocsew1.bof kocsew2.bof bossroom.bof \
-         kcforest.bof orccav1x.bof orccav5x.bof lichmaze.bof necarea1.bof necarea2.bof \
-         necarea3.bof necare3a.bof necare3b.bof necarea4.bof necarea5.bof \
-         marcryp1.bof marcryp2.bof oldjas.bof oldmar.bof oldbarln.bof oldbarls.bof \
-         marcry3a.bof castle2b.bof castle2c.bof throne2.bof survivalroom.bof
+BOFS =  badland1.bof a5.bof a6.bof c4.bof c6.bof castle1b.bof d4.bof d5.bof \
+        e2.bof e4.bof e5.bof e7.bof f2.bof f3.bof f4.bof f6.bof f7.bof \
+        forest2.bof forest3.bof forest4.bof g4.bof g5.bof g6.bof g8.bof \
+        g9.bof h3.bof h5.bof h6.bof h7.bof i3.bof i6.bof i7.bof i8.bof i9.bof \
+        nest1.bof objroom.bof throne1.bof toscrypt.bof tosgrave.bof \
+        uworld.bof d6.bof d7.bof f8.bof barlsew.bof j3.bof feyforst.bof \
+        guest6.bof barlsew2.bof barlsew3.bof jassew1.bof jassew2.bof jassew3.bof \
+        orccave1.bof orccave2.bof orccave3.bof orccave4.bof orccave5.bof \
+        orccave6.bof orcpita.bof orcpitb.bof kocsew1.bof kocsew2.bof bossroom.bof \
+        kcforest.bof orccav1x.bof orccav5x.bof lichmaze.bof necarea1.bof necarea2.bof \
+        necarea3.bof necare3a.bof necare3b.bof necarea4.bof necarea5.bof \
+        marcryp1.bof marcryp2.bof oldjas.bof oldmar.bof oldbarln.bof oldbarls.bof \
+        marcry3a.bof castle2b.bof castle2c.bof throne2.bof survivalroom.bof
 
 
 #       g7.bof h8.bof i2.bof i4.bof i5.bof \

--- a/kod/object/item/passitem/numbitem/reagent/makefile
+++ b/kod/object/item/passitem/numbitem/reagent/makefile
@@ -5,12 +5,11 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\reagent.bof
-BOFS = mushroom.bof mushb.bof mushp.bof mushr.bof \
-        herbs.bof elderbry.bof orctooth.bof bdrgscal.bof \
-	dangfeth.bof farywing.bof diamond.bof emerald.bof sapphire.bof \
-        ruby.bof entberry.bof firesand.bof dflyeye.bof kripclaw.bof \
-        solagh.bof rnbwfern.bof uncserpm.bof webmass.bof shamblod.bof \
-        polserpm.bof yrxlsap.bof webmoss.bof mushgray.bof mushgreen.bof mushyellow.bof \
-        mushcyan.bof
+BOFS = mushroom.bof mushb.bof mushp.bof mushr.bof herbs.bof elderbry.bof \
+       orctooth.bof bdrgscal.bof dangfeth.bof farywing.bof diamond.bof \
+       emerald.bof sapphire.bof ruby.bof entberry.bof firesand.bof \
+       dflyeye.bof kripclaw.bof solagh.bof rnbwfern.bof uncserpm.bof \
+       shamblod.bof polserpm.bof yrxlsap.bof webmoss.bof mushgray.bof \
+       mushgreen.bof mushyellow.bof mushcyan.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/item/passitem/spelitem/scroll/makefile
+++ b/kod/object/item/passitem/spelitem/scroll/makefile
@@ -5,10 +5,11 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\scroll.bof
-BOFS = mrtrscrl.bof lghtscrl.bof darkscrl.bof discscrl.bof \
-      disilscl.bof earthscl.bof firitscl.bof flashscl.bof \
-      heatscrl.bof killfscl.bof lghtscrl.bof \
-      mrtrscrl.bof pfogscrl.bof sporescl.bof trucescl.bof \
-      windscrl.bof loadscrl.bof setscrl.bof mirthscrl.bof melscrl.bof
+BOFS = mrtrscrl.bof lghtscrl.bof darkscrl.bof discscrl.bof disilscl.bof \
+       earthscl.bof firitscl.bof flashscl.bof heatscrl.bof killfscl.bof \
+       pfogscrl.bof sporescl.bof trucescl.bof windscrl.bof loadscrl.bof \
+       setscrl.bof mirthscrl.bof melscrl.bof
+
+# foflscrl.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/brain/makefile
+++ b/kod/object/passive/brain/makefile
@@ -5,7 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\brain.bof
-BOFS = revbrain.bof blindb.bof paralyze.bof guardb.bof karmaagg.bof nonagg.bof \
-       swarmbrain.bof
+BOFS = revbrain.bof blindb.bof paralyze.bof swarmbrain.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/itematt/makefile
+++ b/kod/object/passive/itematt/makefile
@@ -6,8 +6,10 @@
 
 DEPEND = ..\itematt.bof
 BOFS = weapatt.bof iacorptr.bof iadurabl.bof iatransc.bof \
-                iashroud.bof iaengrav.bof iamisdir.bof iaselinf.bof \
-                ianewdsc.bof iaappdsc.bof iaquest.bof iapkptr.bof \
-		iabonded.bof iamade.bof iabond2.bof
+       iashroud.bof iaengrav.bof iamisdir.bof iaselinf.bof \
+       ianewdsc.bof iaappdsc.bof iaquest.bof iapkptr.bof \
+       iabonded.bof iamade.bof
+
+# iarename.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/makefile
+++ b/kod/object/passive/makefile
@@ -9,7 +9,7 @@ BOFS = tree.bof spell.bof boulder.bof news.bof trestype.bof arsign01.bof \
    throne.bof pillar.bof chandelr.bof skull.bof body.bof \
    fountain.bof tombston.bof stool.bof table.bof shrub.bof sngltree.bof \
    bank.bof sign-ar.bof sign-ar2.bof barstool.bof sign.bof \
-   sickness.bof skill.bof treeoak.bof treepine.bof newslink.bof decoitem.bof \
+   skill.bof treeoak.bof treepine.bof newslink.bof decoitem.bof \
    mananode.bof lever.bof trance.bof switch.bof guild.bof guildcmd.bof \
    gldlever.bof brain.bof quillpen.bof sun.bof moon.bof asssign.bof\
    tallbush.bof dispensr.bof fountjet.bof gstlever.bof \
@@ -19,6 +19,6 @@ BOFS = tree.bof spell.bof boulder.bof news.bof trestype.bof arsign01.bof \
    pltngwll.bof nectome.bof modlnode.bof wrmtrail.bof fogcloud.bof \
    bell.bof dflycage.bof pillow.bof ghostitm.bof ventstem.bof shrinfog.bof \
    psporec.bof evntsign.bof maillist.bof objectatt.bof roomflagicon.bof \
-   qormastree.bof snowman.bof heatshimmer.bof questtemplate.bof
+   heatshimmer.bof questtemplate.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/skill/stroke/unarmed/makefile
+++ b/kod/object/passive/skill/stroke/unarmed/makefile
@@ -5,6 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\unarmed.bof
-BOFS = punch.bof kick.bof monsstrk.bof
+BOFS = punch.bof kick.bof
 
 !include $(KODDIR)\kod.mak


### PR DESCRIPTION
#### Commit 1
BOFS2 variable is only used once, 3-8 not at all. I'm guessing at some point in the past the number of files to one nmake variable was limited, or perhaps they were used for neater formatting in the makefiles. Either way, they aren't needed.

Also prevented the output of the bc.exe command (just the command itself, not any error messages generated) from being displayed as it makes the errors easier to spot.

#### Commit 2
Removed some missing bof references from makefiles and added some (commented) bofs from kods that are present but not used.

Fixed some incorrect resources in a couple files.