### PR TITLE
Fix overlay drawing for new helm.

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -7810,7 +7810,6 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 	anglePitch = PlayerGetHeightOffset();
 
 	for (curObject = 0; curObject < nitems; curObject++)
-//	for (list = room->contents; list != NULL; list = list->next)
 	{
 		list_type	list2;
 		int			pass, depth;
@@ -7818,7 +7817,6 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 		if (drawdata[curObject].type != DrawObjectType)
 			continue;
 
-//		pRNode = (room_contents_node *)list->data;
 		pRNode = drawdata[curObject].u.object.object->draw.obj;
 
 		if (pRNode == NULL)
@@ -7849,50 +7847,54 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 		if (NULL == *pRNode->obj.overlays)
 			continue;
 
-//		continue;
-
 		// three passes each
-		for (pass = 0; pass < 3; pass++)
+		for (pass = 0; pass < 4; pass++)
 		{
 			// flush cache between passes
 			// unlock all buffers
 
-			if (underlays)
-				switch (pass)
-				{
-					case 0:
-						depth = HOTSPOT_UNDERUNDER;
-						zBias = ZBIAS_UNDERUNDER;
-					break;
-
-					case 1:
-						depth = HOTSPOT_UNDER;
-						zBias = ZBIAS_UNDER;
-					break;
-
-					case 2:
-						depth = HOTSPOT_UNDEROVER;
-						zBias = ZBIAS_UNDEROVER;
-					break;
-				}
-			else
-				switch (pass)
-				{
-					case 0:
-						depth = HOTSPOT_OVERUNDER;
-						zBias = ZBIAS_OVERUNDER;
-					break;
-
-					case 1:
-						depth = HOTSPOT_OVER;
-						zBias = ZBIAS_OVER;
-					break;
-
-					case 2:
-						depth = HOTSPOT_OVEROVER;
-						zBias = ZBIAS_OVEROVER;
-					break;
-				}
+         if (underlays)
+         {
+            if (pass == 0)
+               continue;
+            switch (pass)
+            {
+            case 1:
+               depth = HOTSPOT_UNDERUNDER;
+               zBias = ZBIAS_UNDERUNDER;
+               break;
+            case 2:
+               depth = HOTSPOT_UNDER;
+               zBias = ZBIAS_UNDER;
+               break;
+            case 3:
+               depth = HOTSPOT_UNDEROVER;
+               zBias = ZBIAS_UNDEROVER;
+               break;
+            }
+         }
+         else
+         {
+            switch (pass)
+            {
+            case 0:
+               depth = HOTSPOT_OVERUNDEROVERUNDER;
+               zBias = ZBIAS_OVERUNDEROVERUNDER;
+               break;
+            case 1:
+               depth = HOTSPOT_OVERUNDER;
+               zBias = ZBIAS_OVERUNDER;
+               break;
+            case 2:
+               depth = HOTSPOT_OVER;
+               zBias = ZBIAS_OVER;
+               break;
+            case 3:
+               depth = HOTSPOT_OVEROVER;
+               zBias = ZBIAS_OVEROVER;
+               break;
+            }
+         }
 
 			for (list2 = *pRNode->obj.overlays; list2 != NULL; list2 = list2->next)
 			{
@@ -8093,10 +8095,6 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 
 					pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDibOv, xLat0, xLat1,
 						pRNode->obj.drawingtype);
-//					pPacket = D3DRenderPacketNew(pPool);
-	//				pPacket = D3DRenderPacketNew(pPool);
-	//				pPacket = NULL;
-	//				pPool->curPacket--;
 
 					if (NULL == pPacket)
 						continue;
@@ -8189,13 +8187,6 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 						if (D3DObjectLightingCalc(room, pRNode, &bgra, 0))
 							pChunk->flags |= D3DRENDER_NOAMBIENT;
 					}
-
-/*					if (pRNode->obj.id != INVALID_ID && pRNode->obj.id == GetUserTargetID())
-					{
-						bgra.b = 0.0f;
-						bgra.g = 0.0f;
-						bgra.r = 255.0f;
-					}*/
 
 					if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT25)
 						bgra.a = D3DRENDER_TRANS25;

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -21,6 +21,7 @@ inline DWORD F2DW( FLOAT f ) { return *((DWORD*)&f); }
 #define ZBIAS_UNDER				3
 #define ZBIAS_UNDEROVER			6
 #define ZBIAS_BASE				10
+#define ZBIAS_OVERUNDEROVERUNDER   10 // Renders after base, but at same zbias.
 #define ZBIAS_OVERUNDER			11
 #define ZBIAS_OVER				13
 #define ZBIAS_OVEROVER			15

--- a/clientd3d/drawbmp.c
+++ b/clientd3d/drawbmp.c
@@ -317,22 +317,29 @@ void DrawOverlays(PDIB pdib_obj, RECT *obj_rect, list_type overlays,
 	int depth; // Current overlay depth to match
 	
 	/* Draw overlays over main object */
-	for (pass = 0; pass < 3; pass++)
+	for (pass = 0; pass < 4; pass++)
 	{
-		if (underlays)
-			switch (pass)
-		{
-	 case 0: depth = HOTSPOT_UNDERUNDER;  break;
-	 case 1: depth = HOTSPOT_UNDER;       break;
-	 case 2: depth = HOTSPOT_UNDEROVER;   break;
-		}
-		else
-			switch (pass)
-		{
-	 case 0: depth = HOTSPOT_OVERUNDER;  break;
-	 case 1: depth = HOTSPOT_OVER;       break;
-	 case 2: depth = HOTSPOT_OVEROVER;   break;
-		}
+      if (underlays)
+      {
+         if (pass == 0)
+            continue;
+         switch (pass)
+         {
+         case 1: depth = HOTSPOT_UNDERUNDER;  break;
+         case 2: depth = HOTSPOT_UNDER;       break;
+         case 3: depth = HOTSPOT_UNDEROVER;   break;
+         }
+      }
+      else
+      {
+         switch (pass)
+         {
+         case 0: depth = HOTSPOT_OVERUNDEROVERUNDER; break;
+         case 1: depth = HOTSPOT_OVERUNDER;  break;
+         case 2: depth = HOTSPOT_OVER;       break;
+         case 3: depth = HOTSPOT_OVEROVER;   break;
+         }
+      }
 		
 		for (l = overlays; l != NULL; l = l->next)
 		{

--- a/clientd3d/object3d.h
+++ b/clientd3d/object3d.h
@@ -22,6 +22,27 @@ enum {
    HOTSPOT_OVEROVER   = 4,   // Overlay on an overlay
    HOTSPOT_UNDERUNDER = 5,   // Underlay on an underlay
    HOTSPOT_UNDEROVER  = 6,   // Over on an underlay
+   HOTSPOT_OVERUNDEROVERUNDER = 7, // Overlay displayed under underlays of overlays
+};
+
+// Hotspot indexes used in BGFs.
+enum {
+   HS_HEAD = 1,
+   HS_HELM = 2,
+   HS_EYES = 11,
+   HS_MOUTH = 12,
+   HS_TOUPEE = 13,
+   HS_NOSE = 14,
+   HS_RIGHT_HAND = 21,
+   HS_RIGHT_WEAPON = 22,
+   HS_TOKEN = 29,
+   HS_LEFT_HAND = 31,
+   HS_LEFT_WEAPON = 32,
+   HS_TOP_BOW = 32,
+   HS_BOTTOM_BOW = 33,
+   HS_LEGS = 41,
+   HS_EMBLEM = 51,
+   HS_SHIELD_BACK = 61,
 };
 
 // Factor by which overlay offsets are magnified to give extra resolution


### PR DESCRIPTION
This handles a missing case in the overlay system - overlays that should
be drawn on top of a base item, but underneath underlays drawn on other
overlays on the base item.

Software renderer handles this by drawing the new type of overlay before
any other overlays are drawn on the base item. Hardware does the same
but also has to set a Z bias equal to that of the base item to avoid
rendering the overlay in the wrong place.

Reproduced the kod hotspot index constants in object3d.h, HS_HELM is
used in FindHotspotPdib rather than using '2'.